### PR TITLE
🔒 Fix Path Traversal in File Upload

### DIFF
--- a/src/server/file.go
+++ b/src/server/file.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	momo_common "github.com/alsotoes/momo/src/common"
@@ -44,7 +45,9 @@ func getMetadata(connection net.Conn) momo_common.FileMetadata {
 // After the transfer is complete, it calculates the MD5 hash of the received file and compares it with the expected hash.
 // It logs the progress and the result of the MD5 check.
 func getFile(connection net.Conn, path string, fileName string, fileMD5 string, fileSize int64) {
-	newFile, err := os.Create(path + fileName)
+	safeFileName := filepath.Base(fileName)
+	fullPath := filepath.Join(path, safeFileName)
+	newFile, err := os.Create(fullPath)
 
 	if err != nil {
 		log.Printf(err.Error())
@@ -72,7 +75,7 @@ func getFile(connection net.Conn, path string, fileName string, fileMD5 string, 
 		receivedBytes += momo_common.TCPSocketBufferSize
 	}
 
-	hash, err := momo_common.HashFile(path + fileName)
+	hash, err := momo_common.HashFile(fullPath)
 	if err != nil {
 		log.Printf(err.Error())
 		connection.Close()
@@ -81,7 +84,7 @@ func getFile(connection net.Conn, path string, fileName string, fileMD5 string, 
 
 	log.Printf("=> MD5:     " + fileMD5)
 	log.Printf("=> New MD5: " + hash)
-	log.Printf("=> Name:    " + path + fileName)
+	log.Printf("=> Name:    " + fullPath)
 	log.Printf("Received file completely!")
 	log.Printf("Sending ACK to client connection")
 }

--- a/src/server/file_test.go
+++ b/src/server/file_test.go
@@ -2,8 +2,12 @@
 package server
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -61,5 +65,50 @@ func TestGetMetadata(t *testing.T) {
 	}
 	if metadata.Size != int64(fileSize) {
 		t.Errorf("Expected file size %d, got %d", fileSize, metadata.Size)
+	}
+}
+
+func TestGetFileTraversal(t *testing.T) {
+	server, client := net.Pipe()
+
+	tempDir, err := os.MkdirTemp("", "test-getfile")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	storageDir := filepath.Join(tempDir, "storage")
+	err = os.Mkdir(storageDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create storage dir: %v", err)
+	}
+
+	traversalFileName := "../traversal.txt"
+	fileContent := "dangerous content"
+
+	hash := md5.New()
+	io.WriteString(hash, fileContent)
+	fileMD5 := hex.EncodeToString(hash.Sum(nil))
+	fileSize := int64(len(fileContent))
+
+	go func() {
+		defer client.Close()
+		client.Write([]byte(fileContent))
+	}()
+
+	// In a real scenario, the server would call getFile after getMetadata.
+	// We call getFile directly to test its path handling.
+
+	getFile(server, storageDir, traversalFileName, fileMD5, fileSize)
+
+	// The file should be created in storageDir/traversal.txt, NOT in tempDir/traversal.txt
+	traversalFilePath := filepath.Join(tempDir, "traversal.txt")
+	if _, err := os.Stat(traversalFilePath); err == nil {
+		t.Errorf("Vulnerability still exists: File created outside storage directory at %s", traversalFilePath)
+	}
+
+	safeFilePath := filepath.Join(storageDir, "traversal.txt")
+	if _, err := os.Stat(safeFilePath); os.IsNotExist(err) {
+		t.Errorf("Expected file to be created at %s, but it was not", safeFilePath)
 	}
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Path Traversal in the File Upload functionality in `src/server/file.go:44`.

⚠️ **Risk:** An attacker could provide a filename containing directory traversal sequences (e.g., `../../etc/passwd`) to create or overwrite files outside the intended storage directory, potentially leading to remote code execution or system compromise.

🛡️ **Solution:** The fix uses `filepath.Base(fileName)` to ensure only the filename part is used, stripping any directory components. It also uses `filepath.Join` to safely combine the storage path and the filename. A regression test `TestGetFileTraversal` has been added to verify the fix.

---
*PR created automatically by Jules for task [9069483943254835261](https://jules.google.com/task/9069483943254835261) started by @alsotoes*