### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via Unbounded JSON Decode

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-09 - [Denial of Service via Unbounded JSON Decode]
+**Vulnerability:** The server accepts configuration changes via an open port without size limits and reads JSON directly from the connection (`json.NewDecoder(connection)`).
+**Learning:** A malicious actor can hold connections open or stream infinite spaces/large payloads, leading to memory exhaustion or goroutine leaks.
+**Prevention:** Always use `io.LimitReader` when decoding JSON from untrusted network connections to enforce a maximum payload size, and use connection read/write deadlines (`SetDeadline`) to prevent slowloris attacks.

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -3,9 +3,11 @@ package server
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net"
 	"os"
+	"time"
 
 	momo_common "github.com/alsotoes/momo/src/common"
 )
@@ -50,9 +52,13 @@ func ChangeReplicationModeServer(daemons []*momo_common.Daemon, serverId int, ti
 			defer connection.Close()
 			log.Printf("Client connected to changeReplicationMode")
 
+			// 🛡️ Sentinel: Enforce a read/write timeout to prevent slowloris DoS attacks
+			connection.SetDeadline(time.Now().Add(10 * time.Second))
+
 			// Decode the replication data directly from the connection
+			// 🛡️ Sentinel: Limit the JSON payload size to prevent DoS via memory exhaustion
 			replicationJson := momo_common.ReplicationData{}
-			if err := json.NewDecoder(connection).Decode(&replicationJson); err != nil {
+			if err := json.NewDecoder(io.LimitReader(connection, 1024)).Decode(&replicationJson); err != nil {
 				log.Printf("Failed to decode replication data: %v", err)
 				return
 			}


### PR DESCRIPTION
This commit resolves a Denial of Service vulnerability in the server's replication configuration endpoint.

🚨 Severity: HIGH
💡 Vulnerability: The replication endpoint accepted configuration changes via JSON decoded directly from an open socket without size constraints or read deadlines.
🎯 Impact: An attacker could perform a Slowloris attack to consume server connection goroutines, or stream massive garbage JSON to induce uncontrolled memory exhaustion (OOM), taking down the service.
🔧 Fix: Enforced a 10-second connection timeout (`SetDeadline`) and limited the JSON payload reader (`io.LimitReader`) to a safe 1024 bytes.
✅ Verification: Passes `make test`.

---
*PR created automatically by Jules for task [3381629438206986058](https://jules.google.com/task/3381629438206986058) started by @alsotoes*