### PR TITLE
🛡️ Sentinel: [HIGH] Fix Slowloris DoS with rolling idle timeout on primary endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Use of MD5 hashing for file integrity verification during network transfers. MD5 is susceptible to collision attacks, allowing a malicious actor to craft a different file with the same hash.
 **Learning:** MD5 was used as a legacy choice for simple integrity checks, but it fails to provide modern security guarantees against intentional tampering.
 **Prevention:** Always use cryptographically secure hashing algorithms like SHA-256 or SHA-3 for integrity checks and digital signatures, even if the primary goal is just "integrity logging".
+## 2026-03-11 - Missing timeout on main network listener connection
+**Vulnerability:** The primary server file upload Daemon lacked a connection deadline (`connection.SetDeadline`). This allowed attackers to perform Slowloris attacks or simply keep TCP connections open indefinitely, potentially exhausting server socket limits and causing a DoS.
+**Learning:** While absolute deadlines (`connection.SetDeadline`) prevent slowloris, they break functionality for endpoints handling large, slow data streams like file uploads because the deadline expires regardless of active transfer progress. An idle timeout (rolling deadline) is required.
+**Prevention:** Use an `IdleTimeoutConn` wrapper that resets `SetReadDeadline` and `SetWriteDeadline` upon every successful read/write operation for streams that take variable time to process.

--- a/src/common/net.go
+++ b/src/common/net.go
@@ -3,7 +3,35 @@ package common
 import (
 	"errors"
 	"net"
+	"time"
 )
+
+// IdleTimeoutConn wraps a net.Conn to provide a rolling idle timeout.
+// Every successful Read or Write resets the deadline, preventing slowloris
+// attacks without interrupting large, active file transfers.
+type IdleTimeoutConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+// NewIdleTimeoutConn creates a new IdleTimeoutConn.
+func NewIdleTimeoutConn(conn net.Conn, timeout time.Duration) *IdleTimeoutConn {
+	return &IdleTimeoutConn{Conn: conn, timeout: timeout}
+}
+
+// Read reads data from the connection and resets the read deadline.
+func (c *IdleTimeoutConn) Read(b []byte) (n int, err error) {
+	c.Conn.SetReadDeadline(time.Now().Add(c.timeout))
+	n, err = c.Conn.Read(b)
+	return n, err
+}
+
+// Write writes data to the connection and resets the write deadline.
+func (c *IdleTimeoutConn) Write(b []byte) (n int, err error) {
+	c.Conn.SetWriteDeadline(time.Now().Add(c.timeout))
+	n, err = c.Conn.Write(b)
+	return n, err
+}
 
 // DialSocket connects to the given address.
 // It returns a net.Conn or an error.

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -64,17 +64,21 @@ func Daemon(ctx context.Context, daemons []*momo_common.Daemon, serverId int) {
 		go func() {
 			var replicationMode int
 			var success bool
+
+			// 🛡️ Sentinel: Use an idle timeout to prevent Slowloris attacks without breaking large file uploads
+			idleConn := momo_common.NewIdleTimeoutConn(connection, 30*time.Second)
+
 			defer func() {
 				if success {
 					log.Printf("Server ACK to Client => ACK%d", serverId)
-					connection.Write([]byte("ACK" + strconv.Itoa(serverId)))
+					idleConn.Write([]byte("ACK" + strconv.Itoa(serverId)))
 				}
-				connection.Close()
+				idleConn.Close()
 			}()
 
 			// Read the timestamp from the connection
 			bufferTimestamp := make([]byte, momo_common.TimestampLength)
-			if _, err := io.ReadFull(connection, bufferTimestamp); err != nil {
+			if _, err := io.ReadFull(idleConn, bufferTimestamp); err != nil {
 				log.Printf("Error reading timestamp: %v", err)
 				return
 			}
@@ -105,12 +109,12 @@ func Daemon(ctx context.Context, daemons []*momo_common.Daemon, serverId int) {
 
 			log.Printf("Cluster object global timestamp: %d", timestamp)
 			log.Printf("Server Daemon replicationMode: %d", replicationMode)
-			if _, err := connection.Write([]byte(strconv.FormatInt(int64(replicationMode), 10))); err != nil {
+			if _, err := idleConn.Write([]byte(strconv.FormatInt(int64(replicationMode), 10))); err != nil {
 				log.Printf("Error sending replication mode: %v", err)
 				return
 			}
 
-			metadata, err := getMetadata(connection)
+			metadata, err := getMetadata(idleConn)
 			if err != nil {
 				log.Printf("Error getting metadata: %v", err)
 				return
@@ -120,14 +124,14 @@ func Daemon(ctx context.Context, daemons []*momo_common.Daemon, serverId int) {
 			// Handle the file based on the replication mode
 			switch replicationMode {
 			case momo_common.ReplicationNone, momo_common.ReplicationPrimarySplay:
-				if err := getFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
+				if err := getFile(idleConn, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
 					log.Printf("Error getting file: %v", err)
 					return
 				}
 			case momo_common.ReplicationChain:
 				if serverId == 1 {
 					wg.Add(1)
-					if err := getFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
+					if err := getFile(idleConn, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
 						log.Printf("Error getting file: %v", err)
 						wg.Done()
 						return
@@ -136,7 +140,7 @@ func Daemon(ctx context.Context, daemons []*momo_common.Daemon, serverId int) {
 					wg.Wait()
 				} else {
 					wg.Add(1)
-					if err := getFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
+					if err := getFile(idleConn, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
 						log.Printf("Error getting file: %v", err)
 						wg.Done()
 						return
@@ -146,7 +150,7 @@ func Daemon(ctx context.Context, daemons []*momo_common.Daemon, serverId int) {
 				}
 			case momo_common.ReplicationSplay:
 				wg.Add(2)
-				if err := getFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
+				if err := getFile(idleConn, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
 					log.Printf("Error getting file: %v", err)
 					wg.Done() // Need to handle waitgroup correctly if one fails
 					wg.Done()


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The primary server file upload Daemon lacked a connection deadline (`connection.SetDeadline`). This allowed attackers to perform Slowloris attacks or simply keep TCP connections open indefinitely, potentially exhausting server socket limits and causing a DoS.
🎯 **Impact**: An unauthenticated attacker could easily open thousands of TCP connections without sending any real payloads, effectively bringing the entire cluster down by denying service to legitimate clients.
🔧 **Fix**: Implemented `IdleTimeoutConn`, a wrapper for `net.Conn` that applies an rolling idle timeout on connections. The deadline is constantly advanced forward by `30 * time.Second` upon every valid `Read` or `Write`. The primary Daemon in `src/server/server.go` now wraps all incoming connections with this timeout immediately after connection establishment and uses it for all downstream protocol and file transfers (including the final ACK transmission).
✅ **Verification**: Validated `make test` to ensure successful transmission of test files with the newly applied wrapper.
📝 **Sentinel Learnings Log**: Updated `.jules/sentinel.md` outlining the critical learning between using an absolute deadline (which will break long data streams like large file uploads) versus a rolling idle deadline, which securely protects without functional interference.

---
*PR created automatically by Jules for task [3049488072886039979](https://jules.google.com/task/3049488072886039979) started by @alsotoes*