### PR TITLE
⚡ Bolt: Optimize file reception by computing hash via io.TeeReader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2026-03-13 - Optimize Network Reads
 **Learning:** Pre-allocating single buffers for network I/O reduces system calls and memory allocations, resulting in faster and more efficient network communication in Go. We applied this pattern to replace multiple smaller `io.ReadFull` calls with a single chunked read.
 **Action:** Always pre-allocate network buffer slices exactly according to protocol specifications where field lengths are fixed and read all components via a single `io.ReadFull()` or `io.Write()` call.
+
+## 2026-03-16 - [Simultaneous hashing with io.TeeReader]
+**Learning:** Using `io.TeeReader` to hash a stream of data as it's being written to disk eliminates the need to read the file from disk a second time to compute its checksum. This halves the total disk I/O during file reception. Since the network connection is already wrapped with a timeout reader (defeating zero-copy `splice`), the user-space routing adds no penalty.
+**Action:** Always compute checksums or metrics on the fly using `io.TeeReader` when streaming data to storage, avoiding redundant disk reads.

--- a/src/server/file.go
+++ b/src/server/file.go
@@ -3,6 +3,8 @@ package server
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"log"
 	"net"
@@ -66,19 +68,22 @@ func getFile(connection net.Conn, path string, fileName string, expectedHash str
 
 	defer newFile.Close()
 
+	// ⚡ Bolt: Compute SHA-256 hash simultaneously while writing to disk using an io.TeeReader.
+	// This eliminates the need to re-read the entire file from disk just to hash it,
+	// cutting disk I/O in half and significantly speeding up file processing.
+	hashCalc := sha256.New()
+	reader := io.TeeReader(connection, hashCalc)
+
 	// Optimization: Use a single io.CopyN instead of manually chunking in a loop.
 	// This enables the Go standard library to utilize zero-copy system calls
 	// (like splice or sendfile) and reduces function call overhead.
 	if fileSize > 0 {
-		if _, err := io.CopyN(newFile, connection, fileSize); err != nil {
+		if _, err := io.CopyN(newFile, reader, fileSize); err != nil {
 			return err
 		}
 	}
 
-	hash, err := momo_common.HashFile(fullPath)
-	if err != nil {
-		return err
-	}
+	hash := hex.EncodeToString(hashCalc.Sum(nil))
 
 	log.Printf("=> Expected Hash: %s", expectedHash)
 	log.Printf("=> Actual Hash:   %s", hash)


### PR DESCRIPTION
💡 **What**:
Modified `getFile` in `src/server/file.go` to compute the SHA-256 hash simultaneously while streaming the file to disk using an `io.TeeReader`. This eliminates the `momo_common.HashFile` call that was re-reading the entire file from disk.

🎯 **Why**:
Previously, the server would write the full file payload to disk and then immediately read it back into memory to compute its SHA-256 hash for logging. For large files, this effectively doubled the required disk I/O bandwidth.

📊 **Impact**:
*   Reduces disk reads during file reception by exactly 100%.
*   Reduces total disk I/O (reads+writes) by 50% for all file transfers.
*   Significantly speeds up file processing, especially on slow mechanical drives or under high concurrency.
*   Because the connection uses `momo_common.IdleTimeoutConn` (which already uses user-space buffering and defeats zero-copy `splice`), the `TeeReader` routing adds virtually no overhead.

🔬 **Measurement**:
Run `go test -v ./src/server/...` to verify the logic remains correct. I/O reduction can be measured via `iostat` or `strace` during high-throughput file uploads via `momo -imp client`.

---
*PR created automatically by Jules for task [14274490327275791874](https://jules.google.com/task/14274490327275791874) started by @alsotoes*