### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service via server crash on Accept errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** The `DialSocket` function in `src/common/net.go` used `net.ResolveTCPAddr` followed by `net.DialTCP` without any connection timeout, allowing a potential Denial of Service (DoS) attack or resource exhaustion by supplying unresponsive IP addresses or causing outbound connections to hang indefinitely during the TCP handshake.
 **Learning:** Network dialing operations must have an enforced timeout because default TCP timeout values provided by the operating system are often very long (e.g. minutes).
 **Prevention:** Use `net.DialTimeout` with a reasonable deadline (e.g., 10 seconds) instead of unbounded `net.DialTCP` or `net.Dial` for all outbound connections.
+
+## 2024-03-24 - DoS via Server Crash on Accept Errors
+**Vulnerability:** The server called `os.Exit(1)` inside the main `server.Accept()` loops upon encountering any network error. This allows a trivial Denial of Service (DoS) attack, as exhausting temporary resources (like `EMFILE` for open file descriptors) would crash the entire application instead of allowing it to recover gracefully.
+**Learning:** Network `Accept()` loops operate in long-running daemon processes where transient errors are expected under load or adversarial conditions. Crashing the process entirely on a transient error turns a temporary bottleneck into a permanent outage.
+**Prevention:** In long-running network daemon loops, log the `Accept()` error, implement a brief sleep (`time.Sleep`) to prevent high CPU spinning, and use `continue` to keep the server alive and processing subsequent requests once resources free up. Never use `os.Exit(1)` or `panic` on expected runtime network errors.

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -85,8 +85,10 @@ func ChangeReplicationModeServer(ctx context.Context, daemons []*momo_common.Dae
 			case <-ctx.Done():
 				return // Shutting down gracefully
 			default:
-				log.Printf("Error: %v", err)
-				os.Exit(1)
+				// 🛡️ Sentinel: Do not exit on Accept errors (e.g. EMFILE) to prevent Denial of Service.
+				log.Printf("Error accepting connection: %v", err)
+				time.Sleep(10 * time.Millisecond)
+				continue
 			}
 		}
 		go func() {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -55,8 +55,10 @@ func Daemon(ctx context.Context, daemons []*momo_common.Daemon, serverId int) {
 			case <-ctx.Done():
 				return // Shutting down gracefully
 			default:
-				log.Printf("Error: %v", err)
-				os.Exit(1)
+				// 🛡️ Sentinel: Do not exit on Accept errors (e.g. EMFILE) to prevent Denial of Service.
+				log.Printf("Error accepting connection: %v", err)
+				time.Sleep(10 * time.Millisecond)
+				continue
 			}
 		}
 		log.Printf("Client connected to primary Daemon")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application previously called `os.Exit(1)` directly from its main `Accept()` loops in both `Daemon` and `ChangeReplicationModeServer` upon encountering any networking error. This creates a trivial Denial of Service vector; an attacker (or heavy load) could exhaust available file descriptors (triggering `EMFILE`), which would instantly crash the entire server process rather than allowing it to gracefully delay and recover.
🎯 Impact: A malicious actor could easily crash all nodes in the cluster with a simple script that holds open connections, causing complete data and service availability loss.
🔧 Fix: Replaced `os.Exit(1)` inside both `Accept()` loops with a safer paradigm: logging the error, introducing a brief 10ms sleep (`time.Sleep`) to prevent a tight CPU-spinning loop, and using `continue` to proceed to the next iteration.
✅ Verification: `make test` executed to verify changes are safe and correctly functioning. Run manual benchmarks or load testing (e.g. with `k6` or `ab`) simulating high connection counts to observe the server throttle rather than crash on `EMFILE`.

---
*PR created automatically by Jules for task [16826462229332289901](https://jules.google.com/task/16826462229332289901) started by @alsotoes*