### PR TITLE
🧪 Add test for empty daemons config in pushNewReplicationMode

### DIFF
--- a/src/metrics/replication_test.go
+++ b/src/metrics/replication_test.go
@@ -52,3 +52,13 @@ func TestPushNewReplicationMode(t *testing.T) {
 	// Give the server time to process the request
 	time.Sleep(100 * time.Millisecond)
 }
+
+func TestPushNewReplicationMode_NoDaemons(t *testing.T) {
+	// Mock config with no daemons
+	cfg := momo_common.Configuration{
+		Daemons: []*momo_common.Daemon{},
+	}
+
+	// This should not panic and should return early
+	pushNewReplicationMode(cfg, 5)
+}


### PR DESCRIPTION
🎯 **What:** The `pushNewReplicationMode` function in `src/metrics/replication.go` had an early return for empty daemon configurations that was not covered by tests.
📊 **Coverage:** Added `TestPushNewReplicationMode_NoDaemons` to `src/metrics/replication_test.go` which specifically tests the case where `config.Daemons` is empty.
✨ **Result:** Verified that the function handles empty daemon configurations gracefully without panicking, improving the robustness of the metrics module.

---
*PR created automatically by Jules for task [4034075491114328144](https://jules.google.com/task/4034075491114328144) started by @alsotoes*