### PR TITLE
🧹 replace deprecated io/ioutil usage in common package

### DIFF
--- a/src/common/hash_test.go
+++ b/src/common/hash_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -9,7 +8,7 @@ import (
 func TestHashFile(t *testing.T) {
 	// Create a temporary file with known content
 	content := []byte("hello world")
-	tmpfile, err := ioutil.TempFile("", "test.txt")
+	tmpfile, err := os.CreateTemp("", "test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/common/log.go
+++ b/src/common/log.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 )
 
@@ -12,6 +12,6 @@ func LogStdOut(logApp bool) {
 	if logApp {
 		log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.Lshortfile | log.LUTC)
 	} else {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 }


### PR DESCRIPTION
🎯 **What:** This PR replaces all usages of the deprecated `io/ioutil` package in the `common` package with their modern counterparts in the `io` and `os` packages.

💡 **Why:** `io/ioutil` has been deprecated since Go 1.16. Moving to `io` and `os` improves code maintainability and aligns with current Go best practices.

✅ **Verification:**
- Ran `go test ./src/common/...` (Passed)
- Ran `make test` (Passed)
- Verified no remaining `io/ioutil` imports in `src/` using `grep`.

✨ **Result:** The `common` package is now free of deprecated `io/ioutil` usage.

---
*PR created automatically by Jules for task [8967969425889215137](https://jules.google.com/task/8967969425889215137) started by @alsotoes*