### PR TITLE
🧪 [testing improvement] Add tests for IdleTimeoutConn methods

### DIFF
--- a/src/common/net_test.go
+++ b/src/common/net_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"net"
 	"testing"
+	"time"
 
 	"go.uber.org/goleak"
 )
@@ -30,5 +31,71 @@ func TestDialSocket(t *testing.T) {
 	_, err = DialSocket("invalid_address")
 	if err == nil {
 		t.Error("Expected error for invalid address, got nil")
+	}
+}
+
+type mockConn struct {
+	readDeadline  time.Time
+	writeDeadline time.Time
+	readCalled    bool
+	writeCalled   bool
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error) {
+	m.readCalled = true
+	return len(b), nil
+}
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	m.writeCalled = true
+	return len(b), nil
+}
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) LocalAddr() net.Addr                { return nil }
+func (m *mockConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { m.readDeadline = t; return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { m.writeDeadline = t; return nil }
+
+func TestIdleTimeoutConn_Read(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	mock := &mockConn{}
+	timeout := 5 * time.Second
+	c := NewIdleTimeoutConn(mock, timeout)
+
+	b := make([]byte, 10)
+	now := time.Now()
+	_, err := c.Read(b)
+	if err != nil {
+		t.Errorf("Read failed: %v", err)
+	}
+
+	if !mock.readCalled {
+		t.Error("Expected underlying Read to be called")
+	}
+
+	if mock.readDeadline.Before(now.Add(timeout)) {
+		t.Errorf("Expected read deadline to be at least %v, got %v", now.Add(timeout), mock.readDeadline)
+	}
+}
+
+func TestIdleTimeoutConn_Write(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	mock := &mockConn{}
+	timeout := 5 * time.Second
+	c := NewIdleTimeoutConn(mock, timeout)
+
+	b := []byte("hello")
+	now := time.Now()
+	_, err := c.Write(b)
+	if err != nil {
+		t.Errorf("Write failed: %v", err)
+	}
+
+	if !mock.writeCalled {
+		t.Error("Expected underlying Write to be called")
+	}
+
+	if mock.writeDeadline.Before(now.Add(timeout)) {
+		t.Errorf("Expected write deadline to be at least %v, got %v", now.Add(timeout), mock.writeDeadline)
 	}
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for `IdleTimeoutConn` in `src/common/net.go` was addressed.
📊 **Coverage:** `Read` and `Write` methods are now tested using a mock `net.Conn`. The tests verify that `SetReadDeadline` and `SetWriteDeadline` are called with the expected timeout before the actual I/O operation.
✨ **Result:** Increased test coverage for the network utility wrapper, ensuring that rolling idle timeouts are correctly applied, which is critical for preventing Slowloris attacks.

---
*PR created automatically by Jules for task [4172309786003681854](https://jules.google.com/task/4172309786003681854) started by @alsotoes*