### PR TITLE
🧹 Fix deprecated API usage of ioutil

### DIFF
--- a/src/common/hash_test.go
+++ b/src/common/hash_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -9,7 +8,7 @@ import (
 func TestHashFile(t *testing.T) {
 	// Create a temporary file with known content
 	content := []byte("hello world")
-	tmpfile, err := ioutil.TempFile("", "test.txt")
+	tmpfile, err := os.CreateTemp("", "test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/common/log.go
+++ b/src/common/log.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 )
 
@@ -12,6 +12,6 @@ func LogStdOut(logApp bool) {
 	if logApp {
 		log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.Lshortfile | log.LUTC)
 	} else {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 }


### PR DESCRIPTION
🎯 **What:** Replaced deprecated functions from the `io/ioutil` package with their modern equivalents in the `io` and `os` packages. Specifically:
- `ioutil.Discard` -> `io.Discard` in `src/common/log.go`
- `ioutil.TempFile` -> `os.CreateTemp` in `src/common/hash_test.go`

💡 **Why:** The `io/ioutil` package has been deprecated since Go 1.16. Using the modern equivalents in `io` and `os` packages improves code health, ensures compatibility with future Go versions, and follows current best practices.

✅ **Verification:**
- Ran the full test suite using `make test`. All tests passed.
- Verified that the `io/ioutil` import was removed where no longer needed.
- Ran `gofmt -s -w src/` to ensure code style consistency.

✨ **Result:** Reduced technical debt and improved maintainability by adhering to modern Go standard library recommendations.

---
*PR created automatically by Jules for task [13889644980413504199](https://jules.google.com/task/13889644980413504199) started by @alsotoes*