### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in auth token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -28,3 +28,7 @@
 **Vulnerability:** The daemon accepted connections and proceeded to read the file timestamp, metadata and content directly without validating the caller. An authentication handshake was missing.
 **Learning:** Accepting network connections and processing data without a verification step (authentication) allows unauthorized users to interact with the system, leading to various security risks including unauthorized data upload and system configuration changes.
 **Prevention:** Always implement a mandatory authentication handshake at the beginning of any network communication before processing any protocol-specific data.
+## 2024-05-24 - Timing Attack on AuthToken Validation
+**Vulnerability:** The server used standard Go string comparison `string(bufferAuthToken) != cfg.Global.AuthToken` to validate the client's authentication token. This exposed the system to timing attacks, where an attacker could deduce the correct token length and contents by measuring response times.
+**Learning:** Even simple string equality checks in security contexts can be dangerous in Go. Additionally, when using `subtle.ConstantTimeCompare`, both byte slices must be exactly the same length or the function will immediately return 0, which still leaks length information.
+**Prevention:** Always use `crypto/subtle.ConstantTimeCompare` for verifying cryptographic secrets and tokens. Ensure the expected token is properly padded to match the protocol's fixed length before comparison.

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"log"
@@ -103,7 +104,9 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 				log.Printf("Error reading AuthToken: %v", err)
 				return
 			}
-			if string(bufferAuthToken) != cfg.Global.AuthToken {
+			// 🛡️ Sentinel: Use constant-time comparison to prevent timing attacks during authentication
+			expectedAuthToken := []byte(momo_common.PadString(cfg.Global.AuthToken, momo_common.AuthTokenLength))
+			if subtle.ConstantTimeCompare(bufferAuthToken, expectedAuthToken) != 1 {
 				log.Printf("Invalid AuthToken received")
 				return
 			}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"io"
 	"log"
 	"net"
@@ -83,7 +84,9 @@ func Daemon(ctx context.Context, cfg momo_common.Configuration, serverId int) {
 				log.Printf("Error reading AuthToken: %v", err)
 				return
 			}
-			if string(bufferAuthToken) != cfg.Global.AuthToken {
+			// 🛡️ Sentinel: Use constant-time comparison to prevent timing attacks during authentication
+			expectedAuthToken := []byte(momo_common.PadString(cfg.Global.AuthToken, momo_common.AuthTokenLength))
+			if subtle.ConstantTimeCompare(bufferAuthToken, expectedAuthToken) != 1 {
 				log.Printf("Invalid AuthToken received")
 				return
 			}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The server used standard Go string comparison `string(bufferAuthToken) != cfg.Global.AuthToken` to validate the client's authentication token. This exposed the system to timing attacks.
🎯 Impact: An attacker could potentially deduce the correct token by measuring the response times of the server to incorrect tokens, bypassing authentication entirely.
🔧 Fix: Swapped the string comparison with `crypto/subtle.ConstantTimeCompare`. The expected token is padded to `momo_common.AuthTokenLength` before comparison to prevent length leakage. This ensures token validation takes a constant amount of time regardless of whether the token is correct or not.
✅ Verification: Ran `make test` and all tests passed successfully, confirming valid token validation works as intended without introducing regressions.

---
*PR created automatically by Jules for task [15235502240903704829](https://jules.google.com/task/15235502240903704829) started by @alsotoes*