### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service via Hanging Outbound Connections

### DIFF
--- a/src/common/net.go
+++ b/src/common/net.go
@@ -36,12 +36,7 @@ func (c *IdleTimeoutConn) Write(b []byte) (n int, err error) {
 // DialSocket connects to the given address.
 // It returns a net.Conn or an error.
 func DialSocket(servAddr string) (net.Conn, error) {
-	tcpAddr, err := net.ResolveTCPAddr("tcp", servAddr)
-	if err != nil {
-		return nil, errors.New("ResolveTCPAddr failed: " + err.Error())
-	}
-
-	connection, err := net.DialTCP("tcp", nil, tcpAddr)
+	connection, err := net.DialTimeout("tcp", servAddr, 10*time.Second)
 	if err != nil {
 		return nil, errors.New("Dial failed: " + err.Error())
 	}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `DialSocket` function previously used an unbounded `net.DialTCP` for initiating outbound network connections to other nodes. This creates a Denial of Service vulnerability, as a malfunctioning or malicious node dropping packets could cause the connection attempt to hang indefinitely, exhausting server resources and open file descriptors.
🎯 Impact: Denial of Service via resource exhaustion on the primary and chained nodes.
🔧 Fix: Replaced `net.DialTCP` with `net.DialTimeout` using a 10-second timeout.
✅ Verification: Ran unit tests via `make test` locally to ensure no regressions. Tests passed successfully.

---
*PR created automatically by Jules for task [13887747868826781429](https://jules.google.com/task/13887747868826781429) started by @alsotoes*