### PR TITLE
🧪 [add test for GetCurrentReplicationMode]

### DIFF
--- a/src/server/replication_test.go
+++ b/src/server/replication_test.go
@@ -166,3 +166,23 @@ func TestChangeReplicationModeClient(t *testing.T) {
 		t.Fatal("Test timed out, no data received by the server.")
 	}
 }
+
+// TestGetCurrentReplicationMode verifies that GetCurrentReplicationMode
+// returns the expected current replication mode.
+func TestGetCurrentReplicationMode(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	// Arrange
+	expectedMode := momo_common.ReplicationChain
+	timestamp := time.Now().Unix()
+
+	// Set the replication state to a known value
+	SetReplicationState(expectedMode, timestamp)
+
+	// Act
+	currentMode := GetCurrentReplicationMode()
+
+	// Assert
+	if currentMode != expectedMode {
+		t.Errorf("Expected replication mode %d, got %d", expectedMode, currentMode)
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a unit test for `GetCurrentReplicationMode` in `src/server/replication.go`. As a simple getter, it was previously untested.

📊 **Coverage:** What scenarios are now tested
The unit test sets a defined replication mode using the corresponding setter `SetReplicationState`, then utilizes `GetCurrentReplicationMode` to verify that the returned value is exactly what was set. This provides complete basic test coverage for this function.

✨ **Result:** The improvement in test coverage
`GetCurrentReplicationMode` is now covered by unit tests, ensuring that future refactoring of state management doesn't accidentally break this straightforward functionality.

---
*PR created automatically by Jules for task [17419072746315291143](https://jules.google.com/task/17419072746315291143) started by @alsotoes*