### PR TITLE
🛡️ Sentinel: [security improvement] Add AUDIT prefix to AuthToken handling logs

### DIFF
--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -117,22 +117,22 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 			// ⚡ Bolt: Stack allocate buffer to avoid heap allocations
 			var bufferAuthToken [momo_common.AuthTokenLength]byte
 			if _, err := io.ReadFull(connection, bufferAuthToken[:]); err != nil {
-				log.Printf("Error reading AuthToken from %s: %v", connection.RemoteAddr(), err)
+				log.Printf("AUDIT: Error reading AuthToken from %s: %v", connection.RemoteAddr(), err)
 				return
 			}
 			// 🛡️ Sentinel: Use constant-time comparison to prevent timing attacks during authentication
 			if subtle.ConstantTimeCompare(bufferAuthToken[:], expectedAuthToken) != 1 {
-				log.Printf("Invalid AuthToken received from %s: %v", connection.RemoteAddr(), syscall.EACCES)
+				log.Printf("AUDIT: Invalid AuthToken received from %s: %v", connection.RemoteAddr(), syscall.EACCES)
 				return
 			}
 			// 🛡️ Sentinel: Add audit logging for successful authentication
-			log.Printf("Successful authentication for changeReplicationMode from %s", connection.RemoteAddr())
+			log.Printf("AUDIT: Successful authentication for changeReplicationMode from %s", connection.RemoteAddr())
 
 			// Decode the replication data directly from the connection
 			// 🛡️ Sentinel: Limit the JSON payload size to prevent DoS via memory exhaustion
 			replicationJson := momo_common.ReplicationData{}
 			if err := json.NewDecoder(io.LimitReader(connection, 1024)).Decode(&replicationJson); err != nil {
-				log.Printf("Failed to decode replication data from %s: %v", connection.RemoteAddr(), err)
+				log.Printf("AUDIT: Failed to decode replication data from %s: %v", connection.RemoteAddr(), err)
 				return
 			}
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Insufficiently distinguishable security logs for authentication processes in `ChangeReplicationModeServer`. While the logs existed, they lacked the required `AUDIT:` prefix, making them difficult for automated monitoring tools (like fail2ban) to parse and trigger alerts for brute-force or unauthorized access attempts.
🎯 Impact: Delayed incident response and inability to automatically block malicious IPs targeting the replication configuration endpoint.
🔧 Fix: Prepended `AUDIT: ` to `log.Printf` statements handling AuthToken reads, validations, success messages, and payload decoding.
✅ Verification: Ran `make test` successfully and verified the log strings match the expected audit prefix standard.

---
*PR created automatically by Jules for task [786675848853482954](https://jules.google.com/task/786675848853482954) started by @alsotoes*