### PR TITLE
🛡️ Sentinel: [MEDIUM] Add AUDIT logging to replication mode changes

### DIFF
--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -117,22 +117,22 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 			// ⚡ Bolt: Stack allocate buffer to avoid heap allocations
 			var bufferAuthToken [momo_common.AuthTokenLength]byte
 			if _, err := io.ReadFull(connection, bufferAuthToken[:]); err != nil {
-				log.Printf("Error reading AuthToken from %s: %v", connection.RemoteAddr(), err)
+				log.Printf("AUDIT: Error reading AuthToken from %s: %v", connection.RemoteAddr(), err)
 				return
 			}
 			// 🛡️ Sentinel: Use constant-time comparison to prevent timing attacks during authentication
 			if subtle.ConstantTimeCompare(bufferAuthToken[:], expectedAuthToken) != 1 {
-				log.Printf("Invalid AuthToken received from %s: %v", connection.RemoteAddr(), syscall.EACCES)
+				log.Printf("AUDIT: Invalid AuthToken received from %s: %v", connection.RemoteAddr(), syscall.EACCES)
 				return
 			}
 			// 🛡️ Sentinel: Add audit logging for successful authentication
-			log.Printf("Successful authentication for changeReplicationMode from %s", connection.RemoteAddr())
+			log.Printf("AUDIT: Successful authentication for changeReplicationMode from %s", connection.RemoteAddr())
 
 			// Decode the replication data directly from the connection
 			// 🛡️ Sentinel: Limit the JSON payload size to prevent DoS via memory exhaustion
 			replicationJson := momo_common.ReplicationData{}
 			if err := json.NewDecoder(io.LimitReader(connection, 1024)).Decode(&replicationJson); err != nil {
-				log.Printf("Failed to decode replication data from %s: %v", connection.RemoteAddr(), err)
+				log.Printf("AUDIT: Failed to decode replication data from %s: %v", connection.RemoteAddr(), err)
 				return
 			}
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application handled sensitive operations (authentication failures and cluster replication mode changes) in `ChangeReplicationModeServer` but did not explicitly prefix these logs with `AUDIT:`.
🎯 Impact: Security logs were insufficient. Without proper log prefixes and consistent remote peer identifiers, incident response teams cannot easily ingest, filter, or investigate the source of an attack, and automated protections like fail2ban cannot dynamically block brute-force or unauthorized access attempts.
🔧 Fix: Added the `AUDIT:` prefix to the relevant `log.Printf` statements for authentication failures, successes, and JSON decoding errors in `src/server/replication.go`.
✅ Verification: Ran `make test` successfully to ensure no regressions were introduced. Evaluated log outputs manually via `grep`.

---
*PR created automatically by Jules for task [15470077700308043459](https://jules.google.com/task/15470077700308043459) started by @alsotoes*