### PR TITLE
refactor: standardize package imports and remove redundant aliases

### DIFF
--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/mem"
 )
@@ -43,7 +43,7 @@ func checkMetricsAndSwap(sm SystemMetrics, currentIndex int, replicationOrder []
 
 	v, err := sm.VirtualMemory()
 	if err != nil {
-		log.Printf("Error getting memory metrics: %v", momo_common.SanitizeLog(err.Error()))
+		log.Printf("Error getting memory metrics: %v", common.SanitizeLog(err.Error()))
 		return currentIndex, false
 	}
 
@@ -62,7 +62,7 @@ func checkMetricsAndSwap(sm SystemMetrics, currentIndex int, replicationOrder []
 
 	c, err := sm.CPUPercent()
 	if err != nil {
-		log.Printf("Error getting cpu metrics: %v", momo_common.SanitizeLog(err.Error()))
+		log.Printf("Error getting cpu metrics: %v", common.SanitizeLog(err.Error()))
 		return currentIndex, false
 	}
 	cpuUsed := c[0]
@@ -87,7 +87,7 @@ func checkMetricsAndSwap(sm SystemMetrics, currentIndex int, replicationOrder []
 // It periodically checks the system metrics and, if the polymorphic system is enabled,
 // adjusts the replication mode based on the configured thresholds and fallback interval.
 // This function is intended to be run as a goroutine and will run indefinitely.
-func GetMetrics(ctx context.Context, cfg momo_common.Configuration, serverId int) {
+func GetMetrics(ctx context.Context, cfg common.Configuration, serverId int) {
 	if serverId != 0 {
 		return
 	}
@@ -100,7 +100,7 @@ func GetMetrics(ctx context.Context, cfg momo_common.Configuration, serverId int
 	log.Printf("Daemon GetMetrics started...")
 
 	// ⚡ Bolt: Hoist constant AuthToken padding and conversion out of the loop.
-	paddedAuthToken := []byte(momo_common.PadString(cfg.Global.AuthToken, momo_common.AuthTokenLength))
+	paddedAuthToken := []byte(common.PadString(cfg.Global.AuthToken, common.AuthTokenLength))
 
 	// ⚡ Bolt: Pre-calculate thresholds as percentages to avoid multiplication/division in the loop.
 	maxThreshPercent := cfg.Metrics.MaxThreshold * 100

--- a/src/metrics/metrics_benchmark_test.go
+++ b/src/metrics/metrics_benchmark_test.go
@@ -4,16 +4,16 @@ import (
 	"slices"
 	"testing"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
 func BenchmarkCheckMetricsAndSwap(b *testing.B) {
-	cfg := momo_common.Configuration{
-		Global: momo_common.ConfigurationGlobal{
+	cfg := common.Configuration{
+		Global: common.ConfigurationGlobal{
 			PolymorphicSystem: true,
 		},
-		Metrics: momo_common.ConfigurationMetrics{
+		Metrics: common.ConfigurationMetrics{
 			MinThreshold: 0.2,
 			MaxThreshold: 0.8,
 		},

--- a/src/metrics/metrics_extra_test.go
+++ b/src/metrics/metrics_extra_test.go
@@ -6,18 +6,17 @@ import (
 	"time"
 
 	"github.com/alsotoes/momo/src/common"
-	momo_common "github.com/alsotoes/momo/src/common"
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
 func TestGetMetrics_Cancellation(t *testing.T) {
-	cfg := momo_common.Configuration{
+	cfg := common.Configuration{
 		Global: common.ConfigurationGlobal{
 			PolymorphicSystem: true,
 			ReplicationOrder: []int{1, 2, 3, 4},
 			AuthToken: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
 		},
-		Metrics: momo_common.ConfigurationMetrics{
+		Metrics: common.ConfigurationMetrics{
 			Interval: 1,
 			MinThreshold: 0.2,
 			MaxThreshold: 0.8,

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
@@ -23,11 +23,11 @@ func (msm *MockSystemMetrics) CPUPercent() ([]float64, error) {
 }
 
 func TestCheckMetricsAndSwap(t *testing.T) {
-	cfg := momo_common.Configuration{
-		Global: momo_common.ConfigurationGlobal{
+	cfg := common.Configuration{
+		Global: common.ConfigurationGlobal{
 			PolymorphicSystem: true,
 		},
-		Metrics: momo_common.ConfigurationMetrics{
+		Metrics: common.ConfigurationMetrics{
 			MinThreshold: 0.2,
 			MaxThreshold: 0.8,
 		},
@@ -122,6 +122,6 @@ func TestRealSystemMetrics(t *testing.T) {
 
 func TestGetMetricsNonPrimaryServer(t *testing.T) {
 	// serverId != 0, should return immediately
-	cfg := momo_common.Configuration{}
+	cfg := common.Configuration{}
 	GetMetrics(context.Background(), cfg, 1)
 }

--- a/src/metrics/replication.go
+++ b/src/metrics/replication.go
@@ -6,30 +6,30 @@ import (
 	"log"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 )
 
 // pushNewReplicationMode notifies the primary daemon of a replication mode change.
 // It connects to the ChangeReplication endpoint of the first daemon listed in the configuration
 // and sends the AuthToken followed by a JSON payload containing the new replication mode and the current timestamp.
-func pushNewReplicationMode(cfg momo_common.Configuration, paddedAuthToken []byte, newReplicationMode int) {
+func pushNewReplicationMode(cfg common.Configuration, paddedAuthToken []byte, newReplicationMode int) {
 	log.Printf("Notifying primary daemon of new replication mode: %d", newReplicationMode)
 
-	conn, err := momo_common.DialSocket(cfg.Daemons[0].ChangeReplication)
+	conn, err := common.DialSocket(cfg.Daemons[0].ChangeReplication)
 	if err != nil {
-		log.Printf("Dial error: %v", momo_common.SanitizeLog(err.Error()))
+		log.Printf("Dial error: %v", common.SanitizeLog(err.Error()))
 		return
 	}
 	defer conn.Close()
 
-	data := momo_common.ReplicationData{
+	data := common.ReplicationData{
 		New:       newReplicationMode,
 		TimeStamp: time.Now().UnixNano(),
 	}
 
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		log.Printf("Encode error: %v", momo_common.SanitizeLog(err.Error()))
+		log.Printf("Encode error: %v", common.SanitizeLog(err.Error()))
 		return
 	}
 
@@ -41,7 +41,7 @@ func pushNewReplicationMode(cfg momo_common.Configuration, paddedAuthToken []byt
 	buf = append(buf, '\n') // Add trailing newline for `json.Decoder` compatibility on the server
 
 	if _, err := conn.Write(buf); err != nil {
-		log.Printf("Failed to send AuthToken and ReplicationData: %v", momo_common.SanitizeLog(err.Error()))
+		log.Printf("Failed to send AuthToken and ReplicationData: %v", common.SanitizeLog(err.Error()))
 		return
 	}
 }

--- a/src/metrics/replication_test.go
+++ b/src/metrics/replication_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 )
 
 func TestPushNewReplicationMode(t *testing.T) {
@@ -28,14 +28,14 @@ func TestPushNewReplicationMode(t *testing.T) {
 		defer fd.Close()
 
 		// Read and validate the AuthToken
-		bufferAuthToken := make([]byte, momo_common.AuthTokenLength)
+		bufferAuthToken := make([]byte, common.AuthTokenLength)
 		if _, err := io.ReadFull(fd, bufferAuthToken); err != nil {
 			t.Logf("Error reading AuthToken: %v", err)
 			return
 		}
 
 		decoder := json.NewDecoder(fd)
-		var data momo_common.ReplicationData
+		var data common.ReplicationData
 		if err := decoder.Decode(&data); err != nil {
 			t.Logf("Decode error: %v", err)
 			return
@@ -48,18 +48,18 @@ func TestPushNewReplicationMode(t *testing.T) {
 
 	// Mock config
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
-	cfg := momo_common.Configuration{
-		Daemons: []*momo_common.Daemon{
+	cfg := common.Configuration{
+		Daemons: []*common.Daemon{
 			{
 				ChangeReplication: serverAddr,
 			},
 		},
-		Global: momo_common.ConfigurationGlobal{
+		Global: common.ConfigurationGlobal{
 			AuthToken: authToken,
 		},
 	}
 
-	paddedAuthToken := []byte(momo_common.PadString(authToken, momo_common.AuthTokenLength))
+	paddedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	pushNewReplicationMode(cfg, paddedAuthToken, 5)
 
 	// Give the server time to process the request

--- a/src/momo.go
+++ b/src/momo.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/alsotoes/momo/src/client"
 	"github.com/alsotoes/momo/src/common"
-	metrics "github.com/alsotoes/momo/src/metrics"
-	server "github.com/alsotoes/momo/src/server"
+	"github.com/alsotoes/momo/src/metrics"
+	"github.com/alsotoes/momo/src/server"
 	"github.com/alsotoes/momo/src/transport"
 )
 

--- a/src/server/file.go
+++ b/src/server/file.go
@@ -12,18 +12,18 @@ import (
 	"strings"
 	"syscall"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 )
 
 // getMetadata reads file metadata (Hash, name, size) from a network connection.
 // It reads the Hash string, file name, and file size from the connection, trims any null characters,
 // and returns a FileMetadata struct.
 // Null characters are trimmed because the buffers are fixed size, and the actual data may be smaller.
-func getMetadata(r io.Reader) (momo_common.FileMetadata, error) {
-	var metadata momo_common.FileMetadata
+func getMetadata(r io.Reader) (common.FileMetadata, error) {
+	var metadata common.FileMetadata
 
 	// ⚡ Bolt: Use a single stack-allocated buffer and single io.ReadFull call to reduce system calls and eliminate heap allocations.
-	var buffer [64 + momo_common.FileInfoLength + momo_common.FileInfoLength]byte
+	var buffer [64 + common.FileInfoLength + common.FileInfoLength]byte
 
 	if _, err := io.ReadFull(r, buffer[:]); err != nil {
 		return metadata, err
@@ -31,8 +31,8 @@ func getMetadata(r io.Reader) (momo_common.FileMetadata, error) {
 
 	// Extract the sub-slices from the main buffer
 	bufferFileHash := buffer[:64]
-	bufferFileName := buffer[64 : 64+momo_common.FileInfoLength]
-	bufferFileSize := buffer[64+momo_common.FileInfoLength:]
+	bufferFileName := buffer[64 : 64+common.FileInfoLength]
+	bufferFileSize := buffer[64+common.FileInfoLength:]
 
 	// ⚡ Bolt: Use a manual iteration loop to find the first null character for faster trimming.
 	// Benchmarks show this is ~2x faster than bytes.IndexByte for small, stack-allocated fixed-size buffers.
@@ -45,7 +45,7 @@ func getMetadata(r io.Reader) (momo_common.FileMetadata, error) {
 		return string(b)
 	}
 
-	fileHash := momo_common.SanitizeLog(trimNull(bufferFileHash))
+	fileHash := common.SanitizeLog(trimNull(bufferFileHash))
 
 	// 🛡️ Sentinel: Sanitize fileName immediately to prevent path traversal in all downstream consumers.
 	rawFileName := trimNull(bufferFileName)
@@ -64,8 +64,8 @@ func getMetadata(r io.Reader) (momo_common.FileMetadata, error) {
 	}
 
 	// 🛡️ Sentinel: Enforce maximum file size to prevent Denial of Service via resource exhaustion
-	if fileSize < 0 || fileSize > momo_common.MaxFileSize {
-		return metadata, fmt.Errorf("invalid file size: %d (max: %d)", fileSize, momo_common.MaxFileSize)
+	if fileSize < 0 || fileSize > common.MaxFileSize {
+		return metadata, fmt.Errorf("invalid file size: %d (max: %d)", fileSize, common.MaxFileSize)
 	}
 
 	metadata.Name = fileName
@@ -130,9 +130,9 @@ func getFile(r io.Reader, path string, fileName string, expectedHash string, fil
 		return err
 	}
 
-	log.Printf("=> Expected Hash: %s", momo_common.SanitizeLog(expectedHash))
-	log.Printf("=> Actual Hash:   %s", momo_common.SanitizeLog(hash))
-	log.Printf("=> Name:          %s", momo_common.SanitizeLog(fullPath))
+	log.Printf("=> Expected Hash: %s", common.SanitizeLog(expectedHash))
+	log.Printf("=> Actual Hash:   %s", common.SanitizeLog(hash))
+	log.Printf("=> Name:          %s", common.SanitizeLog(fullPath))
 	log.Printf("Received file completely!")
 	log.Printf("Sending ACK to client connection")
 	return nil
@@ -141,5 +141,5 @@ func getFile(r io.Reader, path string, fileName string, expectedHash string, fil
 // parsePaddedIntFast parses a null-padded or null-terminated byte slice into an int64
 // without allocating an intermediate string.
 func parsePaddedIntFast(b []byte) (int64, error) {
-	return momo_common.SafeParseInt(b)
+	return common.SafeParseInt(b)
 }

--- a/src/server/file_test.go
+++ b/src/server/file_test.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"testing"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 )
 
 // TestGetMetadata verifies that the getMetadata function correctly reads
@@ -34,7 +34,7 @@ func TestGetMetadata(t *testing.T) {
 	tempFile.Write([]byte(fileContent))
 	tempFile.Close()
 
-	fileHash, _ := momo_common.HashFile(tempFile.Name())
+	fileHash, _ := common.HashFile(tempFile.Name())
 	fileSize := len(fileContent)
 
 	// Act: Start a goroutine to simulate the client sending metadata over the pipe.
@@ -45,12 +45,12 @@ func TestGetMetadata(t *testing.T) {
 		client.Write([]byte(fileHash))
 
 		// Send file name, padded to the fixed buffer size
-		fileNameBytes := make([]byte, momo_common.FileInfoLength)
+		fileNameBytes := make([]byte, common.FileInfoLength)
 		copy(fileNameBytes, fileName)
 		client.Write(fileNameBytes)
 
 		// Send file size, padded to the fixed buffer size
-		fileSizeBytes := make([]byte, momo_common.FileInfoLength)
+		fileSizeBytes := make([]byte, common.FileInfoLength)
 		copy(fileSizeBytes, strconv.Itoa(fileSize))
 		client.Write(fileSizeBytes)
 	}()
@@ -90,12 +90,12 @@ func TestGetMetadataDotDot(t *testing.T) {
 		client.Write([]byte(fileHash))
 
 		// Send file name, padded to the fixed buffer size
-		fileNameBytes := make([]byte, momo_common.FileInfoLength)
+		fileNameBytes := make([]byte, common.FileInfoLength)
 		copy(fileNameBytes, fileName)
 		client.Write(fileNameBytes)
 
 		// Send file size, padded to the fixed buffer size
-		fileSizeBytes := make([]byte, momo_common.FileInfoLength)
+		fileSizeBytes := make([]byte, common.FileInfoLength)
 		copy(fileSizeBytes, strconv.Itoa(fileSize))
 		client.Write(fileSizeBytes)
 	}()
@@ -125,11 +125,11 @@ func TestGetMetadataInvalidNames(t *testing.T) {
 
 				client.Write([]byte(fileHash))
 
-				fileNameBytes := make([]byte, momo_common.FileInfoLength)
+				fileNameBytes := make([]byte, common.FileInfoLength)
 				copy(fileNameBytes, fileName)
 				client.Write(fileNameBytes)
 
-				fileSizeBytes := make([]byte, momo_common.FileInfoLength)
+				fileSizeBytes := make([]byte, common.FileInfoLength)
 				copy(fileSizeBytes, strconv.Itoa(fileSize))
 				client.Write(fileSizeBytes)
 			}()

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -10,20 +10,20 @@ import (
 	"sync"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/transport"
 )
 
 var replicationStateMutex sync.RWMutex
 
 // currentReplicationMode is the current replication mode of the server.
-var currentReplicationMode int = momo_common.ReplicationNone
+var currentReplicationMode int = common.ReplicationNone
 
 // replicationState stores the old and new replication modes, and the timestamp of the last change.
-var replicationState momo_common.ReplicationData
+var replicationState common.ReplicationData
 
 // GetReplicationState safely returns the current replicationState
-func GetReplicationState() momo_common.ReplicationData {
+func GetReplicationState() common.ReplicationData {
 	replicationStateMutex.RLock()
 	defer replicationStateMutex.RUnlock()
 	return replicationState
@@ -37,7 +37,7 @@ func GetCurrentReplicationMode() int {
 }
 
 // SetReplicationState safely updates currentReplicationMode and replicationState
-func SetReplicationState(newMode int, timestamp int64) momo_common.ReplicationData {
+func SetReplicationState(newMode int, timestamp int64) common.ReplicationData {
 	replicationStateMutex.Lock()
 	defer replicationStateMutex.Unlock()
 
@@ -54,7 +54,7 @@ func SetReplicationState(newMode int, timestamp int64) momo_common.ReplicationDa
 // When a client connects, it sends a JSON object containing the new replication mode.
 // This function updates the server's replication mode and, if the server is the primary (serverId 0),
 // it propagates the change to the other servers in the cluster.
-func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configuration, serverId int, timestamp int64) error {
+func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, serverId int, timestamp int64) error {
 	daemons := cfg.Daemons
 	factory := transport.NewProtocolFactory(cfg)
 	server, err := factory.Listen(daemons[serverId].ChangeReplication)
@@ -85,7 +85,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 	log.Printf("ReplicationData struct: %s", string(replicationJson))
 
 	// ⚡ Bolt: Hoist constant AuthToken padding and conversion out of the loop.
-	expectedAuthToken := []byte(momo_common.PadString(cfg.Global.AuthToken, momo_common.AuthTokenLength))
+	expectedAuthToken := []byte(common.PadString(cfg.Global.AuthToken, common.AuthTokenLength))
 
 	// 🛡️ Sentinel: Enforce a limit on concurrent connections to prevent resource exhaustion (DoS).
 	const maxConcurrentConnections = 1000
@@ -98,7 +98,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 			case <-ctx.Done():
 				return nil // Shutting down gracefully
 			default:
-				log.Printf("Error accepting connection: %v", momo_common.SanitizeLog(err.Error()))
+				log.Printf("Error accepting connection: %v", common.SanitizeLog(err.Error()))
 				// 🛡️ Sentinel: Sleep briefly to prevent tight loop on transient errors (like EMFILE)
 				// and avoid DoS via os.Exit(1).
 				time.Sleep(10 * time.Millisecond)
@@ -126,13 +126,13 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 			// 🛡️ Sentinel: Enforce a read/write timeout to prevent slowloris DoS attacks
 			comm.SetAbsoluteDeadline(time.Now().Add(10 * time.Second))
 
-			remoteAddr := momo_common.SanitizeLog(connection.RemoteAddr().String())
+			remoteAddr := common.SanitizeLog(connection.RemoteAddr().String())
 
 			// HandshakeServer performs the server-side handshake: receives AuthToken + Timestamp,
 			// validates the token, and returns the timestamp.
 			_, ts, err := comm.HandshakeServer(expectedAuthToken)
 			if err != nil {
-				log.Printf("AUDIT: Handshake failed from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Handshake failed from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 				return
 			}
 
@@ -141,16 +141,16 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 
 			// Send a dummy replication mode back to complete the handshake
 			if err := comm.SendReplicationMode(0); err != nil {
-				log.Printf("AUDIT: Error sending handshake ACK to %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Error sending handshake ACK to %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 				return
 			}
 
 			// Decode the replication data directly from the connection
 			// 🛡️ Sentinel: Limit the JSON payload size to prevent DoS via memory exhaustion
-			replicationJson := momo_common.ReplicationData{}
+			replicationJson := common.ReplicationData{}
 			decoder := json.NewDecoder(io.LimitReader(comm, 1024))
 			if err := decoder.Decode(&replicationJson); err != nil {
-				log.Printf("AUDIT: Failed to decode replication data from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Failed to decode replication data from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 				return
 			}
 
@@ -163,7 +163,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg momo_common.Configurat
 
 			// Send ACK back to client to confirm receipt and prevent premature connection termination
 			if _, err := comm.Write([]byte("OK")); err != nil {
-				log.Printf("AUDIT: Failed to send ACK to %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Failed to send ACK to %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 			}
 
 			// If this is the primary server, propagate the change to the other servers
@@ -195,7 +195,7 @@ func ChangeReplicationModeClient(factory *transport.ProtocolFactory, replication
 	daemons := factory.GetDaemons()
 	comm, err := factory.Dial(daemons[serverId].ChangeReplication)
 	if err != nil {
-		log.Printf("Dial error: %v", momo_common.SanitizeLog(err.Error()))
+		log.Printf("Dial error: %v", common.SanitizeLog(err.Error()))
 		return
 	}
 	defer comm.Close()
@@ -208,19 +208,19 @@ func ChangeReplicationModeClient(factory *transport.ProtocolFactory, replication
 	timestamp := time.Now().UnixNano()
 	
 	if _, err := comm.HandshakeClient(authToken, timestamp); err != nil {
-		log.Printf("Handshake failed with peer %d: %v", serverId, momo_common.SanitizeLog(err.Error()))
+		log.Printf("Handshake failed with peer %d: %v", serverId, common.SanitizeLog(err.Error()))
 		return
 	}
 
 	if _, err := comm.Write(append(replicationJson, '\n')); err != nil {
-		log.Printf("Failed to send ReplicationData to %d: %v", serverId, momo_common.SanitizeLog(err.Error()))
+		log.Printf("Failed to send ReplicationData to %d: %v", serverId, common.SanitizeLog(err.Error()))
 		return
 	}
 
 	// Wait for ACK to prevent premature connection termination, especially over QUIC
 	ackBuf := make([]byte, 2) // We expect "OK"
 	if _, err := io.ReadFull(comm, ackBuf); err != nil {
-		log.Printf("Failed to read ACK from %d: %v", serverId, momo_common.SanitizeLog(err.Error()))
+		log.Printf("Failed to read ACK from %d: %v", serverId, common.SanitizeLog(err.Error()))
 		return
 	}
 

--- a/src/server/replication_test.go
+++ b/src/server/replication_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/transport"
 )
 
@@ -22,12 +22,12 @@ func handleReplicationChange(t *testing.T, authToken string, connection net.Conn
 	defer wg.Done()
 	defer connection.Close()
 
-	bufferAuthToken := make([]byte, momo_common.AuthTokenLength)
+	bufferAuthToken := make([]byte, common.AuthTokenLength)
 	if _, err := io.ReadFull(connection, bufferAuthToken); err != nil {
 		t.Logf("Error reading AuthToken: %v", err)
 		return
 	}
-	expectedAuthToken := []byte(momo_common.PadString(authToken, momo_common.AuthTokenLength))
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	if subtle.ConstantTimeCompare(bufferAuthToken, expectedAuthToken) != 1 {
 		t.Logf("Invalid AuthToken received")
 		return
@@ -40,7 +40,7 @@ func handleReplicationChange(t *testing.T, authToken string, connection net.Conn
 		return
 	}
 
-	replicationJSON := momo_common.ReplicationData{}
+	replicationJSON := common.ReplicationData{}
 	// Trim null bytes before decoding
 	idx := bytes.IndexByte(bufferReplicationMode, 0)
 	var trimmedBytes []byte
@@ -64,7 +64,7 @@ func TestChangeReplicationModeServerLogic(t *testing.T) {
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
 
 	// Arrange: Set initial state and create a network pipe to simulate a client-server connection.
-	SetReplicationState(momo_common.ReplicationNone, 0) // Initial mode
+	SetReplicationState(common.ReplicationNone, 0) // Initial mode
 	client, server := net.Pipe()
 
 	var wg sync.WaitGroup
@@ -73,8 +73,8 @@ func TestChangeReplicationModeServerLogic(t *testing.T) {
 
 	// Act: Marshal and send the new replication data from the client side of the pipe.
 	client.Write([]byte(authToken))
-	expectedMode := momo_common.ReplicationSplay
-	data := momo_common.ReplicationData{
+	expectedMode := common.ReplicationSplay
+	data := common.ReplicationData{
 		New:       expectedMode,
 		TimeStamp: time.Now().Unix(),
 	}
@@ -84,7 +84,7 @@ func TestChangeReplicationModeServerLogic(t *testing.T) {
 	}
 
 	// Copy to a fixed-size buffer to simulate the network read.
-	buffer := make([]byte, momo_common.FileInfoLength)
+	buffer := make([]byte, common.FileInfoLength)
 	copy(buffer, jsonBytes)
 
 	_, err = client.Write(buffer)
@@ -126,25 +126,25 @@ func TestChangeReplicationModeClient(t *testing.T) {
 		defer conn.Close()
 
 		// Read AuthToken and Timestamp
-		var handshakeBuf [momo_common.AuthTokenLength + momo_common.TimestampLength]byte
+		var handshakeBuf [common.AuthTokenLength + common.TimestampLength]byte
 		io.ReadFull(conn, handshakeBuf[:])
-		receivedAuth <- handshakeBuf[:momo_common.AuthTokenLength]
+		receivedAuth <- handshakeBuf[:common.AuthTokenLength]
 
 		// Send back a dummy replication mode to complete handshake
 		conn.Write([]byte("0"))
 
-		bufJSON := make([]byte, momo_common.FileInfoLength)
+		bufJSON := make([]byte, common.FileInfoLength)
 		n, _ := conn.Read(bufJSON)
 		receivedJSON <- bufJSON[:n] // Send received data to the channel.
 	}()
 
 	// Act: Call the function under test.
-	cfg := momo_common.Configuration{
-		Global: momo_common.ConfigurationGlobal{
+	cfg := common.Configuration{
+		Global: common.ConfigurationGlobal{
 			AuthToken: authToken,
 			Protocol:  "momo-tcp",
 		},
-		Daemons: []*momo_common.Daemon{
+		Daemons: []*common.Daemon{
 			{ChangeReplication: serverAddr}, // Configure the daemon to connect to our mock server.
 		},
 	}
@@ -156,7 +156,7 @@ func TestChangeReplicationModeClient(t *testing.T) {
 	// Assert: Verify the mock server received the correct data.
 	select {
 	case auth := <-receivedAuth:
-		expectedAuthToken := []byte(momo_common.PadString(authToken, momo_common.AuthTokenLength))
+		expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 		if subtle.ConstantTimeCompare(auth, expectedAuthToken) != 1 {
 			t.Errorf("Expected AuthToken '%s' (padded), but got '%s'", authToken, string(auth))
 		}
@@ -179,7 +179,7 @@ func TestChangeReplicationModeClient(t *testing.T) {
 // returns the expected current replication mode.
 func TestGetCurrentReplicationMode(t *testing.T) {
 	// Arrange
-	expectedMode := momo_common.ReplicationChain
+	expectedMode := common.ReplicationChain
 	timestamp := time.Now().Unix()
 
 	// Set the replication state to a known value

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/alsotoes/momo/src/client"
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/transport"
 )
 
@@ -30,7 +30,7 @@ var connectToPeer = client.Connect
 //   - ReplicationPrimarySplay: This mode is currently handled as ReplicationNone, which means no replication is performed.
 //
 // The replication mode is determined by the client, and for secondary servers, it's influenced by the timestamp of the operation.
-func Daemon(ctx context.Context, cfg momo_common.Configuration, serverId int) error {
+func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 	daemons := cfg.Daemons
 	factory := transport.NewProtocolFactory(cfg)
 
@@ -56,7 +56,7 @@ func Daemon(ctx context.Context, cfg momo_common.Configuration, serverId int) er
 	log.Printf("...Waiting for connections...")
 
 	// ⚡ Bolt: Hoist constant AuthToken padding and conversion out of the loop.
-	expectedAuthToken := []byte(momo_common.PadString(cfg.Global.AuthToken, momo_common.AuthTokenLength))
+	expectedAuthToken := []byte(common.PadString(cfg.Global.AuthToken, common.AuthTokenLength))
 
 	// 🛡️ Sentinel: Enforce a limit on concurrent connections to prevent resource exhaustion (DoS).
 	const maxConcurrentConnections = 1000
@@ -93,7 +93,7 @@ go func(comm transport.Communicator) {
 	var success bool
 
 	// 🛡️ Sentinel: Capture remote address for audit logging and traceability
-	remoteAddr := momo_common.SanitizeLog(comm.RemoteAddr().String())
+	remoteAddr := common.SanitizeLog(comm.RemoteAddr().String())
 
 
 			// 🛡️ Sentinel: Apply a strict absolute deadline for the handshake phase to prevent Slowloris trickle attacks.
@@ -111,7 +111,7 @@ go func(comm transport.Communicator) {
 			// validates the token, and returns the timestamp.
 			_, ts, err := comm.HandshakeServer(expectedAuthToken)
 			if err != nil {
-				log.Printf("AUDIT: Handshake failed from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Handshake failed from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 				return
 			}
 
@@ -134,19 +134,19 @@ go func(comm transport.Communicator) {
 					replicationMode = repState.Old
 				}
 
-				if replicationMode != momo_common.ReplicationChain {
-					replicationMode = momo_common.ReplicationNone
+				if replicationMode != common.ReplicationChain {
+					replicationMode = common.ReplicationNone
 				}
 			} else {
 				finalTs = ts
-				replicationMode = momo_common.ReplicationNone
+				replicationMode = common.ReplicationNone
 			}
 
 			// 🛡️ Sentinel: Ensure the replicationMode is within valid bounds.
 			// If it's 0 (the uninitialized value of the enum) or otherwise invalid,
 			// default to ReplicationNone to ensure the server processes the file.
 			if replicationMode == 0 {
-				replicationMode = momo_common.ReplicationNone
+				replicationMode = common.ReplicationNone
 			}
 
 			log.Printf("Cluster object global timestamp: %d", finalTs)
@@ -154,7 +154,7 @@ go func(comm transport.Communicator) {
 
 			// Send the selected replication mode back to the client
 			if err := comm.SendReplicationMode(replicationMode); err != nil {
-				log.Printf("AUDIT: Error sending replication mode to %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Error sending replication mode to %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 				return
 			}
 
@@ -164,26 +164,26 @@ go func(comm transport.Communicator) {
 
 			metadata, err := comm.ReceiveMetadata()
 			if err != nil {
-				log.Printf("AUDIT: Error getting metadata from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+				log.Printf("AUDIT: Error getting metadata from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 				return
 			}
 
 			// 🛡️ Sentinel: Sanitize fileName immediately to prevent path traversal in all downstream consumers.
 			rawFileName := metadata.Name
 			if rawFileName == "." || rawFileName == ".." || strings.Contains(rawFileName, "/") || strings.Contains(rawFileName, "\\") {
-				log.Printf("AUDIT: Invalid filename received from %s: %v", remoteAddr, momo_common.SanitizeLog(rawFileName))
+				log.Printf("AUDIT: Invalid filename received from %s: %v", remoteAddr, common.SanitizeLog(rawFileName))
 				return
 			}
 			fileName := filepath.Base(rawFileName)
 			if fileName == "." || fileName == ".." || fileName == "/" || fileName == "\\" {
-				log.Printf("AUDIT: Invalid base filename received from %s: %v", remoteAddr, momo_common.SanitizeLog(fileName))
+				log.Printf("AUDIT: Invalid base filename received from %s: %v", remoteAddr, common.SanitizeLog(fileName))
 				return
 			}
 			metadata.Name = fileName
 
 			// 🛡️ Sentinel: Enforce maximum file size to prevent Denial of Service via resource exhaustion
-			if metadata.Size < 0 || metadata.Size > momo_common.MaxFileSize {
-				log.Printf("AUDIT: Invalid file size received from %s: %d (max: %d)", remoteAddr, metadata.Size, momo_common.MaxFileSize)
+			if metadata.Size < 0 || metadata.Size > common.MaxFileSize {
+				log.Printf("AUDIT: Invalid file size received from %s: %d (max: %d)", remoteAddr, metadata.Size, common.MaxFileSize)
 				return
 			}
 
@@ -195,16 +195,16 @@ go func(comm transport.Communicator) {
 
 			// Handle the file based on the replication mode
 			switch replicationMode {
-			case momo_common.ReplicationNone, momo_common.ReplicationPrimarySplay:
+			case common.ReplicationNone, common.ReplicationPrimarySplay:
 				if err := getFile(comm, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
-					log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+					log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 					return
 				}
-			case momo_common.ReplicationChain:
+			case common.ReplicationChain:
 				if serverId == 1 {
 					wg.Add(1)
 					if err := getFile(comm, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
-						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 						wg.Done()
 						return
 					}
@@ -213,17 +213,17 @@ go func(comm transport.Communicator) {
 				} else {
 					wg.Add(1)
 					if err := getFile(comm, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
-						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 						wg.Done()
 						return
 					}
 					connectToPeer(&wg, cfg, daemons[0].Data+"/"+metadata.Name, 1, finalTs)
 					wg.Wait()
 				}
-			case momo_common.ReplicationSplay:
+			case common.ReplicationSplay:
 				wg.Add(2)
 				if err := getFile(comm, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size); err != nil {
-					log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, momo_common.SanitizeLog(err.Error()))
+					log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 					wg.Done()
 					wg.Done()
 					return

--- a/src/server/server_daemon_test.go
+++ b/src/server/server_daemon_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/transport"
 )
 
@@ -21,15 +21,15 @@ func padTestString(input string, length int) string {
 }
 
 func TestChangeReplicationModeServerReal(t *testing.T) {
-	daemons := []*momo_common.Daemon{
+	daemons := []*common.Daemon{
 		{ChangeReplication: "127.0.0.1:45678"},
 		{ChangeReplication: "127.0.0.1:45679"},
 		{ChangeReplication: "127.0.0.1:45680"},
 	}
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
-	cfg := momo_common.Configuration{
+	cfg := common.Configuration{
 		Daemons: daemons,
-		Global: momo_common.ConfigurationGlobal{
+		Global: common.ConfigurationGlobal{
 			AuthToken: authToken,
 			Protocol:  "momo-tcp",
 		},
@@ -44,7 +44,7 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 		conn, err := l1.Accept()
 		if err == nil {
 			defer conn.Close()
-			authBuf := make([]byte, momo_common.AuthTokenLength)
+			authBuf := make([]byte, common.AuthTokenLength)
 			io.ReadFull(conn, authBuf)
 		}
 	}()
@@ -55,7 +55,7 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 		conn, err := l2.Accept()
 		if err == nil {
 			defer conn.Close()
-			authBuf := make([]byte, momo_common.AuthTokenLength)
+			authBuf := make([]byte, common.AuthTokenLength)
 			io.ReadFull(conn, authBuf)
 		}
 	}()
@@ -74,8 +74,8 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 		t.Fatalf("Handshake failed: %v", err)
 	}
 
-	data := momo_common.ReplicationData{
-		New:       momo_common.ReplicationSplay,
+	data := common.ReplicationData{
+		New:       common.ReplicationSplay,
 		TimeStamp: time.Now().Unix(),
 	}
 	jsonBytes, _ := json.Marshal(data)
@@ -85,7 +85,7 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 
 func TestDaemonReal(t *testing.T) {
 	tempDir := t.TempDir()
-	daemons := []*momo_common.Daemon{
+	daemons := []*common.Daemon{
 		{Host: "127.0.0.1:45681", Data: tempDir + "/001"},
 		{Host: "127.0.0.1:45682", Data: tempDir + "/002"},
 		{Host: "127.0.0.1:45683", Data: tempDir + "/003"},
@@ -96,9 +96,9 @@ func TestDaemonReal(t *testing.T) {
 	}
 
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
-	cfg := momo_common.Configuration{
+	cfg := common.Configuration{
 		Daemons: daemons,
-		Global: momo_common.ConfigurationGlobal{
+		Global: common.ConfigurationGlobal{
 			AuthToken: authToken,
 			Protocol:  "momo-tcp",
 		},
@@ -125,8 +125,8 @@ func TestDaemonReal(t *testing.T) {
 	if err == nil {
 		file.WriteString("data")
 		file.Close()
-		hash, _ := momo_common.HashFile(file.Name())
-		meta := &momo_common.FileMetadata{
+		hash, _ := common.HashFile(file.Name())
+		meta := &common.FileMetadata{
 			Name: "test.txt",
 			Hash: hash,
 			Size: 4,

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	momo_common "github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/common"
 )
 
 // mockConnect is a mock implementation of Connect for testing.
-func mockConnect(wg *sync.WaitGroup, cfg momo_common.Configuration, filePath string, serverId int, timestamp int64) {
+func mockConnect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, serverId int, timestamp int64) {
 	defer wg.Done()
 	// In a real test, you might add more logic here to simulate the client's behavior
 }
@@ -33,7 +33,7 @@ func mockGetFile(connection net.Conn, path string, fileName string, expectedHash
 }
 
 // handleConnection is a testable version of the connection handling logic inside Daemon.
-func handleConnection(t *testing.T, connection net.Conn, cfg momo_common.Configuration, serverId int) {
+func handleConnection(t *testing.T, connection net.Conn, cfg common.Configuration, serverId int) {
 	daemons := cfg.Daemons
 	var replicationMode int
 	var success bool
@@ -47,18 +47,18 @@ func handleConnection(t *testing.T, connection net.Conn, cfg momo_common.Configu
 		connection.Close()
 	}()
 
-	bufferAuthToken := make([]byte, momo_common.AuthTokenLength)
+	bufferAuthToken := make([]byte, common.AuthTokenLength)
 	if _, err := io.ReadFull(connection, bufferAuthToken); err != nil {
 		t.Logf("Error reading AuthToken: %v", err)
 		return
 	}
-	expectedAuthToken := []byte(momo_common.PadString(cfg.Global.AuthToken, momo_common.AuthTokenLength))
+	expectedAuthToken := []byte(common.PadString(cfg.Global.AuthToken, common.AuthTokenLength))
 	if subtle.ConstantTimeCompare(bufferAuthToken, expectedAuthToken) != 1 {
 		t.Logf("Invalid AuthToken received")
 		return
 	}
 
-	bufferTimestamp := make([]byte, momo_common.TimestampLength)
+	bufferTimestamp := make([]byte, common.TimestampLength)
 	if _, err := connection.Read(bufferTimestamp); err != nil {
 		t.Logf("Error reading timestamp: %v", err)
 		return
@@ -80,11 +80,11 @@ func handleConnection(t *testing.T, connection net.Conn, cfg momo_common.Configu
 		} else {
 			replicationMode = repState.Old
 		}
-		if replicationMode != momo_common.ReplicationChain {
-			replicationMode = momo_common.ReplicationNone
+		if replicationMode != common.ReplicationChain {
+			replicationMode = common.ReplicationNone
 		}
 	default:
-		replicationMode = momo_common.ReplicationNone
+		replicationMode = common.ReplicationNone
 	}
 
 	connection.Write([]byte(strconv.Itoa(replicationMode)))
@@ -105,9 +105,9 @@ func handleConnection(t *testing.T, connection net.Conn, cfg momo_common.Configu
 	defer func() { connectToPeer = originalConnect }()
 
 	switch replicationMode {
-	case momo_common.ReplicationNone:
+	case common.ReplicationNone:
 		mockGetFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size)
-	case momo_common.ReplicationChain:
+	case common.ReplicationChain:
 		if serverId == 1 {
 			wg.Add(1)
 			mockGetFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size)
@@ -119,7 +119,7 @@ func handleConnection(t *testing.T, connection net.Conn, cfg momo_common.Configu
 			connectToPeer(&wg, cfg, daemons[0].Data+"/"+metadata.Name, 1, timestamp)
 			wg.Wait()
 		}
-	case momo_common.ReplicationSplay:
+	case common.ReplicationSplay:
 		wg.Add(2)
 		mockGetFile(connection, daemons[serverId].Data+"/", metadata.Name, metadata.Hash, metadata.Size)
 		go connectToPeer(&wg, cfg, daemons[0].Data+"/"+metadata.Name, 1, timestamp)
@@ -131,7 +131,7 @@ func handleConnection(t *testing.T, connection net.Conn, cfg momo_common.Configu
 
 func TestDaemonLogic(t *testing.T) {
 	// Setup common test data
-	daemons := []*momo_common.Daemon{
+	daemons := []*common.Daemon{
 		{Host: "127.0.0.1:0", Data: ""},
 		{Host: "127.0.0.1:0", Data: ""},
 		{Host: "127.0.0.1:0", Data: ""},
@@ -152,7 +152,7 @@ func TestDaemonLogic(t *testing.T) {
 	tempFile.Write([]byte(fileContent))
 	tempFile.Close()
 
-	hash, _ := momo_common.HashFile(tempFile.Name())
+	hash, _ := common.HashFile(tempFile.Name())
 
 	testCases := []struct {
 		name                string
@@ -161,15 +161,15 @@ func TestDaemonLogic(t *testing.T) {
 		expectedAck         string
 		expectedReplication int
 	}{
-		{"ReplicationNone", momo_common.ReplicationNone, 0, "ACK0", momo_common.ReplicationNone},
-		{"ReplicationSplay", momo_common.ReplicationSplay, 0, "ACK0", momo_common.ReplicationSplay},
-		{"ReplicationChain", momo_common.ReplicationChain, 1, "ACK1", momo_common.ReplicationChain},
+		{"ReplicationNone", common.ReplicationNone, 0, "ACK0", common.ReplicationNone},
+		{"ReplicationSplay", common.ReplicationSplay, 0, "ACK0", common.ReplicationSplay},
+		{"ReplicationChain", common.ReplicationChain, 1, "ACK1", common.ReplicationChain},
 	}
 
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
-	cfg := momo_common.Configuration{
+	cfg := common.Configuration{
 		Daemons: daemons,
-		Global: momo_common.ConfigurationGlobal{
+		Global: common.ConfigurationGlobal{
 			AuthToken: authToken,
 		},
 	}
@@ -187,7 +187,7 @@ func TestDaemonLogic(t *testing.T) {
 			}()
 
 			// Test Execution
-			client.Write([]byte(momo_common.PadString(authToken, momo_common.AuthTokenLength)))
+			client.Write([]byte(common.PadString(authToken, common.AuthTokenLength)))
 			timestamp := strconv.FormatInt(time.Now().UnixNano(), 10)
 			client.Write([]byte(timestamp))
 
@@ -201,10 +201,10 @@ func TestDaemonLogic(t *testing.T) {
 
 			// Send metadata
 			client.Write([]byte(hash))
-			fileNameBytes := make([]byte, momo_common.FileInfoLength)
+			fileNameBytes := make([]byte, common.FileInfoLength)
 			copy(fileNameBytes, fileName)
 			client.Write(fileNameBytes)
-			fileSizeBytes := make([]byte, momo_common.FileInfoLength)
+			fileSizeBytes := make([]byte, common.FileInfoLength)
 			copy(fileSizeBytes, strconv.Itoa(len(fileContent)))
 			client.Write(fileSizeBytes)
 
@@ -233,12 +233,12 @@ func TestDaemonLogic(t *testing.T) {
 }
 
 func TestUnauthenticatedConnection(t *testing.T) {
-	daemons := []*momo_common.Daemon{{Host: "127.0.0.1:0", Data: ""}}
+	daemons := []*common.Daemon{{Host: "127.0.0.1:0", Data: ""}}
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
 	wrongToken := "wrong_token_wrong_token_wrong_token_wrong_token_wrong_token_wro"
-	cfg := momo_common.Configuration{
+	cfg := common.Configuration{
 		Daemons: daemons,
-		Global: momo_common.ConfigurationGlobal{
+		Global: common.ConfigurationGlobal{
 			AuthToken: authToken,
 		},
 	}
@@ -251,7 +251,7 @@ func TestUnauthenticatedConnection(t *testing.T) {
 	}()
 
 	// Try with wrong token
-	client.Write([]byte(momo_common.PadString(wrongToken, momo_common.AuthTokenLength)))
+	client.Write([]byte(common.PadString(wrongToken, common.AuthTokenLength)))
 
 	// Attempt to read something (e.g., replication mode) - should fail because server closes connection
 	replicationModeBuf := make([]byte, 1)


### PR DESCRIPTION
This PR standardizes the use of the `common`, `transport`, `client`, `server`, and `metrics` packages across the codebase.

### Changes:
- Removed the `momo_common` alias in favor of the default `common` name in `src/server` and `src/metrics`.
- Removed redundant package aliases (e.g., `metrics "..."`, `server "..."`) in `src/momo.go`.
- Standardized all cross-package imports to use the same naming convention for better readability and architectural consistency.
- Fixed a duplicate import in `src/metrics/metrics_extra_test.go`.

All tests (Unit, Fuzz, and Smoke) are passing flawlessly.