### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability via unsanitized metadata fields

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -93,3 +93,8 @@
 **Vulnerability:** Path traversal (`../../../file`) and DoS (unbounded `metadata.Size`) vulnerabilities existed because the sanitization logic was implemented in an unused/dead utility function (`getMetadata` in `file.go`), while the active network data path (`comm.ReceiveMetadata()`) returned unsanitized metadata directly to the core `Daemon` handler.
 **Learning:** Security checks that are not structurally enforced on the active data paths are ineffective. It's a common pattern for "hardened" functions to be bypassed during refactoring if the architecture allows extracting raw data directly from the connection via alternative methods.
 **Prevention:** Enforce input sanitization at the lowest possible layer (e.g., directly inside `ReceiveMetadata` for each protocol) or immediately at the first use site in the handler before *any* logic (like deadline calculations or logging) consumes the untrusted data.
+
+## 2026-06-13 - Path Traversal via Unsanitized Content Hash
+**Vulnerability:** The application used `metadata.Hash` directly in the `store.Has(metadata.Hash)` deduplication check before sanitizing it, potentially allowing path traversal if the backend storage mechanism uses the hash as part of a file path.
+**Learning:** Security validations and sanitizations must be performed immediately after receiving untrusted data and strictly *before* that data interacts with internal systems or storage components.
+**Prevention:** Sanitize the file hash against path traversal characters (`.`, `/`, `\`) explicitly, and ensure all untrusted network inputs (Hash, Name, Size) are validated immediately upon receipt, rather than waiting until just before final write operations.

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -185,6 +185,30 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 				return
 			}
 
+			// 🛡️ Sentinel: Sanitize hash immediately to prevent path traversal via malicious hashes.
+			if metadata.Hash == "" || metadata.Hash == "." || metadata.Hash == ".." || strings.Contains(metadata.Hash, "/") || strings.Contains(metadata.Hash, "\\") {
+				log.Printf("AUDIT: Invalid hash received from %s: %v", remoteAddr, common.SanitizeLog(metadata.Hash))
+				return
+			}
+
+			// 🛡️ Sentinel: Sanitize fileName immediately to prevent path traversal in all downstream consumers.
+			rawFileName := metadata.Name
+			if rawFileName == "" || rawFileName == "." || rawFileName == ".." || strings.Contains(rawFileName, "/") || strings.Contains(rawFileName, "\\") {
+				log.Printf("AUDIT: Invalid filename received from %s: %v", remoteAddr, common.SanitizeLog(rawFileName))
+				return
+			}
+			fileName := filepath.Base(rawFileName)
+			if fileName == "" || fileName == "." || fileName == ".." || fileName == "/" || fileName == "\\" {
+				log.Printf("AUDIT: Invalid filename received from %s: %v", remoteAddr, common.SanitizeLog(fileName))
+				return
+			}
+
+			// 🛡️ Sentinel: Enforce maximum file size to prevent Denial of Service via resource exhaustion
+			if metadata.Size < 0 || metadata.Size > common.MaxFileSize {
+				log.Printf("AUDIT: Invalid file size received from %s: %d (max: %d)", remoteAddr, metadata.Size, common.MaxFileSize)
+				return
+			}
+
 			// 🛡️ Zero-Crash: Defensive check for storage initialization.
 			if store == nil {
 				log.Printf("AUDIT: Storage error for %s: store not initialized: %v", remoteAddr, syscall.EIO)
@@ -209,24 +233,6 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 					log.Printf("AUDIT: Error sending metadata status to %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 					return
 				}
-			}
-
-			// 🛡️ Sentinel: Sanitize fileName immediately to prevent path traversal in all downstream consumers.
-			rawFileName := metadata.Name
-			if rawFileName == "" || rawFileName == "." || rawFileName == ".." || strings.Contains(rawFileName, "/") || strings.Contains(rawFileName, "\\") {
-				log.Printf("AUDIT: Invalid filename received from %s: %v", remoteAddr, common.SanitizeLog(rawFileName))
-				return
-			}
-			fileName := filepath.Base(rawFileName)
-			if fileName == "" || fileName == "." || fileName == ".." || fileName == "/" || fileName == "\\" {
-				log.Printf("AUDIT: Invalid filename received from %s: %v", remoteAddr, common.SanitizeLog(fileName))
-				return
-			}
-
-			// 🛡️ Sentinel: Enforce maximum file size to prevent Denial of Service via resource exhaustion
-			if metadata.Size < 0 || metadata.Size > common.MaxFileSize {
-				log.Printf("AUDIT: Invalid file size received from %s: %d (max: %d)", remoteAddr, metadata.Size, common.MaxFileSize)
-				return
 			}
 
 			// Calculate Placement using CRUSH


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unsanitized file hashes (`metadata.Hash`) were passed directly to the internal storage backend (`store.Has()`). Additionally, validation logic for filenames and sizes was executed *after* interacting with the storage layer.
🎯 Impact: An attacker could supply malicious hash strings containing path traversal characters (e.g. `../`) leading to directory traversal attacks against the CAS storage backend.
🔧 Fix: Added explicit sanitization for `metadata.Hash` against path traversal characters. Reordered the flow to ensure that Name, Hash, and Size are validated immediately after being received from the network, before any internal system interaction.
✅ Verification: Ensure the test suite passes (`make test`), demonstrating that valid network payloads are processed correctly and malicious metadata payloads are neutralized early.

---
*PR created automatically by Jules for task [16750672460649056113](https://jules.google.com/task/16750672460649056113) started by @alsotoes*