### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal via unsanitized hash metadata

### DIFF
--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -220,6 +220,11 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		if m.meta.Hash == "" {
 			m.meta.Hash = req.Header.Get("Content-SHA256") // Fallback
 		}
+
+		// 🛡️ Sentinel: Sanitize S3 hash to prevent directory traversal via malicious metadata.
+		if m.meta.Hash != "" && hasPathTraversalChars(m.meta.Hash) {
+			return 0, 0, fmt.Errorf("invalid hash: %s: %w", m.meta.Hash, syscall.EBADMSG)
+		}
 	}
 
 	return requestedMode, timestamp, nil
@@ -343,6 +348,11 @@ func (m *S3Communicator) ReceiveMetadata() (meta common.FileMetadata, err error)
 		if hash == "" {
 			hash = req.Header.Get("Content-SHA256")
 		}
+
+		// 🛡️ Sentinel: Sanitize S3 hash to prevent directory traversal via malicious metadata.
+		if hash != "" && hasPathTraversalChars(hash) {
+			return common.FileMetadata{}, fmt.Errorf("invalid hash: %s: %w", hash, syscall.EBADMSG)
+		}
 		m.meta.Hash = hash
 	}
 	return m.meta, nil
@@ -437,4 +447,16 @@ func (m *S3Communicator) ReceiveACK() (err error) {
 
 func (m *S3Communicator) RemoteAddr() net.Addr {
 	return m.remoteAddr
+}
+
+// hasPathTraversalChars returns true if the string contains '.', '/' or '\'.
+// It is inlineable and operates directly on the string bytes without any heap allocation (Rule 19).
+func hasPathTraversalChars(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '.' || c == '/' || c == '\\' {
+			return true
+		}
+	}
+	return false
 }

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -1,7 +1,10 @@
 package transport
 
 import (
+	"errors"
 	"net"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/alsotoes/momo/src/common"
@@ -112,5 +115,58 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 	_, _, err := comm.HandshakeServer(expectedAuthToken)
 	if err != nil {
 		t.Fatalf("HandshakeServer failed with AWS v4 auth: %v", err)
+	}
+}
+
+func TestS3Communicator_HashTraversalValidation(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+	maliciousHashes := []string{
+		"../../malicious",
+		"some/path",
+		"bad\\hash",
+		".dot",
+	}
+
+	for _, malHash := range maliciousHashes {
+		t.Run("hash_"+malHash, func(t *testing.T) {
+			reqBody := "PUT /test-file.txt HTTP/1.1\r\n" +
+				"Host: 127.0.0.1:4440\r\n" +
+				"Authorization: Bearer " + authToken + "\r\n" +
+				"X-Amz-Date: 20260604T120000Z\r\n" +
+				"X-Amz-Content-Sha256: " + malHash + "\r\n" +
+				"Content-Length: 1024\r\n\r\n"
+
+			clientConn, serverConn := net.Pipe()
+			defer clientConn.Close()
+			defer serverConn.Close()
+
+			go func() {
+				clientConn.Write([]byte(reqBody))
+				buf := make([]byte, 1024)
+				for {
+					_, err := clientConn.Read(buf)
+					if err != nil {
+						break
+					}
+				}
+			}()
+
+			comm := NewS3Communicator(serverConn)
+			_, _, err := comm.HandshakeServer(expectedAuthToken)
+			if err == nil {
+				t.Fatalf("Expected HandshakeServer to fail on malicious hash %q, but got success", malHash)
+			}
+			if !strings.Contains(err.Error(), "invalid hash") {
+				t.Errorf("Expected invalid hash error, got %v", err)
+			}
+			// Verify POSIX error mapping to syscall.EBADMSG
+			if !errors.Is(err, syscall.EBADMSG) {
+				t.Errorf("Expected error to wrap syscall.EBADMSG, got %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix path traversal via unsanitized hash metadata

• 🚨 Severity: CRITICAL
• 💡 Vulnerability: Unsanitized extraction of `X-Amz-Content-Sha256` / `Content-SHA256` HTTP headers in S3 communicator.
• 🎯 Impact: If an attacker sends a malicious hash header like `../../../`, downstream functions like `storage.CASStore.getBlobPath` will interpret it as a directory component, enabling arbitrary file overwrites and logic bypasses.
• 🔧 Fix: Added validation checks directly in `HandshakeServer` and `ReceiveMetadata` within `src/transport/s3_communicator.go` to explicitly reject hashes containing `.`, `/`, or `\`. This guarantees the hash string is sanitized at the point of receipt.
• 🧪 Verification: Ran `make test` and ensured `TestS3Communicator_HandshakeServer` passes alongside other test suites. Verified that the hash path traversal character verification succeeds gracefully without raising untyped errors by injecting `syscall.EBADMSG`.

--------

### 🛡️ Resolved Audits & Hardening Changes (AI Reviewer Feedback):

1. **Panic Recovery & Zero-Crash (Rule 4)**:
   - Verified that `HandshakeServer` and `ReceiveMetadata` run under full defer-recovery blocks to satisfy the Zero-Crash Pattern.
2. **Resource-Aware Hashing (Rule 19)**:
   - Configured all hash-traversal validations to operate directly on existing stack variables to avoid heap allocation overhead.
   - Refactored sanitization from `strings.ContainsAny` to a custom, zero-allocation character validation loop (`hasPathTraversalChars`) operating directly on string bytes to completely eliminate any heap allocation in high-throughput S3 metadata hot paths.
3. **POSIX Error Mapping (Rule 10)**:
   - Wrapped character validation to return standard POSIX `syscall.EBADMSG` on invalid hashes.
4. **Clean Integration & Conflict Resolution (Rule 23)**:
   - Fully synchronized the branch with the latest `master` to resolve stale layout discrepancies cleanly and ported functional fixes conflict-free.
5. **Robust Test Coverage (Rule 5 & 7)**:
   - Added a dedicated unit test suite (`TestS3Communicator_HashTraversalValidation`) covering path traversal vectors (`../../malicious`, `some/path`, `bad\hash`, `.dot`) to guarantee stable and secure error propagation behavior.

PR created automatically by Jules for task 11833291342624452368 https://jules.google.com/task/11833291342624452368
started by @alsotoes

Resolves #204
Resolves https://github.com/alsotoes/momo/issues/228