### PR TITLE
🛡️ Security: Add trailing comments to dummy tokens to avoid false positives

### DIFF
--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -1,7 +1,7 @@
 [global]
 auth_token=super_secret_token
 debug=true
-auth_token=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6
+auth_token=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # not a real token
 replication_order=3,2,1
 polymorphic_system=false
 

--- a/src/client/client_extra_test.go
+++ b/src/client/client_extra_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestConnect_PrimarySplay(t *testing.T) {
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	
 	file, err := os.CreateTemp("", "test_splay_*.txt")
 	if err != nil {

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -124,7 +124,7 @@ func startDummyServer(t *testing.T, authToken string) (string, net.Listener) {
 }
 
 func TestConnect(t *testing.T) {
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 
 	// Create a temp file to send
 	file, err := os.CreateTemp("", "test_connect_*.txt")
@@ -222,7 +222,7 @@ func TestConnect(t *testing.T) {
 }
 
 func TestSendFile(t *testing.T) {
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 
 	file, err := os.CreateTemp("", "test_sendfile_*.txt")
 	if err != nil {

--- a/src/common/config_bench_test.go
+++ b/src/common/config_bench_test.go
@@ -11,7 +11,7 @@ func BenchmarkLoadGlobalConfig(b *testing.B) {
 [global]
 debug = true
 protocol = momo-tcp
-auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6
+auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # not a real token
 replication_order = 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20
 polymorphic_system = true
 `))

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -11,7 +11,7 @@ import (
 const validConfig = `
 [global]
 debug = true
-auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6
+auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # not a real token
 replication_order = 2,3,1
 polymorphic_system = true
 
@@ -102,7 +102,7 @@ func TestGetConfig_Failures(t *testing.T) {
 		},
 		{
 			name:          "Missing auth_token",
-			content:       strings.Replace(validConfig, "auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", "", 1),
+			content:       strings.Replace(validConfig, "auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # not a real token", "", 1),
 			expectedError: "failed to load [global] section: 'auth_token' is missing or empty",
 		},
 		{

--- a/src/metrics/metrics_extra_test.go
+++ b/src/metrics/metrics_extra_test.go
@@ -14,7 +14,7 @@ func TestGetMetrics_Cancellation(t *testing.T) {
 		Global: common.ConfigurationGlobal{
 			PolymorphicSystem: true,
 			ReplicationOrder: []int{1, 2, 3, 4},
-			AuthToken: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
+			AuthToken: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", // not a real token
 		},
 		Metrics: common.ConfigurationMetrics{
 			Interval: 1,

--- a/src/metrics/replication_test.go
+++ b/src/metrics/replication_test.go
@@ -47,7 +47,7 @@ func TestPushNewReplicationMode(t *testing.T) {
 	}()
 
 	// Mock config
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	cfg := common.Configuration{
 		Daemons: []*common.Daemon{
 			{

--- a/src/server/cas_integration_test.go
+++ b/src/server/cas_integration_test.go
@@ -28,7 +28,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 	stores := make([]storage.Store, nodeCount)
 	listeners := make([]net.Listener, nodeCount)
 	
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	
 	for i := 0; i < nodeCount; i++ {
 		nodeData := filepath.Join(tempDir, fmt.Sprintf("node-%d", i))

--- a/src/server/replication_test.go
+++ b/src/server/replication_test.go
@@ -61,7 +61,7 @@ func handleReplicationChange(t *testing.T, authToken string, connection net.Conn
 // TestChangeReplicationModeServerLogic verifies that the server correctly
 // updates its replication mode based on data from a client connection.
 func TestChangeReplicationModeServerLogic(t *testing.T) {
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 
 	// Arrange: Set initial state and create a network pipe to simulate a client-server connection.
 	SetReplicationState(common.ReplicationNone, 0) // Initial mode
@@ -105,7 +105,7 @@ func TestChangeReplicationModeServerLogic(t *testing.T) {
 // TestChangeReplicationModeClient verifies that the client function correctly sends the
 // replication mode JSON payload to a listening server.
 func TestChangeReplicationModeClient(t *testing.T) {
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 
 	// Arrange: Set up a listener to act as a mock server.
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/src/server/server_daemon_test.go
+++ b/src/server/server_daemon_test.go
@@ -26,7 +26,7 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 		{ChangeReplication: "127.0.0.1:45679"},
 		{ChangeReplication: "127.0.0.1:45680"},
 	}
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	cfg := common.Configuration{
 		Daemons: daemons,
 		Global: common.ConfigurationGlobal{
@@ -120,7 +120,7 @@ func TestDaemonReal(t *testing.T) {
 		os.MkdirAll(d.Data, 0755)
 	}
 
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	cfg := common.Configuration{
 		Daemons: daemons,
 		Global: common.ConfigurationGlobal{

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -151,7 +151,7 @@ func TestDaemonLogic(t *testing.T) {
 		{"ReplicationChain", common.ReplicationChain, 1, "ACK1", common.ReplicationChain},
 	}
 
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	cfg := common.Configuration{
 		Daemons: daemons,
 		Global: common.ConfigurationGlobal{
@@ -229,7 +229,7 @@ func TestDaemonLogic(t *testing.T) {
 
 func TestUnauthenticatedConnection(t *testing.T) {
 	daemons := []*common.Daemon{{Host: "127.0.0.1:0", Data: ""}}
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	wrongToken := "wrong_token_wrong_token_wrong_token_wrong_token_wrong_token_wro"
 	cfg := common.Configuration{
 		Daemons: daemons,

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -23,7 +23,7 @@ func verifyNoLeaks(t *testing.T) {
 func TestS3Communicator_HandshakeServer(t *testing.T) {
 	defer verifyNoLeaks(t)
 
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
 	reqBody := "PUT /test-file.txt HTTP/1.1\r\n" +
@@ -81,7 +81,7 @@ func TestS3Communicator_HandshakeServer(t *testing.T) {
 func TestS3Communicator_AWSV4Auth(t *testing.T) {
 	defer verifyNoLeaks(t)
 
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
 	// AWS v4 style Auth header
@@ -121,7 +121,7 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 func TestS3Communicator_HashTraversalValidation(t *testing.T) {
 	defer verifyNoLeaks(t)
 
-	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // not a real token
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
 	maliciousHashes := []string{


### PR DESCRIPTION
💡 **What:** Added trailing comments (e.g. '// not a real token' or '# not a real token') to all dummy 64-character auth tokens and keys used across the codebase and testing suites.

🎯 **Why:** To prevent online security scanners (like Gitleaks or GitGuardian) from flagging these dummy test values as true-positive leaks and causing build/scanner noise.

Resolves #216

Resolves https://github.com/alsotoes/momo/issues/232