### PR TITLE
feat: unify and log panic recovery blocks across transport and common libraries (Resolves #245)

### DIFF
--- a/openspec/changes/archive/2026-06-30-unify-panic-logging/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-30-unify-panic-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/archive/2026-06-30-unify-panic-logging/design.md
+++ b/openspec/changes/archive/2026-06-30-unify-panic-logging/design.md
@@ -1,0 +1,28 @@
+## Context
+
+Momo implements robust crash-safety, but several `defer recover()` blocks across `momo_tcp.go`, `momo_quic.go`, and `crush.go` are silent (only assigning to `err` but omitting logging). **Project Steering Rule 9** mandates that all failures must be logged explicitly. To align with this, we must update all remaining silent recovery blocks to employ our established two-line recovery pattern (log + error).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Update all 18 silent recovery blocks to print detailed critical messages using `log.Printf`.
+- Guarantee that all panic recoveries remain crash-safe and correctly propagate POSIX errors wrapping `syscall.EIO` or `syscall.EBADMSG`.
+
+**Non-Goals:**
+- Alter any functional data flow or network framing layouts.
+- Change the structure or execution of background daemon thread pools.
+
+## Decisions
+
+### 1. Two-Line Recovery Refactoring
+- **Choice:** Consistently update each target method's recovery block to include a distinct, trackable `log.Printf("CRITICAL: Recovered from panic in <MethodName>: %v", r)` statement.
+- **Rationale:** This establishes perfect code consistency and ensures that any caught panic immediately emits a highly visible diagnostic trace in stderr, completely resolving logging gaps.
+
+### 2. Standardizing Imports
+- **Choice:** Ensure the standard `"log"` package is imported in `crush.go` (since it is not currently imported there) and verify it is correctly utilized.
+- **Rationale:** Conforms to standard compilation requirements.
+
+## Risks / Trade-offs
+
+- **[Risk] Missing a Block:** Accidentally leaving some recovery blocks silent.
+  - **Mitigation:** Rely strictly on our global `recover()` grep audit results containing all 53 recovery blocks across the codebase to perform exhaustive, sequential edits.

--- a/openspec/changes/archive/2026-06-30-unify-panic-logging/proposal.md
+++ b/openspec/changes/archive/2026-06-30-unify-panic-logging/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+While Momo implements robust crash-safety with `defer recover()` blocks across its transport and common layers (satisfying Rule 4), several of these recovery blocks are currently silent: they assign an error to the named `err` return parameter but do not emit a `log.Printf` message to Stderr (violating **Rule 9: No Silent Failures**). To ensure complete, consistent system observability on failures, we must unify these blocks under our established two-line recovery pattern, resolving tracking issue #245.
+
+## What Changes
+
+- **Refactor Silent Recovery Blocks:** Add explicit `log.Printf` statements to all 18 silent recovery blocks in `src/transport/momo_tcp.go`, `src/transport/momo_quic.go`, and `src/common/crush.go`.
+- **Unify Logger Imports:** Ensure the standard `"log"` package is correctly imported and utilized across all target source files.
+
+## Capabilities
+
+### New Capabilities
+- `unified-panic-logging`: Observability suite ensuring all transport and placement recovery blocks emit trace-friendly, explicit logs upon catching a panic.
+
+## Impact
+
+- **Affected Code:**
+  - `src/transport/momo_tcp.go`
+  - `src/transport/momo_quic.go`
+  - `src/common/crush.go`
+- **APIs:** Does not alter any API signatures or protocol wire frames.

--- a/openspec/changes/archive/2026-06-30-unify-panic-logging/specs/unified-panic-logging/spec.md
+++ b/openspec/changes/archive/2026-06-30-unify-panic-logging/specs/unified-panic-logging/spec.md
@@ -1,0 +1,29 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/245
+
+# Unified Panic Logging Specification
+
+## Purpose
+This specification enforces that all crash-safety recovery blocks across Momo's transports and libraries emit trace-friendly, explicit logging, completely eliminating silent failures and satisfying Rule 9.
+
+## ADDED Requirements
+
+### Requirement: Observable TCP Transport Recovery (Resolves #245)
+The system SHALL ensure that any panic recovered inside `MomoTCPCommunicator` methods is explicitly logged using `log.Printf`.
+
+#### Scenario: Recovering and logging TCP panics
+- **WHEN** a panic occurs during a TCP operation (such as `SendMetadata`, `ReceiveACK`, or `Close`)
+- **THEN** the recovery block logs a traceback warning with `log.Printf` and returns a formatted error wrapping `syscall.EIO`
+
+### Requirement: Observable QUIC Transport Recovery (Resolves #245)
+The system SHALL ensure that any panic recovered inside `MomoQUICCommunicator` methods is explicitly logged using `log.Printf`.
+
+#### Scenario: Recovering and logging QUIC panics
+- **WHEN** a panic occurs during a QUIC operation (such as `SendMetadata`, `ReceiveACK`, or `Close`)
+- **THEN** the recovery block logs a traceback warning with `log.Printf` and returns a formatted error wrapping `syscall.EIO`
+
+### Requirement: Observable CRUSH Placement Recovery (Resolves #245)
+The system SHALL ensure that any panic recovered inside the `ClusterMap.Placement` calculation is explicitly logged using `log.Printf`.
+
+#### Scenario: Recovering and logging placement panics
+- **WHEN** a panic occurs during weighted rendezvous hashing or placement calculation
+- **THEN** the recovery block logs a traceback warning with `log.Printf` and returns a formatted error wrapping `syscall.EIO`

--- a/openspec/changes/archive/2026-06-30-unify-panic-logging/tasks.md
+++ b/openspec/changes/archive/2026-06-30-unify-panic-logging/tasks.md
@@ -1,0 +1,11 @@
+## 1. Specification and Core Refactoring
+
+- [x] 1.1 Finalize the OpenSpec proposal and capabilities documentation for `unified-panic-logging`
+- [x] 1.2 Update all 8 silent recovery blocks in `src/transport/momo_tcp.go` to include `log.Printf` logging
+- [x] 1.3 Update all 9 silent recovery blocks in `src/transport/momo_quic.go` to include `log.Printf` logging
+- [x] 1.4 Update the silent recovery block in `src/common/crush.go` to include `"log"` package and `log.Printf` logging
+
+## 2. Testing and Validation
+
+- [x] 2.1 Run the full Momo unit and integration test suite to verify correct compilation
+- [x] 2.2 Verify that all tests pass perfectly with zero memory leaks, thread stalls, or regressions

--- a/openspec/specs/unified-panic-logging/spec.md
+++ b/openspec/specs/unified-panic-logging/spec.md
@@ -1,0 +1,26 @@
+# unified-panic-logging Specification
+
+## Purpose
+TBD - created by archiving change unify-panic-logging. Update Purpose after archive.
+## Requirements
+### Requirement: Observable TCP Transport Recovery (Resolves #245)
+The system SHALL ensure that any panic recovered inside `MomoTCPCommunicator` methods is explicitly logged using `log.Printf`.
+
+#### Scenario: Recovering and logging TCP panics
+- **WHEN** a panic occurs during a TCP operation (such as `SendMetadata`, `ReceiveACK`, or `Close`)
+- **THEN** the recovery block logs a traceback warning with `log.Printf` and returns a formatted error wrapping `syscall.EIO`
+
+### Requirement: Observable QUIC Transport Recovery (Resolves #245)
+The system SHALL ensure that any panic recovered inside `MomoQUICCommunicator` methods is explicitly logged using `log.Printf`.
+
+#### Scenario: Recovering and logging QUIC panics
+- **WHEN** a panic occurs during a QUIC operation (such as `SendMetadata`, `ReceiveACK`, or `Close`)
+- **THEN** the recovery block logs a traceback warning with `log.Printf` and returns a formatted error wrapping `syscall.EIO`
+
+### Requirement: Observable CRUSH Placement Recovery (Resolves #245)
+The system SHALL ensure that any panic recovered inside the `ClusterMap.Placement` calculation is explicitly logged using `log.Printf`.
+
+#### Scenario: Recovering and logging placement panics
+- **WHEN** a panic occurs during weighted rendezvous hashing or placement calculation
+- **THEN** the recovery block logs a traceback warning with `log.Printf` and returns a formatted error wrapping `syscall.EIO`
+

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"log"
 	"math"
 	"sort"
 	"syscall"
@@ -30,6 +31,7 @@ type ClusterMap struct {
 func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes []*Node, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in Placement: %v", r)
 			err = fmt.Errorf("panic in Placement: %v: %w", r, syscall.EIO)
 		}
 	}()

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -48,6 +48,7 @@ func (m *MomoQUICCommunicator) SetStore(store storage.Store) {
 func (m *MomoQUICCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SetAbsoluteDeadline: %v", r)
 			err = fmt.Errorf("panic in SetAbsoluteDeadline: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -63,6 +64,7 @@ func (m *MomoQUICCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
 func (m *MomoQUICCommunicator) HandshakeClient(authToken string, timestamp int64, requestedMode int) (mode int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in HandshakeClient: %v", r)
 			err = fmt.Errorf("panic in HandshakeClient: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -259,6 +261,7 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 func (m *MomoQUICCommunicator) SendReplicationMode(mode int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendReplicationMode: %v", r)
 			err = fmt.Errorf("panic in SendReplicationMode: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -273,6 +276,7 @@ func (m *MomoQUICCommunicator) SendReplicationMode(mode int) (err error) {
 func (m *MomoQUICCommunicator) SendMetadata(meta *common.FileMetadata) (status int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendMetadata: %v", r)
 			err = fmt.Errorf("panic in SendMetadata: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -312,6 +316,7 @@ func (m *MomoQUICCommunicator) SendMetadata(meta *common.FileMetadata) (status i
 func (m *MomoQUICCommunicator) ReceiveMetadata() (meta common.FileMetadata, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in ReceiveMetadata: %v", r)
 			err = fmt.Errorf("panic in ReceiveMetadata: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -339,6 +344,7 @@ func (m *MomoQUICCommunicator) ReceiveMetadata() (meta common.FileMetadata, err 
 func (m *MomoQUICCommunicator) SendMetadataStatus(status int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendMetadataStatus: %v", r)
 			err = fmt.Errorf("panic in SendMetadataStatus: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -352,6 +358,7 @@ func (m *MomoQUICCommunicator) SendMetadataStatus(status int) (err error) {
 func (m *MomoQUICCommunicator) SendACK(serverId int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendACK: %v", r)
 			err = fmt.Errorf("panic in SendACK: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -366,6 +373,7 @@ func (m *MomoQUICCommunicator) SendACK(serverId int) (err error) {
 func (m *MomoQUICCommunicator) ReceiveACK() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in ReceiveACK: %v", r)
 			err = fmt.Errorf("panic in ReceiveACK: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -402,6 +410,7 @@ func (m *MomoQUICCommunicator) RemoteAddr() net.Addr {
 func (m *MomoQUICCommunicator) Close() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in Close: %v", r)
 			err = fmt.Errorf("panic in Close: %v: %w", r, syscall.EIO)
 		}
 	}()

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -40,6 +40,7 @@ func (m *MomoTCPCommunicator) SetStore(store storage.Store) {
 func (m *MomoTCPCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SetAbsoluteDeadline: %v", r)
 			err = fmt.Errorf("panic in SetAbsoluteDeadline: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -54,6 +55,7 @@ func (m *MomoTCPCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
 func (m *MomoTCPCommunicator) HandshakeClient(authToken string, timestamp int64, requestedMode int) (mode int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in HandshakeClient: %v", r)
 			err = fmt.Errorf("panic in HandshakeClient: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -251,6 +253,7 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 func (m *MomoTCPCommunicator) SendReplicationMode(mode int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendReplicationMode: %v", r)
 			err = fmt.Errorf("panic in SendReplicationMode: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -265,6 +268,7 @@ func (m *MomoTCPCommunicator) SendReplicationMode(mode int) (err error) {
 func (m *MomoTCPCommunicator) SendMetadata(meta *common.FileMetadata) (status int, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendMetadata: %v", r)
 			err = fmt.Errorf("panic in SendMetadata: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -304,6 +308,7 @@ func (m *MomoTCPCommunicator) SendMetadata(meta *common.FileMetadata) (status in
 func (m *MomoTCPCommunicator) ReceiveMetadata() (meta common.FileMetadata, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in ReceiveMetadata: %v", r)
 			err = fmt.Errorf("panic in ReceiveMetadata: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -331,6 +336,7 @@ func (m *MomoTCPCommunicator) ReceiveMetadata() (meta common.FileMetadata, err e
 func (m *MomoTCPCommunicator) SendMetadataStatus(status int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendMetadataStatus: %v", r)
 			err = fmt.Errorf("panic in SendMetadataStatus: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -352,6 +358,7 @@ func bytesTrimNull(b []byte) []byte {
 func (m *MomoTCPCommunicator) SendACK(serverId int) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in SendACK: %v", r)
 			err = fmt.Errorf("panic in SendACK: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -366,6 +373,7 @@ func (m *MomoTCPCommunicator) SendACK(serverId int) (err error) {
 func (m *MomoTCPCommunicator) ReceiveACK() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in ReceiveACK: %v", r)
 			err = fmt.Errorf("panic in ReceiveACK: %v: %w", r, syscall.EIO)
 		}
 	}()


### PR DESCRIPTION
## Overview

This Pull Request fully resolves and closes #245. It aligns all remaining silent `defer recover()` blocks inside Momo's transport and common layers with our established **Two-Line Panic Recovery Pattern**, completely satisfying **Rule 4 (Zero-Crash)** and **Rule 9 (No Silent Failures)**.

Every single catch-safe recovery boundary in the system now explicitly logs caught panics with highly visible, trace-friendly diagnostic logs in stderr, ensuring consistent distributed systems observability.

## Key Changes

### 1. Momo-TCP Transport (`src/transport/momo_tcp.go`)
- Added explicit `log.Printf("CRITICAL: Recovered from panic in <MethodName>: %v", r)` to all 8 remaining silent recovery blocks:
  - `SetAbsoluteDeadline`
  - `HandshakeClient`
  - `SendReplicationMode`
  - `SendMetadata`
  - `ReceiveMetadata`
  - `SendMetadataStatus`
  - `SendACK`
  - `ReceiveACK`

### 2. Momo-QUIC Transport (`src/transport/momo_quic.go`)
- Added explicit `log.Printf("CRITICAL: Recovered from panic in <MethodName>: %v", r)` to all 9 remaining silent recovery blocks:
  - `SetAbsoluteDeadline`
  - `HandshakeClient`
  - `SendReplicationMode`
  - `SendMetadata`
  - `ReceiveMetadata`
  - `SendMetadataStatus`
  - `SendACK`
  - `ReceiveACK`
  - `Close`

### 3. Weighted Rendezvous Hashing / CRUSH (`src/common/crush.go`)
- Imported `"log"` package.
- Added explicit `log.Printf("CRITICAL: Recovered from panic in Placement: %v", r)` inside the `ClusterMap.Placement` recovery block.

### 4. Specifications & Governance
- Promoted and archived specifications under `openspec/specs/unified-panic-logging/spec.md` with explicit top-of-file issue linkage, satisfying Rule 11.

## Testing & Verification

- **Unit/Race Coverage (`make test`):** **PASSED** (100% of all unit and integration tests across all packages passed successfully with zero leaks).


Resolves https://github.com/alsotoes/momo/issues/247