### PR TITLE
🛡️ Sentinel: [HIGH] Fix max-keys DoS vulnerability

### DIFF
--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -255,6 +255,10 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			if maxKeysStr := q.Get("max-keys"); maxKeysStr != "" {
 				if mk, err := strconv.Atoi(maxKeysStr); err == nil && mk > 0 {
 					maxKeys = mk
+					// 🛡️ Sentinel: Clamp max-keys to prevent DoS via memory or CPU exhaustion.
+					if maxKeys > 1000 {
+						maxKeys = 1000
+					}
 				}
 			}
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `max-keys` parameter parsed from the user's S3 `ListObjectsV2` request was directly passed to `FormatListObjectsV2XML` without any upper bound.
🎯 **Impact**: An attacker could provide an arbitrarily large `max-keys` value, forcing the server to load, process, and return a massive XML payload, leading to Denial of Service (DoS) via CPU or memory exhaustion.
🔧 **Fix**: Clamped the `maxKeys` variable to a maximum safe limit of `1000`, mirroring standard AWS S3 behavior.
✅ **Verification**: Code review and testing confirmed that if the client specifies a `max-keys` larger than `1000`, it is capped at `1000`. The test suite runs successfully without regressions.

---
*PR created automatically by Jules for task [9364426863032616403](https://jules.google.com/task/9364426863032616403) started by @alsotoes*