### PR TITLE
ci: separate P2P E2E test into dedicated workflow

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -771,3 +771,10 @@ a899eb7,BenchmarkPadString-8,2.08,0.00,0.00
 0a4d49a,BenchmarkIndexSearch-8,3.11,0.00,0.00
 0a4d49a,BenchmarkLoadGlobalConfig-8,732.10,160.00,1.00
 0a4d49a,BenchmarkPadString-8,2.32,0.00,0.00
+cbc36a6,BenchmarkCheckMetricsAndSwap-8,6.84,0.00,0.00
+cbc36a6,BenchmarkCrushOptimized-8,357.00,0.00,0.00
+cbc36a6,BenchmarkCrushOriginal-8,469.20,164.00,3.00
+cbc36a6,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+cbc36a6,BenchmarkIndexSearch-8,2.76,0.00,0.00
+cbc36a6,BenchmarkLoadGlobalConfig-8,736.20,160.00,1.00
+cbc36a6,BenchmarkPadString-8,1.94,0.00,0.00

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,9 +56,6 @@ jobs:
     - name: E2E Integration Tests
       run: make test-e2e
 
-    - name: E2E P2P Gossip Tests
-      run: make test-e2e-p2p
-
     - name: Coverage
       run: make coverage
 

--- a/.github/workflows/p2p_test.yml
+++ b/.github/workflows/p2p_test.yml
@@ -1,0 +1,23 @@
+name: P2P Gossip E2E Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  p2p-gossip-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.25.x'
+          
+      - name: Run P2P Gossip E2E Test
+        run: |
+          chmod +x .github/scripts/test-e2e-p2p.sh
+          ./.github/scripts/test-e2e-p2p.sh

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        402.1n ± ∞ ¹    403.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       300.4n ± ∞ ¹    299.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     999.1n ± ∞ ¹    732.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.082n ± ∞ ¹    2.319n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.716n ± ∞ ¹    8.644n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.706n ± ∞ ¹    3.107n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3099n ± ∞ ¹   0.3225n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.70n          20.96n        +1.26%
+CrushOriginal-8                        403.2n ± ∞ ¹    469.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       299.4n ± ∞ ¹    357.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     732.1n ± ∞ ¹    736.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.319n ± ∞ ¹    1.937n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.644n ± ∞ ¹    6.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.107n ± ∞ ¹    2.760n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3225n ± ∞ ¹   0.3286n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.96n          20.42n        -2.54%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.64 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 299.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 403.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.11 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 732.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 357.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 469.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.76 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 736.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [899e2bd,0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a]
-    line "CheckMetricsAndSwap" [13,9,11,7,8,8,10,7,8,9]
-    line "CrushOptimized" [483,372,397,348,309,404,320,301,300,299]
-    line "CrushOriginal" [702,416,426,425,417,505,379,390,402,403]
-    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [4,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [1202,876,1036,775,740,707,702,701,999,732]
-    line "PadString" [3,2,3,2,2,3,2,2,2,2]
+    x-axis [0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6]
+    line "CheckMetricsAndSwap" [9,11,7,8,8,10,7,8,9,7]
+    line "CrushOptimized" [372,397,348,309,404,320,301,300,299,357]
+    line "CrushOriginal" [416,426,425,417,505,379,390,402,403,469]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [876,1036,775,740,707,702,701,999,732,736]
+    line "PadString" [2,3,2,2,3,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [899e2bd,0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a]
+    x-axis [0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [899e2bd,0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a]
+    x-axis [0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,6 +9,7 @@ This document describes every test suite and validation step that runs in the Mo
 | Go | `go.yml` | push to master, PRs | Build, unit tests, benchmarks, E2E, coverage |
 | Smoke Test | `smoke_test.yml` | push to master, PRs | Multi-protocol file replication verification |
 | Scale & CAS E2E | `scale_cas_test.yml` | push to master, PRs | CAS storage scale testing |
+| P2P Gossip E2E | `p2p_test.yml` | push to master, PRs | P2P gossip convergence + failure detection |
 | Performance Comparison | `benchmark_compare.yml` | PRs, push to master | Benchmark regression detection (>5% threshold) |
 | Go Version Consistency | `verify_go_version.yml` | PRs, push to master | Go version sync across all config files |
 | Gemini AI Reviewer | `gemini_reviewer.yml` | PRs | AI code review (security, performance, architecture) |
@@ -31,7 +32,6 @@ The primary CI pipeline. Runs on every push to `master` and every PR targeting `
 | **Test** | `make test` | `go test -v -race -cover` across all modules |
 | **Benchmark** | `make benchmark` | `go test -bench=. -benchmem` across all modules |
 | **E2E Integration Tests** | `make test-e2e` | 3-node cluster: file upload + replication consistency |
-| **E2E P2P Gossip Tests** | `make test-e2e-p2p` | 3-node cluster with P2P enabled: gossip convergence + failure detection |
 | **Coverage** | `make coverage` | Generates HTML coverage report |
 | **Upload Coverage** | `upload-artifact` | Stores `coverage.out` as CI artifact |
 
@@ -71,6 +71,22 @@ Each smoke test:
 ## Scale & CAS E2E Test (`scale_cas_test.yml`)
 
 Runs `.github/scripts/test-scale-cas.sh` — exercises the CAS (Content-Addressable Storage) engine at scale, verifying CRUSH placement, deduplication, and metadata consistency.
+
+---
+
+## P2P Gossip E2E Test (`p2p_test.yml`)
+
+Runs `.github/scripts/test-e2e-p2p.sh` — tests P2P gossip membership and failure detection across 3 separate momo server processes.
+
+1. Builds momo binary
+2. Creates a 3-daemon config with `[p2p] enabled=true`
+3. Starts 3 server processes with P2P gossip enabled
+4. Waits for gossip convergence (8 seconds)
+5. Verifies all nodes started P2P gossip
+6. Verifies nodes discovered each other via gossip heartbeats
+7. **Kills node 2** to simulate failure
+8. Waits for suspicion timeout (12 seconds)
+9. Verifies surviving nodes marked the dead node as SUSPECT or OFFLINE
 
 ---
 
@@ -124,20 +140,6 @@ Tests file replication across 3 separate momo server processes.
 6. Verifies the file content exists on all 3 nodes
 
 **Protocols tested:** `momo-tcp`, `momo-quic`, `s3-tcp`, `s3-quic`
-
-### P2P Gossip E2E (`test-e2e-p2p.sh`)
-
-Tests P2P gossip membership and failure detection across 3 separate momo server processes.
-
-1. Builds momo binary
-2. Creates a 3-daemon config with `[p2p] enabled=true`
-3. Starts 3 server processes with P2P gossip enabled
-4. Waits for gossip convergence (8 seconds)
-5. Verifies all nodes started P2P gossip
-6. Verifies nodes discovered each other via gossip heartbeats
-7. **Kills node 2** to simulate failure
-8. Waits for suspicion timeout (12 seconds)
-9. Verifies surviving nodes marked the dead node as SUSPECT or OFFLINE
 
 ---
 


### PR DESCRIPTION
Resolves #153

## Summary

Move P2P gossip E2E test from `go.yml` build job into its own `p2p_test.yml` workflow, matching the `scale_cas_test.yml` pattern.

## Rationale

- Runs **in parallel** with build/smoke/scale jobs instead of blocking the build job
- **Isolates failures** — P2P test failure won't fail the build job
- Matches existing pattern (`scale_cas_test.yml`, `smoke_test.yml`)
- Allows re-running just the P2P test without re-running the entire build

## Changes

- **New:** `.github/workflows/p2p_test.yml` — standalone workflow for P2P gossip E2E
- **Modified:** `.github/workflows/go.yml` — removed P2P E2E step from build job
- **Modified:** `docs/TESTING.md` — updated pipeline overview and test documentation