### PR TITLE
feat: scatter-gather queries and lease-based consensus

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -785,3 +785,10 @@ ea712a7,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 ea712a7,BenchmarkIndexSearch-8,2.87,0.00,0.00
 ea712a7,BenchmarkLoadGlobalConfig-8,725.60,160.00,1.00
 ea712a7,BenchmarkPadString-8,1.97,0.00,0.00
+31e546a,BenchmarkCheckMetricsAndSwap-8,7.64,0.00,0.00
+31e546a,BenchmarkCrushOptimized-8,332.20,0.00,0.00
+31e546a,BenchmarkCrushOriginal-8,397.70,164.00,3.00
+31e546a,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+31e546a,BenchmarkIndexSearch-8,2.75,0.00,0.00
+31e546a,BenchmarkLoadGlobalConfig-8,738.40,160.00,1.00
+31e546a,BenchmarkPadString-8,1.94,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -778,3 +778,10 @@ cbc36a6,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
 cbc36a6,BenchmarkIndexSearch-8,2.76,0.00,0.00
 cbc36a6,BenchmarkLoadGlobalConfig-8,736.20,160.00,1.00
 cbc36a6,BenchmarkPadString-8,1.94,0.00,0.00
+ea712a7,BenchmarkCheckMetricsAndSwap-8,7.20,0.00,0.00
+ea712a7,BenchmarkCrushOptimized-8,302.30,0.00,0.00
+ea712a7,BenchmarkCrushOriginal-8,419.20,164.00,3.00
+ea712a7,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+ea712a7,BenchmarkIndexSearch-8,2.87,0.00,0.00
+ea712a7,BenchmarkLoadGlobalConfig-8,725.60,160.00,1.00
+ea712a7,BenchmarkPadString-8,1.97,0.00,0.00

--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -36,3 +36,5 @@ gossip_port=4450
 gossip_interval=1
 suspicion_timeout=5
 fanout=3
+scatter_gather_timeout=5
+lease_timeout=10

--- a/docs/P2P.md
+++ b/docs/P2P.md
@@ -127,9 +127,85 @@ make test-e2e-p2p
 
 ## Future Work
 
-This transport layer enables:
-- **Issue #248**: Scatter-gather queries over the cluster
-- **Issue #248**: Lease-based consensus for coordinated operations
-- SWIM-style suspicion mechanism refinement
+- SWIM-style suspicion mechanism refinement (indirect ping, RTT tuning)
 - Compression for large heartbeat payloads
+- CAS garbage collection via decentralized refcounting
+
+---
+
+## Scatter-Gather Queries
+
+### Overview
+
+The `ScatterGather` struct enables distributed queries across the cluster. When a node receives a list request, it broadcasts a `MsgQuery` RPC to all alive peers, collects their responses within a timeout, and merges/deduplicates the results.
+
+### Message Types
+
+| Type | Value | Description |
+|------|-------|-------------|
+| `MsgQuery` | 4 | Scatter-gather query request |
+| `MsgQueryResponse` | 5 | Scatter-gather query response |
+
+### Query Types
+
+| Query | Description |
+|-------|-------------|
+| `QueryList` | List all local files |
+| `QueryGet` | Get metadata for a specific file |
+| `QueryHas` | Check if a hash exists locally |
+
+### RPC Routing
+
+Query RPCs are multiplexed on the existing `transport.Consume()` channel alongside gossip heartbeats. The `Gossiper.HandleRPC` routes `MsgQuery` and `MsgQueryResponse` to the `ScatterGather.HandleRPC` method.
+
+### Server Integration
+
+- `StorageQueryHandler` (in `src/server/query_handler.go`) implements `p2p.QueryHandler` over the local CAS store
+- `ScatterGatherLister` adapts `ScatterGather` to the `transport.GlobalLister` interface
+- When P2P is enabled, S3 `ListObjectsV2` and native list operations use scatter-gather to return a unified global directory
+- Results are merged and deduplicated by content hash
+
+### Configuration
+
+```ini
+[p2p]
+scatter_gather_timeout = 5  # seconds
+```
+
+---
+
+## Lease-Based Consensus
+
+### Overview
+
+The `LeaseManager` provides time-bound, self-expiring leases for destructive operations (deletes). A lease must be granted by a majority quorum of alive peers before the operation proceeds. Leases are kept in-memory and expire automatically.
+
+### Message Types
+
+| Type | Value | Description |
+|------|-------|-------------|
+| `MsgLeaseRequest` | 6 | Request a lease for a resource key |
+| `MsgLeaseGrant` | 7 | Grant or deny a lease request |
+| `MsgLeaseRelease` | 8 | Release a held lease |
+
+### Protocol
+
+1. **Acquire**: Node broadcasts `MsgLeaseRequest` to all alive peers
+2. **Grant**: Each peer checks if the key is available (no active lease) and responds with `MsgLeaseGrant` (expiry > 0 = granted, expiry = 0 = denied)
+3. **Quorum**: Acquirer needs majority (N/2 + 1) grants within timeout/2
+4. **Release**: After operation completes, broadcasts `MsgLeaseRelease`
+5. **Expiry**: Background loop cleans up expired leases every 500ms
+
+### Server Integration
+
+- `LeaseAcquirerAdapter` adapts `LeaseManager` to the `transport.LeaseAcquirer` interface
+- When P2P is enabled, S3 `DELETE` and native delete operations acquire a lease before proceeding
+- If lease acquisition fails (quorum not reached), returns 503 Service Unavailable (S3) or error status (native)
+
+### Configuration
+
+```ini
+[p2p]
+lease_timeout = 10  # seconds
+```
 ```

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        469.2n ± ∞ ¹    419.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       357.0n ± ∞ ¹    302.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     736.2n ± ∞ ¹    725.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.937n ± ∞ ¹    1.969n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.843n ± ∞ ¹    7.202n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.760n ± ∞ ¹    2.873n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3286n ± ∞ ¹   0.3355n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.42n          19.95n        -2.33%
+CrushOriginal-8                        419.2n ± ∞ ¹    397.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       302.3n ± ∞ ¹    332.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     725.6n ± ∞ ¹    738.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.969n ± ∞ ¹    1.938n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.202n ± ∞ ¹    7.643n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.873n ± ∞ ¹    2.749n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3355n ± ∞ ¹   0.3611n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.95n          20.33n        +1.91%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 302.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 419.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 725.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.97 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.64 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 332.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 397.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 738.40 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7]
-    line "CheckMetricsAndSwap" [11,7,8,8,10,7,8,9,7,7]
-    line "CrushOptimized" [397,348,309,404,320,301,300,299,357,302]
-    line "CrushOriginal" [426,425,417,505,379,390,402,403,469,419]
+    x-axis [657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a]
+    line "CheckMetricsAndSwap" [7,8,8,10,7,8,9,7,7,8]
+    line "CrushOptimized" [348,309,404,320,301,300,299,357,302,332]
+    line "CrushOriginal" [425,417,505,379,390,402,403,469,419,398]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [1036,775,740,707,702,701,999,732,736,726]
-    line "PadString" [3,2,2,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [775,740,707,702,701,999,732,736,726,738]
+    line "PadString" [2,2,3,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7]
+    x-axis [657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7]
+    x-axis [657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        403.2n ± ∞ ¹    469.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       299.4n ± ∞ ¹    357.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     732.1n ± ∞ ¹    736.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.319n ± ∞ ¹    1.937n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.644n ± ∞ ¹    6.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.107n ± ∞ ¹    2.760n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3225n ± ∞ ¹   0.3286n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.96n          20.42n        -2.54%
+CrushOriginal-8                        469.2n ± ∞ ¹    419.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       357.0n ± ∞ ¹    302.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     736.2n ± ∞ ¹    725.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.937n ± ∞ ¹    1.969n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.843n ± ∞ ¹    7.202n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.760n ± ∞ ¹    2.873n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3286n ± ∞ ¹   0.3355n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.42n          19.95n        -2.33%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 357.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 469.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.76 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 736.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 302.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 419.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 725.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.97 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6]
-    line "CheckMetricsAndSwap" [9,11,7,8,8,10,7,8,9,7]
-    line "CrushOptimized" [372,397,348,309,404,320,301,300,299,357]
-    line "CrushOriginal" [416,426,425,417,505,379,390,402,403,469]
+    x-axis [6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7]
+    line "CheckMetricsAndSwap" [11,7,8,8,10,7,8,9,7,7]
+    line "CrushOptimized" [397,348,309,404,320,301,300,299,357,302]
+    line "CrushOriginal" [426,425,417,505,379,390,402,403,469,419]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [876,1036,775,740,707,702,701,999,732,736]
-    line "PadString" [2,3,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [1036,775,740,707,702,701,999,732,736,726]
+    line "PadString" [3,2,2,3,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6]
+    x-axis [6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0dfc90c,6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6]
+    x-axis [6e6806d,657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -220,6 +220,16 @@ func loadP2PConfig(section *ini.Section) (ConfigurationP2P, error) {
 		p2pCfg.Fanout = 3
 	}
 
+	p2pCfg.ScatterGatherTimeout, err = section.Key("scatter_gather_timeout").Int()
+	if err != nil || p2pCfg.ScatterGatherTimeout <= 0 {
+		p2pCfg.ScatterGatherTimeout = 5
+	}
+
+	p2pCfg.LeaseTimeout, err = section.Key("lease_timeout").Int()
+	if err != nil || p2pCfg.LeaseTimeout <= 0 {
+		p2pCfg.LeaseTimeout = 10
+	}
+
 	return p2pCfg, nil
 }
 

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -72,7 +72,7 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 		// ⚡ Bolt: Eliminate heap allocation of hash.Sum by using stack-allocated slice
 		var sumBuf [sha256.Size]byte
 		sum := h.Sum(sumBuf[:0])
-		
+
 		val := binary.LittleEndian.Uint64(sum[:8])
 		floatVal := float64(val) / float64(math.MaxUint64)
 

--- a/src/common/crush_test.go
+++ b/src/common/crush_test.go
@@ -44,7 +44,7 @@ func TestClusterMap_Placement(t *testing.T) {
 	}
 
 	t.Logf("Load distribution over 1000 objects: %v", distribution)
-	
+
 	// Ensure all nodes got some load
 	for _, node := range nodes {
 		if distribution[node.ID] == 0 {

--- a/src/common/string.go
+++ b/src/common/string.go
@@ -42,17 +42,17 @@ func HasPathTraversalChars(s string) bool {
 
 // PadString pads or truncates a string to the given length.
 func PadString(input string, length int) string {
-        if len(input) >= length {
-                return input[:length]
-        }
-        b := make([]byte, length)
-        copy(b, input)
-        // ⚡ Bolt: Eliminate string allocation overhead by using unsafe.String.
-        return unsafe.String(unsafe.SliceData(b), length)
+	if len(input) >= length {
+		return input[:length]
+	}
+	b := make([]byte, length)
+	copy(b, input)
+	// ⚡ Bolt: Eliminate string allocation overhead by using unsafe.String.
+	return unsafe.String(unsafe.SliceData(b), length)
 }
 
 // NormalizeVirtualPath cleans and validates virtual remote paths.
-// It trims whitespace, resolves parent directory references via path.Clean, 
+// It trims whitespace, resolves parent directory references via path.Clean,
 // and strictly rejects any directory traversal (..) sequences to prevent security escalation.
 func NormalizeVirtualPath(p string) (string, error) {
 	p = strings.TrimSpace(p)

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -74,6 +74,10 @@ type ConfigurationP2P struct {
 	SuspicionTimeout int
 	// Fanout is the number of random peers to gossip to per heartbeat.
 	Fanout int
+	// ScatterGatherTimeout is the timeout for scatter-gather queries, in seconds.
+	ScatterGatherTimeout int
+	// LeaseTimeout is the default lease duration for consensus operations, in seconds.
+	LeaseTimeout int
 }
 
 // Configuration holds the overall configuration for the application.

--- a/src/p2p/benchmark_test.go
+++ b/src/p2p/benchmark_test.go
@@ -6,8 +6,8 @@ import (
 
 func BenchmarkRPC_Encode(b *testing.B) {
 	rpc := &RPC{
-		From:    1,
-		Type:    MsgHeartbeat,
+		From: 1,
+		Type: MsgHeartbeat,
 		Payload: (&HeartbeatPayload{
 			Peers: []PeerInfo{
 				{ID: 1, Addr: "127.0.0.1:4450"},

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -13,7 +13,7 @@ const MaxPeersInHeartbeat = 256
 
 // GossipConfig holds configuration for the Gossiper.
 type GossipConfig struct {
-	LocalID         int32
+	LocalID           int32
 	HeartbeatInterval time.Duration
 	SuspicionTimeout  time.Duration
 	Fanout            int
@@ -22,7 +22,7 @@ type GossipConfig struct {
 // DefaultGossipConfig returns sensible defaults for gossip.
 func DefaultGossipConfig(localID int32) GossipConfig {
 	return GossipConfig{
-		LocalID:         localID,
+		LocalID:           localID,
 		HeartbeatInterval: 1 * time.Second,
 		SuspicionTimeout:  5 * time.Second,
 		Fanout:            3,
@@ -33,12 +33,12 @@ func DefaultGossipConfig(localID int32) GossipConfig {
 // It periodically sends heartbeats to random peers, merges membership
 // information from received heartbeats, and marks unreachable peers as suspect/offline.
 type Gossiper struct {
-	cfg      GossipConfig
+	cfg       GossipConfig
 	transport Transport
-	done    chan struct{}
-	closed  bool
-	mu      sync.Mutex
-	wg      sync.WaitGroup
+	done      chan struct{}
+	closed    bool
+	mu        sync.Mutex
+	wg        sync.WaitGroup
 
 	onJoin  func(peer *Peer)
 	onLeave func(peerID int32)
@@ -50,9 +50,9 @@ type Gossiper struct {
 // NewGossiper creates a new Gossiper.
 func NewGossiper(cfg GossipConfig, transport Transport) *Gossiper {
 	return &Gossiper{
-		cfg:      cfg,
+		cfg:       cfg,
 		transport: transport,
-		done:     make(chan struct{}),
+		done:      make(chan struct{}),
 	}
 }
 
@@ -199,6 +199,11 @@ func (g *Gossiper) checkSuspicion() {
 // HandleRPC processes an incoming gossip RPC. It should be called for each
 // RPC received from the transport's Consume() channel.
 func (g *Gossiper) HandleRPC(rpc *RPC) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Gossip HandleRPC panic recovered: %v (errno=%d)", r, syscall.EIO)
+		}
+	}()
 	switch rpc.Type {
 	case MsgHeartbeat:
 		g.handleHeartbeat(rpc)

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -33,7 +33,7 @@ func DefaultGossipConfig(localID int32) GossipConfig {
 // It periodically sends heartbeats to random peers, merges membership
 // information from received heartbeats, and marks unreachable peers as suspect/offline.
 type Gossiper struct {
-	cfg     GossipConfig
+	cfg      GossipConfig
 	transport Transport
 	done    chan struct{}
 	closed  bool
@@ -42,6 +42,9 @@ type Gossiper struct {
 
 	onJoin  func(peer *Peer)
 	onLeave func(peerID int32)
+
+	scatterGather *ScatterGather
+	leaseManager  *LeaseManager
 }
 
 // NewGossiper creates a new Gossiper.
@@ -61,6 +64,18 @@ func (g *Gossiper) OnJoin(fn func(peer *Peer)) {
 // OnLeave sets a callback invoked when a peer leaves the cluster.
 func (g *Gossiper) OnLeave(fn func(peerID int32)) {
 	g.onLeave = fn
+}
+
+// SetScatterGather attaches a ScatterGather instance whose query RPCs will be
+// routed by the gossiper's consumer loop.
+func (g *Gossiper) SetScatterGather(sg *ScatterGather) {
+	g.scatterGather = sg
+}
+
+// SetLeaseManager attaches a LeaseManager instance whose lease RPCs will be
+// routed by the gossiper's consumer loop.
+func (g *Gossiper) SetLeaseManager(lm *LeaseManager) {
+	g.leaseManager = lm
 }
 
 // Start launches the heartbeat and suspicion loops.
@@ -191,6 +206,14 @@ func (g *Gossiper) HandleRPC(rpc *RPC) {
 		g.handleMembership(rpc)
 	case MsgSuspect:
 		g.handleSuspect(rpc)
+	case MsgQuery, MsgQueryResponse:
+		if g.scatterGather != nil {
+			g.scatterGather.HandleRPC(rpc)
+		}
+	case MsgLeaseRequest, MsgLeaseGrant, MsgLeaseRelease:
+		if g.leaseManager != nil {
+			g.leaseManager.HandleLeaseRPC(rpc)
+		}
 	}
 }
 

--- a/src/p2p/gossip_test.go
+++ b/src/p2p/gossip_test.go
@@ -33,13 +33,13 @@ func TestGossiper_HeartbeatExchange(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	cfg1 := GossipConfig{
-		LocalID:          1,
+		LocalID:           1,
 		HeartbeatInterval: 50 * time.Millisecond,
 		SuspicionTimeout:  500 * time.Millisecond,
 		Fanout:            3,
 	}
 	cfg2 := GossipConfig{
-		LocalID:          2,
+		LocalID:           2,
 		HeartbeatInterval: 50 * time.Millisecond,
 		SuspicionTimeout:  500 * time.Millisecond,
 		Fanout:            3,
@@ -138,7 +138,7 @@ func TestGossiper_SuspicionTimeout(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	cfg1 := GossipConfig{
-		LocalID:          1,
+		LocalID:           1,
 		HeartbeatInterval: 50 * time.Millisecond,
 		SuspicionTimeout:  150 * time.Millisecond,
 		Fanout:            3,

--- a/src/p2p/integration_test.go
+++ b/src/p2p/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration_ThreeNodeCluster(t *testing.T) {
 		}
 
 		cfg := GossipConfig{
-			LocalID:          int32(i),
+			LocalID:           int32(i),
 			HeartbeatInterval: 50 * time.Millisecond,
 			SuspicionTimeout:  300 * time.Millisecond,
 			Fanout:            3,

--- a/src/p2p/lease.go
+++ b/src/p2p/lease.go
@@ -109,6 +109,11 @@ func (lm *LeaseManager) cleanupExpired() {
 // HandleLeaseRPC processes incoming lease RPCs from remote peers.
 // Called by the Gossiper's consumer loop.
 func (lm *LeaseManager) HandleLeaseRPC(rpc *RPC) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("LeaseManager HandleLeaseRPC panic recovered: %v (errno=%d)", r, syscall.EIO)
+		}
+	}()
 	switch rpc.Type {
 	case MsgLeaseRequest:
 		lm.handleLeaseRequest(rpc)

--- a/src/p2p/lease.go
+++ b/src/p2p/lease.go
@@ -1,0 +1,306 @@
+package p2p
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// Lease represents a time-bound, self-expiring lease granted by a majority quorum.
+type Lease struct {
+	LeaseID    uint64
+	HolderID   int32
+	Key        string
+	Expiry     time.Time
+	QuorumSize int
+}
+
+// LeaseManager handles lease-based consensus for destructive operations.
+// Leases are kept in-memory and expire automatically on timeout.
+type LeaseManager struct {
+	localID   int32
+	transport Transport
+
+	nextLeaseID atomic.Uint64
+
+	grantedMu sync.Mutex
+	granted   map[string]int64
+
+	heldMu sync.Mutex
+	held   map[uint64]*Lease
+
+	pendingMu sync.Mutex
+	pending   map[uint64]chan bool
+
+	done chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewLeaseManager creates a new LeaseManager.
+func NewLeaseManager(localID int32, transport Transport) *LeaseManager {
+	return &LeaseManager{
+		localID:   localID,
+		transport: transport,
+		granted:   make(map[string]int64),
+		held:      make(map[uint64]*Lease),
+		pending:   make(map[uint64]chan bool),
+		done:      make(chan struct{}),
+	}
+}
+
+// Start launches the expiry loop that cleans up expired leases.
+func (lm *LeaseManager) Start() {
+	lm.wg.Add(1)
+	go lm.expireLoop()
+}
+
+// Stop shuts down the lease manager.
+func (lm *LeaseManager) Stop() {
+	close(lm.done)
+	lm.wg.Wait()
+}
+
+// expireLoop periodically cleans up expired locally-granted leases.
+func (lm *LeaseManager) expireLoop() {
+	defer lm.wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("LeaseManager expireLoop panic recovered: %v (errno=%d)", r, syscall.EIO)
+		}
+	}()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-lm.done:
+			return
+		case <-ticker.C:
+			lm.cleanupExpired()
+		}
+	}
+}
+
+// cleanupExpired removes expired leases from the granted and held maps.
+func (lm *LeaseManager) cleanupExpired() {
+	now := time.Now().UnixNano()
+
+	lm.grantedMu.Lock()
+	for key, expiry := range lm.granted {
+		if expiry < now {
+			delete(lm.granted, key)
+		}
+	}
+	lm.grantedMu.Unlock()
+
+	lm.heldMu.Lock()
+	for id, lease := range lm.held {
+		if lease.Expiry.Before(time.Now()) {
+			delete(lm.held, id)
+		}
+	}
+	lm.heldMu.Unlock()
+}
+
+// HandleLeaseRPC processes incoming lease RPCs from remote peers.
+// Called by the Gossiper's consumer loop.
+func (lm *LeaseManager) HandleLeaseRPC(rpc *RPC) {
+	switch rpc.Type {
+	case MsgLeaseRequest:
+		lm.handleLeaseRequest(rpc)
+	case MsgLeaseGrant:
+		lm.handleLeaseGrant(rpc)
+	case MsgLeaseRelease:
+		lm.handleLeaseRelease(rpc)
+	}
+}
+
+// handleLeaseRequest decides whether to grant a lease request from a remote peer.
+func (lm *LeaseManager) handleLeaseRequest(rpc *RPC) {
+	payload, err := DecodeLeasePayload(rpc.Payload)
+	if err != nil {
+		log.Printf("LeaseManager: failed to decode lease request from peer %d: %v (errno=%d)", rpc.From, err, syscall.EBADMSG)
+		return
+	}
+
+	now := time.Now().UnixNano()
+
+	lm.grantedMu.Lock()
+	existing, ok := lm.granted[payload.Key]
+	if ok && existing > now {
+		lm.grantedMu.Unlock()
+		grant := &LeasePayload{LeaseID: payload.LeaseID, Key: payload.Key, Expiry: 0}
+		resp := &RPC{From: lm.localID, Type: MsgLeaseGrant, Payload: grant.Encode()}
+		lm.transport.Send(rpc.From, resp)
+		return
+	}
+	lm.granted[payload.Key] = payload.Expiry
+	lm.grantedMu.Unlock()
+
+	grant := &LeasePayload{LeaseID: payload.LeaseID, Key: payload.Key, Expiry: payload.Expiry}
+	resp := &RPC{From: lm.localID, Type: MsgLeaseGrant, Payload: grant.Encode()}
+	if err := lm.transport.Send(rpc.From, resp); err != nil {
+		log.Printf("LeaseManager: failed to send grant to peer %d: %v (errno=%d)", rpc.From, err, syscall.EHOSTUNREACH)
+	}
+}
+
+// handleLeaseGrant routes an incoming lease grant to the pending Acquire call.
+func (lm *LeaseManager) handleLeaseGrant(rpc *RPC) {
+	payload, err := DecodeLeasePayload(rpc.Payload)
+	if err != nil {
+		log.Printf("LeaseManager: failed to decode lease grant from peer %d: %v (errno=%d)", rpc.From, err, syscall.EBADMSG)
+		return
+	}
+
+	lm.pendingMu.Lock()
+	ch, ok := lm.pending[payload.LeaseID]
+	lm.pendingMu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	granted := payload.Expiry != 0
+	select {
+	case ch <- granted:
+	default:
+	}
+}
+
+// handleLeaseRelease releases a previously granted lease.
+func (lm *LeaseManager) handleLeaseRelease(rpc *RPC) {
+	payload, err := DecodeLeasePayload(rpc.Payload)
+	if err != nil {
+		log.Printf("LeaseManager: failed to decode lease release from peer %d: %v (errno=%d)", rpc.From, err, syscall.EBADMSG)
+		return
+	}
+
+	lm.grantedMu.Lock()
+	delete(lm.granted, payload.Key)
+	lm.grantedMu.Unlock()
+}
+
+// Acquire requests a lease for the given resource key from a majority of alive peers.
+// Returns the lease if the quorum is reached, or an error otherwise.
+func (lm *LeaseManager) Acquire(key string, duration time.Duration) (*Lease, error) {
+	peers := lm.transport.Peers().Alive()
+	peerCount := 0
+	for _, p := range peers {
+		if p.ID != lm.localID {
+			peerCount++
+		}
+	}
+
+	quorum := (peerCount+1)/2 + 1
+	if quorum < 1 {
+		quorum = 1
+	}
+
+	leaseID := lm.nextLeaseID.Add(1)
+	expiry := time.Now().Add(duration)
+
+	payload := &LeasePayload{
+		LeaseID: leaseID,
+		Key:     key,
+		Expiry:  expiry.UnixNano(),
+	}
+
+	rpc := &RPC{
+		From:    lm.localID,
+		Type:    MsgLeaseRequest,
+		Payload: payload.Encode(),
+	}
+
+	grantCh := make(chan bool, peerCount)
+
+	lm.pendingMu.Lock()
+	lm.pending[leaseID] = grantCh
+	lm.pendingMu.Unlock()
+
+	defer func() {
+		lm.pendingMu.Lock()
+		delete(lm.pending, leaseID)
+		lm.pendingMu.Unlock()
+	}()
+
+	sent := lm.transport.Broadcast(rpc)
+	if sent < quorum {
+		return nil, fmt.Errorf("not enough peers for quorum: contacted %d, need %d (errno=%d)", sent, quorum, syscall.EHOSTUNREACH)
+	}
+
+	grants := 0
+	timer := time.NewTimer(duration / 2)
+	defer timer.Stop()
+
+	for grants < quorum {
+		select {
+		case granted := <-grantCh:
+			if granted {
+				grants++
+			}
+		case <-timer.C:
+			return nil, fmt.Errorf("lease quorum timeout: got %d/%d grants (errno=%d)", grants, quorum, syscall.ETIMEDOUT)
+		case <-lm.done:
+			return nil, fmt.Errorf("lease manager stopped (errno=%d)", syscall.ECANCELED)
+		}
+	}
+
+	lease := &Lease{
+		LeaseID:    leaseID,
+		HolderID:   lm.localID,
+		Key:        key,
+		Expiry:     expiry,
+		QuorumSize: grants,
+	}
+
+	lm.heldMu.Lock()
+	lm.held[leaseID] = lease
+	lm.heldMu.Unlock()
+
+	return lease, nil
+}
+
+// Release broadcasts a lease release to all peers.
+func (lm *LeaseManager) Release(lease *Lease) error {
+	payload := &LeasePayload{
+		LeaseID: lease.LeaseID,
+		Key:     lease.Key,
+		Expiry:  0,
+	}
+
+	rpc := &RPC{
+		From:    lm.localID,
+		Type:    MsgLeaseRelease,
+		Payload: payload.Encode(),
+	}
+
+	lm.transport.Broadcast(rpc)
+
+	lm.heldMu.Lock()
+	delete(lm.held, lease.LeaseID)
+	lm.heldMu.Unlock()
+
+	return nil
+}
+
+// ReleaseByKey releases a held lease matching the given resource key.
+func (lm *LeaseManager) ReleaseByKey(key string) error {
+	lm.heldMu.Lock()
+	for id, lease := range lm.held {
+		if lease.Key == key {
+			delete(lm.held, id)
+			lm.heldMu.Unlock()
+
+			payload := &LeasePayload{LeaseID: id, Key: key, Expiry: 0}
+			rpc := &RPC{From: lm.localID, Type: MsgLeaseRelease, Payload: payload.Encode()}
+			lm.transport.Broadcast(rpc)
+			return nil
+		}
+	}
+	lm.heldMu.Unlock()
+	return nil
+}

--- a/src/p2p/lease_test.go
+++ b/src/p2p/lease_test.go
@@ -1,0 +1,143 @@
+package p2p
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestLeaseManager_AcquireRelease(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	tr3 := NewTCPTransport(TCPTransportConfig{LocalID: 3})
+	defer tr1.Close()
+	defer tr2.Close()
+	defer tr3.Close()
+
+	ln1, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr1 := ln1.Addr().String()
+	ln1.Close()
+	ln2, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr2 := ln2.Addr().String()
+	ln2.Close()
+	ln3, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr3 := ln3.Addr().String()
+	ln3.Close()
+
+	tr1.Listen(addr1)
+	tr2.Listen(addr2)
+	tr3.Listen(addr3)
+
+	tr1.Dial(2, addr2)
+	tr1.Dial(3, addr3)
+	time.Sleep(100 * time.Millisecond)
+
+	lm1 := NewLeaseManager(1, tr1)
+	lm2 := NewLeaseManager(2, tr2)
+	lm3 := NewLeaseManager(3, tr3)
+
+	g1 := NewGossiper(DefaultGossipConfig(1), tr1)
+	g2 := NewGossiper(DefaultGossipConfig(2), tr2)
+	g3 := NewGossiper(DefaultGossipConfig(3), tr3)
+	g1.SetLeaseManager(lm1)
+	g2.SetLeaseManager(lm2)
+	g3.SetLeaseManager(lm3)
+	defer g1.Close()
+	defer g2.Close()
+	defer g3.Close()
+
+	lm1.Start()
+	lm2.Start()
+	lm3.Start()
+	defer lm1.Stop()
+	defer lm2.Stop()
+	defer lm3.Stop()
+
+	g1.Run()
+	g2.Run()
+	g3.Run()
+
+	time.Sleep(200 * time.Millisecond)
+
+	lease, err := lm1.Acquire("test-key", 5*time.Second)
+	if err != nil {
+		t.Fatalf("acquire failed: %v", err)
+	}
+	if lease == nil {
+		t.Fatal("expected non-nil lease")
+	}
+	if lease.Key != "test-key" {
+		t.Errorf("key mismatch: got %q, want %q", lease.Key, "test-key")
+	}
+	if lease.QuorumSize < 2 {
+		t.Errorf("expected quorum >= 2, got %d", lease.QuorumSize)
+	}
+
+	if err := lm1.Release(lease); err != nil {
+		t.Fatalf("release failed: %v", err)
+	}
+}
+
+func TestLeaseManager_NoPeers(t *testing.T) {
+	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr.Close()
+
+	lm := NewLeaseManager(1, tr)
+	lm.Start()
+	defer lm.Stop()
+
+	_, err := lm.Acquire("test-key", 5*time.Second)
+	if err == nil {
+		t.Error("expected error with no peers")
+	}
+}
+
+func TestLeaseManager_Expiry(t *testing.T) {
+	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr.Close()
+
+	lm := NewLeaseManager(1, tr)
+	lm.Start()
+	defer lm.Stop()
+
+	lm.grantedMu.Lock()
+	lm.granted["expiring-key"] = time.Now().Add(-1 * time.Hour).UnixNano()
+	lm.grantedMu.Unlock()
+
+	time.Sleep(700 * time.Millisecond)
+
+	lm.grantedMu.Lock()
+	_, exists := lm.granted["expiring-key"]
+	lm.grantedMu.Unlock()
+
+	if exists {
+		t.Error("expected expired lease to be cleaned up")
+	}
+}
+
+func TestLeaseManager_QuorumTimeout(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr1.Close()
+
+	ln1, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr1 := ln1.Addr().String()
+	ln1.Close()
+
+	tr1.Listen(addr1)
+
+	lm1 := NewLeaseManager(1, tr1)
+	lm1.Start()
+	defer lm1.Stop()
+
+	g1 := NewGossiper(DefaultGossipConfig(1), tr1)
+	g1.SetLeaseManager(lm1)
+	defer g1.Close()
+	g1.Run()
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, err := lm1.Acquire("test-key", 1*time.Second)
+	if err == nil {
+		t.Error("expected timeout error with no peers for quorum")
+	}
+}

--- a/src/p2p/scatter_gather.go
+++ b/src/p2p/scatter_gather.go
@@ -44,6 +44,11 @@ func NewScatterGather(localID int32, transport Transport, handler QueryHandler) 
 
 // HandleRPC dispatches query-related RPCs. Called by the Gossiper's consumer loop.
 func (sg *ScatterGather) HandleRPC(rpc *RPC) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("ScatterGather HandleRPC panic recovered: %v (errno=%d)", r, syscall.EIO)
+		}
+	}()
 	switch rpc.Type {
 	case MsgQuery:
 		sg.handleQuery(rpc)

--- a/src/p2p/scatter_gather.go
+++ b/src/p2p/scatter_gather.go
@@ -1,0 +1,173 @@
+package p2p
+
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// QueryHandler processes a scatter-gather query locally and returns the result.
+type QueryHandler interface {
+	HandleQuery(qt QueryType, data []byte) ([]byte, error)
+}
+
+// ScatterGather provides distributed query capabilities over the P2P transport.
+// It broadcasts a query to all alive peers and collects their responses within
+// a timeout window. RPCs are routed by the Gossiper's consumer loop via HandleRPC.
+type ScatterGather struct {
+	localID   int32
+	transport Transport
+	handler   QueryHandler
+
+	nextRequestID atomic.Uint64
+	pendingMu     sync.Mutex
+	pending       map[uint64]*pendingQuery
+}
+
+type pendingQuery struct {
+	responses chan QueryResponsePayload
+	peerCount int
+}
+
+// NewScatterGather creates a new ScatterGather instance.
+// The handler is invoked for incoming queries from remote peers.
+func NewScatterGather(localID int32, transport Transport, handler QueryHandler) *ScatterGather {
+	return &ScatterGather{
+		localID:   localID,
+		transport: transport,
+		handler:   handler,
+		pending:   make(map[uint64]*pendingQuery),
+	}
+}
+
+// HandleRPC dispatches query-related RPCs. Called by the Gossiper's consumer loop.
+func (sg *ScatterGather) HandleRPC(rpc *RPC) {
+	switch rpc.Type {
+	case MsgQuery:
+		sg.handleQuery(rpc)
+	case MsgQueryResponse:
+		sg.handleQueryResponse(rpc)
+	}
+}
+
+// handleQuery processes an incoming query from a remote peer, invokes the local
+// handler, and sends the response back.
+func (sg *ScatterGather) handleQuery(rpc *RPC) {
+	payload, err := DecodeQueryPayload(rpc.Payload)
+	if err != nil {
+		log.Printf("ScatterGather: failed to decode query from peer %d: %v (errno=%d)", rpc.From, err, syscall.EBADMSG)
+		return
+	}
+
+	var respData []byte
+	var respErr string
+	if sg.handler != nil {
+		data, err := sg.handler.HandleQuery(payload.Type, payload.Data)
+		if err != nil {
+			respErr = err.Error()
+		} else {
+			respData = data
+		}
+	}
+
+	resp := &QueryResponsePayload{
+		RequestID: payload.RequestID,
+		Data:      respData,
+		Error:     respErr,
+	}
+
+	respRPC := &RPC{
+		From:    sg.localID,
+		Type:    MsgQueryResponse,
+		Payload: resp.Encode(),
+	}
+
+	if err := sg.transport.Send(rpc.From, respRPC); err != nil {
+		log.Printf("ScatterGather: failed to send response to peer %d: %v (errno=%d)", rpc.From, err, syscall.EHOSTUNREACH)
+	}
+}
+
+// handleQueryResponse routes an incoming query response to the pending request.
+func (sg *ScatterGather) handleQueryResponse(rpc *RPC) {
+	payload, err := DecodeQueryResponsePayload(rpc.Payload)
+	if err != nil {
+		log.Printf("ScatterGather: failed to decode query response from peer %d: %v (errno=%d)", rpc.From, err, syscall.EBADMSG)
+		return
+	}
+
+	sg.pendingMu.Lock()
+	pq, ok := sg.pending[payload.RequestID]
+	sg.pendingMu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	select {
+	case pq.responses <- *payload:
+	default:
+	}
+}
+
+// Query broadcasts a query to all alive peers and collects responses within
+// the given timeout. Returns the collected responses and the number of peers
+// that responded.
+func (sg *ScatterGather) Query(qt QueryType, data []byte, timeout time.Duration) ([]QueryResponsePayload, int) {
+	peers := sg.transport.Peers().Alive()
+	peerCount := 0
+	for _, p := range peers {
+		if p.ID != sg.localID {
+			peerCount++
+		}
+	}
+	if peerCount == 0 {
+		return nil, 0
+	}
+
+	requestID := sg.nextRequestID.Add(1)
+	payload := &QueryPayload{
+		Type:      qt,
+		RequestID: requestID,
+		Data:      data,
+	}
+
+	rpc := &RPC{
+		From:    sg.localID,
+		Type:    MsgQuery,
+		Payload: payload.Encode(),
+	}
+
+	pq := &pendingQuery{
+		responses: make(chan QueryResponsePayload, peerCount),
+		peerCount: peerCount,
+	}
+
+	sg.pendingMu.Lock()
+	sg.pending[requestID] = pq
+	sg.pendingMu.Unlock()
+
+	defer func() {
+		sg.pendingMu.Lock()
+		delete(sg.pending, requestID)
+		sg.pendingMu.Unlock()
+	}()
+
+	sg.transport.Broadcast(rpc)
+
+	var results []QueryResponsePayload
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for len(results) < peerCount {
+		select {
+		case resp := <-pq.responses:
+			results = append(results, resp)
+		case <-timer.C:
+			return results, len(results)
+		}
+	}
+
+	return results, len(results)
+}

--- a/src/p2p/scatter_gather_test.go
+++ b/src/p2p/scatter_gather_test.go
@@ -1,0 +1,295 @@
+package p2p
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestQueryPayload_EncodeDecode(t *testing.T) {
+	original := &QueryPayload{
+		Type:      QueryList,
+		RequestID: 12345,
+		Data:      []byte("test-data"),
+	}
+
+	encoded := original.Encode()
+	decoded, err := DecodeQueryPayload(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.Type != original.Type {
+		t.Errorf("type mismatch: got %d, want %d", decoded.Type, original.Type)
+	}
+	if decoded.RequestID != original.RequestID {
+		t.Errorf("requestID mismatch: got %d, want %d", decoded.RequestID, original.RequestID)
+	}
+	if string(decoded.Data) != string(original.Data) {
+		t.Errorf("data mismatch: got %q, want %q", decoded.Data, original.Data)
+	}
+}
+
+func TestQueryResponsePayload_EncodeDecode(t *testing.T) {
+	original := &QueryResponsePayload{
+		RequestID: 99999,
+		Data:      []byte("response-data"),
+		Error:     "test error",
+	}
+
+	encoded := original.Encode()
+	decoded, err := DecodeQueryResponsePayload(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.RequestID != original.RequestID {
+		t.Errorf("requestID mismatch: got %d, want %d", decoded.RequestID, original.RequestID)
+	}
+	if string(decoded.Data) != string(original.Data) {
+		t.Errorf("data mismatch: got %q, want %q", decoded.Data, original.Data)
+	}
+	if decoded.Error != original.Error {
+		t.Errorf("error mismatch: got %q, want %q", decoded.Error, original.Error)
+	}
+}
+
+func TestLeasePayload_EncodeDecode(t *testing.T) {
+	original := &LeasePayload{
+		LeaseID: 42,
+		Key:     "file-hash-abc",
+		Expiry:  time.Now().UnixNano(),
+	}
+
+	encoded := original.Encode()
+	decoded, err := DecodeLeasePayload(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.LeaseID != original.LeaseID {
+		t.Errorf("leaseID mismatch: got %d, want %d", decoded.LeaseID, original.LeaseID)
+	}
+	if decoded.Key != original.Key {
+		t.Errorf("key mismatch: got %q, want %q", decoded.Key, original.Key)
+	}
+	if decoded.Expiry != original.Expiry {
+		t.Errorf("expiry mismatch: got %d, want %d", decoded.Expiry, original.Expiry)
+	}
+}
+
+// mockQueryHandler is a test QueryHandler that returns predefined data.
+type mockQueryHandler struct {
+	data []byte
+	err  error
+}
+
+func (m *mockQueryHandler) HandleQuery(qt QueryType, data []byte) ([]byte, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.data, nil
+}
+
+func TestScatterGather_Query(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	defer tr1.Close()
+	defer tr2.Close()
+
+	ln1, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr1 := ln1.Addr().String()
+	ln1.Close()
+	ln2, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr2 := ln2.Addr().String()
+	ln2.Close()
+
+	tr1.Listen(addr1)
+	tr2.Listen(addr2)
+
+	tr1.Dial(2, addr2)
+	time.Sleep(100 * time.Millisecond)
+
+	handler1 := &mockQueryHandler{data: []byte("node1-data")}
+	handler2 := &mockQueryHandler{data: []byte("node2-data")}
+
+	sg1 := NewScatterGather(1, tr1, handler1)
+	sg2 := NewScatterGather(2, tr2, handler2)
+
+	g1 := NewGossiper(DefaultGossipConfig(1), tr1)
+	g2 := NewGossiper(DefaultGossipConfig(2), tr2)
+	g1.SetScatterGather(sg1)
+	g2.SetScatterGather(sg2)
+	defer g1.Close()
+	defer g2.Close()
+
+	g1.Run()
+	g2.Run()
+
+	time.Sleep(200 * time.Millisecond)
+
+	responses, count := sg1.Query(QueryList, nil, 2*time.Second)
+	if count < 1 {
+		t.Fatalf("expected at least 1 response, got %d", count)
+	}
+
+	found := false
+	for _, resp := range responses {
+		if string(resp.Data) == "node2-data" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected to find 'node2-data' in responses, got %v", responses)
+	}
+}
+
+func TestScatterGather_QueryNoPeers(t *testing.T) {
+	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr.Close()
+
+	handler := &mockQueryHandler{data: []byte("data")}
+	sg := NewScatterGather(1, tr, handler)
+
+	responses, count := sg.Query(QueryList, nil, 1*time.Second)
+	if count != 0 {
+		t.Errorf("expected 0 responses with no peers, got %d", count)
+	}
+	if responses != nil {
+		t.Errorf("expected nil responses, got %v", responses)
+	}
+}
+
+func TestScatterGather_QueryWithError(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	defer tr1.Close()
+	defer tr2.Close()
+
+	ln1, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr1 := ln1.Addr().String()
+	ln1.Close()
+	ln2, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr2 := ln2.Addr().String()
+	ln2.Close()
+
+	tr1.Listen(addr1)
+	tr2.Listen(addr2)
+
+	tr1.Dial(2, addr2)
+	time.Sleep(100 * time.Millisecond)
+
+	handler1 := &mockQueryHandler{data: []byte("ok")}
+	handler2 := &mockQueryHandler{err: errTestQuery}
+
+	sg1 := NewScatterGather(1, tr1, handler1)
+	sg2 := NewScatterGather(2, tr2, handler2)
+
+	g1 := NewGossiper(DefaultGossipConfig(1), tr1)
+	g2 := NewGossiper(DefaultGossipConfig(2), tr2)
+	g1.SetScatterGather(sg1)
+	g2.SetScatterGather(sg2)
+	defer g1.Close()
+	defer g2.Close()
+
+	g1.Run()
+	g2.Run()
+
+	time.Sleep(200 * time.Millisecond)
+
+	responses, count := sg1.Query(QueryGet, nil, 2*time.Second)
+	if count < 1 {
+		t.Fatalf("expected at least 1 response, got %d", count)
+	}
+
+	for _, resp := range responses {
+		if resp.Error != "" {
+			return
+		}
+	}
+	t.Errorf("expected at least one error response")
+}
+
+var errTestQuery = newTestError("test query error")
+
+func newTestError(msg string) error {
+	return &testError{msg: msg}
+}
+
+type testError struct{ msg string }
+
+func (e *testError) Error() string { return e.msg }
+
+func TestScatterGather_LargeData(t *testing.T) {
+	largeData := make([]byte, 10000)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	original := &QueryResponsePayload{
+		RequestID: 1,
+		Data:      largeData,
+	}
+	encoded := original.Encode()
+	decoded, err := DecodeQueryResponsePayload(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(decoded.Data) != len(largeData) {
+		t.Errorf("data length mismatch: got %d, want %d", len(decoded.Data), len(largeData))
+	}
+	for i := range largeData {
+		if decoded.Data[i] != largeData[i] {
+			t.Errorf("data mismatch at index %d", i)
+			break
+		}
+	}
+}
+
+func TestQueryPayload_EmptyData(t *testing.T) {
+	original := &QueryPayload{
+		Type:      QueryHas,
+		RequestID: 1,
+		Data:      nil,
+	}
+	encoded := original.Encode()
+	decoded, err := DecodeQueryPayload(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.Type != QueryHas {
+		t.Errorf("type mismatch")
+	}
+	if len(decoded.Data) != 0 {
+		t.Errorf("expected empty data")
+	}
+}
+
+func TestLeasePayload_ZeroExpiry(t *testing.T) {
+	original := &LeasePayload{
+		LeaseID: 1,
+		Key:     "test",
+		Expiry:  0,
+	}
+	encoded := original.Encode()
+	decoded, err := DecodeLeasePayload(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if decoded.Expiry != 0 {
+		t.Errorf("expected zero expiry")
+	}
+}
+
+func TestQueryResponseBinaryFormat(t *testing.T) {
+	resp := &QueryResponsePayload{
+		RequestID: 0xABCDEF,
+		Data:      []byte("x"),
+		Error:     "e",
+	}
+	encoded := resp.Encode()
+
+	reqID := binary.BigEndian.Uint64(encoded[0:8])
+	if reqID != 0xABCDEF {
+		t.Errorf("requestID mismatch: got %x, want %x", reqID, 0xABCDEF)
+	}
+}

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -13,18 +13,18 @@ import (
 // It maintains a pool of peer connections and a background goroutine
 // that reads RPCs from all peers and delivers them via Consume().
 type TCPTransport struct {
-	cfg     TCPTransportConfig
-	ln      net.Listener
+	cfg        TCPTransportConfig
+	ln         net.Listener
 	listenAddr string
 
 	peerMap *PeerMap
 	conns   map[net.Conn]struct{}
 
-	rpcCh   chan RPC
-	done    chan struct{}
-	closed  bool
-	mu      sync.Mutex
-	wg      sync.WaitGroup
+	rpcCh  chan RPC
+	done   chan struct{}
+	closed bool
+	mu     sync.Mutex
+	wg     sync.WaitGroup
 }
 
 // NewTCPTransport creates a new TCPTransport with the given configuration.

--- a/src/p2p/types.go
+++ b/src/p2p/types.go
@@ -15,19 +15,23 @@ import (
 type PeerState int32
 
 const (
-	PeerStateAlive    PeerState = 0
-	PeerStateSuspect  PeerState = 1
-	PeerStateOffline  PeerState = 2
+	PeerStateAlive   PeerState = 0
+	PeerStateSuspect PeerState = 1
+	PeerStateOffline PeerState = 2
 )
+
+// maxPayloadSize is the maximum allowed size for a single decoded payload (1 MiB).
+// This prevents unbounded allocations from malformed or malicious peers.
+const maxPayloadSize = 1 << 20
 
 // Peer represents a remote node in the P2P network.
 type Peer struct {
-	ID        int32
-	Addr      string
-	state     atomic.Int32
-	lastSeen  atomic.Int64
-	conn      net.Conn
-	mu        sync.Mutex
+	ID       int32
+	Addr     string
+	state    atomic.Int32
+	lastSeen atomic.Int64
+	conn     net.Conn
+	mu       sync.Mutex
 }
 
 // NewPeer creates a new Peer with the given ID and address.
@@ -79,10 +83,10 @@ func (p *Peer) Conn() net.Conn {
 type MessageType uint8
 
 const (
-	MsgHeartbeat    MessageType = 1
-	MsgMembership   MessageType = 2
-	MsgSuspect      MessageType = 3
-	MsgQuery        MessageType = 4
+	MsgHeartbeat     MessageType = 1
+	MsgMembership    MessageType = 2
+	MsgSuspect       MessageType = 3
+	MsgQuery         MessageType = 4
 	MsgQueryResponse MessageType = 5
 	MsgLeaseRequest  MessageType = 6
 	MsgLeaseGrant    MessageType = 7
@@ -224,6 +228,9 @@ func (q *QueryPayload) Encode() []byte {
 
 // DecodeQueryPayload deserializes a QueryPayload from binary.
 func DecodeQueryPayload(data []byte) (*QueryPayload, error) {
+	if len(data) > maxPayloadSize {
+		return nil, fmt.Errorf("query payload too large: %d (errno=%d)", len(data), syscall.EFBIG)
+	}
 	if len(data) < 9 {
 		return nil, fmt.Errorf("query payload too short: %w", syscall.EBADMSG)
 	}
@@ -258,6 +265,9 @@ func (q *QueryResponsePayload) Encode() []byte {
 
 // DecodeQueryResponsePayload deserializes a QueryResponsePayload from binary.
 func DecodeQueryResponsePayload(data []byte) (*QueryResponsePayload, error) {
+	if len(data) > maxPayloadSize {
+		return nil, fmt.Errorf("query response payload too large: %d (errno=%d)", len(data), syscall.EFBIG)
+	}
 	if len(data) < 14 {
 		return nil, fmt.Errorf("query response payload too short: %w", syscall.EBADMSG)
 	}
@@ -284,9 +294,9 @@ func DecodeQueryResponsePayload(data []byte) (*QueryResponsePayload, error) {
 // LeasePayload is the payload for lease request/grant/release RPCs.
 // Wire format: [8 bytes: lease ID] [4 bytes: key len] [N bytes: key] [8 bytes: expiry unixnano]
 type LeasePayload struct {
-	LeaseID  uint64
-	Key      string
-	Expiry   int64
+	LeaseID uint64
+	Key     string
+	Expiry  int64
 }
 
 // Encode serializes a LeasePayload into binary.
@@ -303,6 +313,9 @@ func (l *LeasePayload) Encode() []byte {
 
 // DecodeLeasePayload deserializes a LeasePayload from binary.
 func DecodeLeasePayload(data []byte) (*LeasePayload, error) {
+	if len(data) > maxPayloadSize {
+		return nil, fmt.Errorf("lease payload too large: %d (errno=%d)", len(data), syscall.EFBIG)
+	}
 	if len(data) < 20 {
 		return nil, fmt.Errorf("lease payload too short: %w", syscall.EBADMSG)
 	}

--- a/src/p2p/types.go
+++ b/src/p2p/types.go
@@ -79,9 +79,14 @@ func (p *Peer) Conn() net.Conn {
 type MessageType uint8
 
 const (
-	MsgHeartbeat  MessageType = 1
-	MsgMembership MessageType = 2
-	MsgSuspect    MessageType = 3
+	MsgHeartbeat    MessageType = 1
+	MsgMembership   MessageType = 2
+	MsgSuspect      MessageType = 3
+	MsgQuery        MessageType = 4
+	MsgQueryResponse MessageType = 5
+	MsgLeaseRequest  MessageType = 6
+	MsgLeaseGrant    MessageType = 7
+	MsgLeaseRelease  MessageType = 8
 )
 
 // RPC is a remote procedure call exchanged between peers.
@@ -189,4 +194,129 @@ func DecodeHeartbeatPayload(data []byte) (*HeartbeatPayload, error) {
 		peers = append(peers, PeerInfo{ID: id, Addr: addr})
 	}
 	return &HeartbeatPayload{Peers: peers}, nil
+}
+
+// QueryType identifies the kind of scatter-gather query.
+type QueryType uint8
+
+const (
+	QueryList QueryType = 1
+	QueryGet  QueryType = 2
+	QueryHas  QueryType = 3
+)
+
+// QueryPayload is the payload of a MsgQuery RPC.
+// Wire format: [1 byte: query type] [8 bytes: request ID] [N bytes: data]
+type QueryPayload struct {
+	Type      QueryType
+	RequestID uint64
+	Data      []byte
+}
+
+// Encode serializes a QueryPayload into binary.
+func (q *QueryPayload) Encode() []byte {
+	buf := make([]byte, 1+8+len(q.Data))
+	buf[0] = byte(q.Type)
+	binary.BigEndian.PutUint64(buf[1:9], q.RequestID)
+	copy(buf[9:], q.Data)
+	return buf
+}
+
+// DecodeQueryPayload deserializes a QueryPayload from binary.
+func DecodeQueryPayload(data []byte) (*QueryPayload, error) {
+	if len(data) < 9 {
+		return nil, fmt.Errorf("query payload too short: %w", syscall.EBADMSG)
+	}
+	return &QueryPayload{
+		Type:      QueryType(data[0]),
+		RequestID: binary.BigEndian.Uint64(data[1:9]),
+		Data:      data[9:],
+	}, nil
+}
+
+// QueryResponsePayload is the payload of a MsgQueryResponse RPC.
+// Wire format: [8 bytes: request ID] [4 bytes: data len] [N bytes: data] [2 bytes: err len] [M bytes: err]
+type QueryResponsePayload struct {
+	RequestID uint64
+	Data      []byte
+	Error     string
+}
+
+// Encode serializes a QueryResponsePayload into binary.
+func (q *QueryResponsePayload) Encode() []byte {
+	errLen := len(q.Error)
+	buf := make([]byte, 8+4+len(q.Data)+2+errLen)
+	binary.BigEndian.PutUint64(buf[0:8], q.RequestID)
+	binary.BigEndian.PutUint32(buf[8:12], uint32(len(q.Data)))
+	copy(buf[12:], q.Data)
+	off := 12 + len(q.Data)
+	binary.BigEndian.PutUint16(buf[off:off+2], uint16(errLen))
+	off += 2
+	copy(buf[off:], q.Error)
+	return buf
+}
+
+// DecodeQueryResponsePayload deserializes a QueryResponsePayload from binary.
+func DecodeQueryResponsePayload(data []byte) (*QueryResponsePayload, error) {
+	if len(data) < 14 {
+		return nil, fmt.Errorf("query response payload too short: %w", syscall.EBADMSG)
+	}
+	reqID := binary.BigEndian.Uint64(data[0:8])
+	dataLen := int(binary.BigEndian.Uint32(data[8:12]))
+	if 12+dataLen+2 > len(data) {
+		return nil, fmt.Errorf("truncated query response data: %w", syscall.EBADMSG)
+	}
+	respData := make([]byte, dataLen)
+	copy(respData, data[12:12+dataLen])
+	off := 12 + dataLen
+	errLen := int(binary.BigEndian.Uint16(data[off : off+2]))
+	off += 2
+	if off+errLen > len(data) {
+		return nil, fmt.Errorf("truncated query response error: %w", syscall.EBADMSG)
+	}
+	return &QueryResponsePayload{
+		RequestID: reqID,
+		Data:      respData,
+		Error:     string(data[off : off+errLen]),
+	}, nil
+}
+
+// LeasePayload is the payload for lease request/grant/release RPCs.
+// Wire format: [8 bytes: lease ID] [4 bytes: key len] [N bytes: key] [8 bytes: expiry unixnano]
+type LeasePayload struct {
+	LeaseID  uint64
+	Key      string
+	Expiry   int64
+}
+
+// Encode serializes a LeasePayload into binary.
+func (l *LeasePayload) Encode() []byte {
+	keyLen := len(l.Key)
+	buf := make([]byte, 8+4+keyLen+8)
+	binary.BigEndian.PutUint64(buf[0:8], l.LeaseID)
+	binary.BigEndian.PutUint32(buf[8:12], uint32(keyLen))
+	copy(buf[12:], l.Key)
+	off := 12 + keyLen
+	binary.BigEndian.PutUint64(buf[off:off+8], uint64(l.Expiry))
+	return buf
+}
+
+// DecodeLeasePayload deserializes a LeasePayload from binary.
+func DecodeLeasePayload(data []byte) (*LeasePayload, error) {
+	if len(data) < 20 {
+		return nil, fmt.Errorf("lease payload too short: %w", syscall.EBADMSG)
+	}
+	leaseID := binary.BigEndian.Uint64(data[0:8])
+	keyLen := int(binary.BigEndian.Uint32(data[8:12]))
+	if 12+keyLen+8 > len(data) {
+		return nil, fmt.Errorf("truncated lease payload key: %w", syscall.EBADMSG)
+	}
+	key := string(data[12 : 12+keyLen])
+	off := 12 + keyLen
+	expiry := int64(binary.BigEndian.Uint64(data[off : off+8]))
+	return &LeasePayload{
+		LeaseID: leaseID,
+		Key:     key,
+		Expiry:  expiry,
+	}, nil
 }

--- a/src/server/cas_integration_test.go
+++ b/src/server/cas_integration_test.go
@@ -23,17 +23,17 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 	nodeCount := 5
 	replFactor := 3
 	tempDir := t.TempDir()
-	
+
 	daemons := make([]*common.Daemon, nodeCount)
 	stores := make([]storage.Store, nodeCount)
 	listeners := make([]net.Listener, nodeCount)
-	
+
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
-	
+
 	for i := 0; i < nodeCount; i++ {
 		nodeData := filepath.Join(tempDir, fmt.Sprintf("node-%d", i))
 		os.MkdirAll(nodeData, 0755)
-		
+
 		// Create local Bbolt store for this node
 		store, err := storage.NewCASStore(nodeData)
 		if err != nil {
@@ -41,7 +41,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 		}
 		stores[i] = store
 		defer store.Close()
-		
+
 		// Bind a local listener
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
@@ -49,7 +49,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 		}
 		listeners[i] = ln
 		defer ln.Close()
-		
+
 		daemons[i] = &common.Daemon{
 			Host: ln.Addr().String(),
 			Data: nodeData,
@@ -62,22 +62,22 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 		id := i
 		ln := listeners[i]
 		store := stores[i]
-		
+
 		daemonsWg.Add(1)
 		go func() {
 			defer daemonsWg.Done()
-			
+
 			for {
 				conn, err := ln.Accept()
 				if err != nil {
 					return
 				}
-				
+
 				// Handle connection
 				func(c net.Conn) {
 					comm := transport.NewMomoTCPCommunicator(c)
 					defer comm.Close()
-					
+
 					// Handshake
 					expectedAuth := []byte(common.PadString(authToken, 64))
 					_, _, err := comm.HandshakeServer(expectedAuth)
@@ -85,12 +85,12 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 						return
 					}
 					comm.SendReplicationMode(common.ReplicationNone) // Simple integration test
-					
+
 					meta, err := comm.ReceiveMetadata()
 					if err != nil {
 						return
 					}
-					
+
 					// Check deduplication
 					exists, _ := store.Has(meta.Hash)
 					if exists {
@@ -127,33 +127,33 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 	for _, f := range files {
 		content := []byte(f.content)
 		hash := common.HashBytes(content)
-		
+
 		// Calculate Primary using CRUSH
 		placement, _ := cmap.Placement(hash, replFactor)
 		primary := placement[0]
-		
+
 		t.Logf("File %s (hash: %s) -> Primary Node: %d", f.name, hash[:8], primary.ID)
-		
+
 		// Connect to primary
 		conn, err := net.Dial("tcp", primary.Addr)
 		if err != nil {
 			t.Fatalf("Failed to dial node %d: %v", primary.ID, err)
 		}
 		comm := transport.NewMomoTCPCommunicator(conn)
-		
+
 		// Handshake
 		_, err = comm.HandshakeClient(authToken, common.DummyEpoch, 0)
 		if err != nil {
 			t.Fatalf("Handshake failed: %v", err)
 		}
-		
+
 		// Send Metadata
 		meta := &common.FileMetadata{Name: f.name, Hash: hash, Size: int64(len(content))}
 		status, err := comm.SendMetadata(meta)
 		if err != nil {
 			t.Fatalf("SendMetadata failed: %v", err)
 		}
-		
+
 		if f.name == "duplicate.txt" {
 			// This should be a deduplication hit!
 			if status != transport.MetadataStatusSkipPayload {
@@ -166,7 +166,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 			// Send payload
 			comm.Write(content)
 		}
-		
+
 		// Wait for ACK
 		if err := comm.ReceiveACK(); err != nil {
 			t.Errorf("ReceiveACK failed for %s: %v", f.name, err)
@@ -194,7 +194,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 			if _, err := os.Stat(path); err != nil {
 				t.Errorf("Physical blob missing on node %d at %s", i, path)
 			}
-			
+
 			// Verify duplicate.txt also maps here
 			_, m, err := stores[i].Get("duplicate.txt")
 			if err == nil && m.Hash == file1Hash {
@@ -202,7 +202,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 			}
 		}
 	}
-	
+
 	if !foundInObjects {
 		t.Errorf("Content hash %s not found in any node", file1Hash)
 	}

--- a/src/server/file_test.go
+++ b/src/server/file_test.go
@@ -278,9 +278,9 @@ func FuzzParsePaddedIntFast(f *testing.F) {
 	f.Add([]byte("12345\x00\x00"))
 	f.Add([]byte("-123"))
 	f.Add([]byte("+456"))
-	f.Add([]byte("9223372036854775807")) // MaxInt64
+	f.Add([]byte("9223372036854775807"))  // MaxInt64
 	f.Add([]byte("-9223372036854775808")) // MinInt64
-	f.Add([]byte("9223372036854775808")) // Overflow
+	f.Add([]byte("9223372036854775808"))  // Overflow
 	f.Add([]byte("abc"))
 	f.Add([]byte(""))
 	f.Add([]byte("\x00\x00"))
@@ -294,12 +294,12 @@ func FuzzGetMetadata(f *testing.F) {
 	// Seed data: a valid 192-byte metadata packet
 	valid := make([]byte, 192)
 	copy(valid[:64], bytes.Repeat([]byte("a"), 64)) // Hash
-	copy(valid[64:128], "test.txt") // Name
-	copy(valid[128:], "12345") // Size
+	copy(valid[64:128], "test.txt")                 // Name
+	copy(valid[128:], "12345")                      // Size
 	f.Add(valid)
-	
+
 	f.Add(make([]byte, 192)) // All zeros
-	f.Add(make([]byte, 10)) // Too short
+	f.Add(make([]byte, 10))  // Too short
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		reader := bytes.NewReader(data)

--- a/src/server/p2p_adapters.go
+++ b/src/server/p2p_adapters.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/p2p"
+)
+
+// ScatterGatherLister adapts p2p.ScatterGather to the transport.GlobalLister interface.
+type ScatterGatherLister struct {
+	sg      *p2p.ScatterGather
+	timeout time.Duration
+}
+
+// NewScatterGatherLister creates a new ScatterGatherLister adapter.
+func NewScatterGatherLister(sg *p2p.ScatterGather, timeout time.Duration) *ScatterGatherLister {
+	return &ScatterGatherLister{sg: sg, timeout: timeout}
+}
+
+// GlobalList queries all peers for their local file lists and: merges and deduplicates results.
+func (s *ScatterGatherLister) GlobalList(timeout time.Duration) ([]common.FileMetadata, error) {
+	if s.sg == nil {
+		return nil, fmt.Errorf("scatter-gather not initialized")
+	}
+
+	responses, count := s.sg.Query(p2p.QueryList, nil, timeout)
+	if count == 0 {
+		return nil, nil
+	}
+
+	var allLists [][]common.FileMetadata
+	for _, resp := range responses {
+		if resp.Error != "" {
+			continue
+		}
+		files, err := DecodeFileMetadataList(resp.Data)
+		if err != nil {
+			continue
+		}
+		allLists = append(allLists, files)
+	}
+
+	return MergeFileMetadataLists(allLists...), nil
+}
+
+// LeaseAcquirerAdapter adapts p2p.LeaseManager to the transport.LeaseAcquirer interface.
+type LeaseAcquirerAdapter struct {
+	lm       *p2p.LeaseManager
+	duration time.Duration
+}
+
+// NewLeaseAcquirerAdapter creates a new LeaseAcquirerAdapter.
+func NewLeaseAcquirerAdapter(lm *p2p.LeaseManager, duration time.Duration) *LeaseAcquirerAdapter {
+	return &LeaseAcquirerAdapter{lm: lm, duration: duration}
+}
+
+// AcquireLease acquires a lease for the given key.
+func (l *LeaseAcquirerAdapter) AcquireLease(key string, timeout time.Duration) error {
+	if l.lm == nil {
+		return fmt.Errorf("lease manager not initialized")
+	}
+	_, err := l.lm.Acquire(key, l.duration)
+	return err
+}
+
+// ReleaseLease releases the lease for the given key.
+func (l *LeaseAcquirerAdapter) ReleaseLease(key string) error {
+	if l.lm == nil {
+		return nil
+	}
+	return l.lm.ReleaseByKey(key)
+}

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/alsotoes/momo/src/common"
+	"github.com/alsotoes/momo/src/p2p"
+	"github.com/alsotoes/momo/src/storage"
+)
+
+// StorageQueryHandler implements p2p.QueryHandler over the local CAS store.
+// It enables scatter-gather queries for list/get/has operations across the cluster.
+type StorageQueryHandler struct {
+	store storage.Store
+}
+
+// NewStorageQueryHandler creates a new StorageQueryHandler.
+func NewStorageQueryHandler(store storage.Store) *StorageQueryHandler {
+	return &StorageQueryHandler{store: store}
+}
+
+// HandleQuery processes a scatter-gather query locally and returns the encoded result.
+func (h *StorageQueryHandler) HandleQuery(qt p2p.QueryType, data []byte) ([]byte, error) {
+	switch qt {
+	case p2p.QueryList:
+		return h.handleList()
+	case p2p.QueryGet:
+		return h.handleGet(data)
+	case p2p.QueryHas:
+		return h.handleHas(data)
+	default:
+		return nil, fmt.Errorf("unknown query type: %d", qt)
+	}
+}
+
+// handleList returns all local files as binary-encoded FileMetadata list.
+func (h *StorageQueryHandler) handleList() ([]byte, error) {
+	files, err := h.store.List()
+	if err != nil {
+		return nil, err
+	}
+	return EncodeFileMetadataList(files), nil
+}
+
+// handleGet returns metadata for a specific file.
+func (h *StorageQueryHandler) handleGet(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty file name")
+	}
+	name := string(data)
+	_, meta, err := h.store.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return EncodeFileMetadataList([]common.FileMetadata{meta}), nil
+}
+
+// handleHas checks if a hash exists in the local store.
+func (h *StorageQueryHandler) handleHas(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty hash")
+	}
+	hash := string(data)
+	exists, err := h.store.Has(hash)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]byte, 1)
+	if exists {
+		result[0] = 1
+	}
+	return result, nil
+}
+
+// EncodeFileMetadataList serializes a list of FileMetadata into binary.
+// Format: [4B count] [for each: 4B nameLen + name + 4B hashLen + hash + 8B size + 4B pathLen + path]
+func EncodeFileMetadataList(files []common.FileMetadata) []byte {
+	size := 4
+	for _, f := range files {
+		size += 4 + len(f.Name) + 4 + len(f.Hash) + 8 + 4 + len(f.RemotePath)
+	}
+	buf := make([]byte, size)
+	binary.BigEndian.PutUint32(buf[0:4], uint32(len(files)))
+	off := 4
+	for _, f := range files {
+		binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(f.Name)))
+		off += 4
+		copy(buf[off:], f.Name)
+		off += len(f.Name)
+		binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(f.Hash)))
+		off += 4
+		copy(buf[off:], f.Hash)
+		off += len(f.Hash)
+		binary.BigEndian.PutUint64(buf[off:off+8], uint64(f.Size))
+		off += 8
+		binary.BigEndian.PutUint32(buf[off:off+4], uint32(len(f.RemotePath)))
+		off += 4
+		copy(buf[off:], f.RemotePath)
+		off += len(f.RemotePath)
+	}
+	return buf
+}
+
+// DecodeFileMetadataList deserializes a binary FileMetadata list.
+func DecodeFileMetadataList(data []byte) ([]common.FileMetadata, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("file metadata list too short")
+	}
+	count := int(binary.BigEndian.Uint32(data[0:4]))
+	off := 4
+	files := make([]common.FileMetadata, 0, count)
+	for i := 0; i < count; i++ {
+		if off+4 > len(data) {
+			return nil, fmt.Errorf("truncated name length at entry %d", i)
+		}
+		nameLen := int(binary.BigEndian.Uint32(data[off : off+4]))
+		off += 4
+		if off+nameLen > len(data) {
+			return nil, fmt.Errorf("truncated name at entry %d", i)
+		}
+		name := string(data[off : off+nameLen])
+		off += nameLen
+
+		if off+4 > len(data) {
+			return nil, fmt.Errorf("truncated hash length at entry %d", i)
+		}
+		hashLen := int(binary.BigEndian.Uint32(data[off : off+4]))
+		off += 4
+		if off+hashLen > len(data) {
+			return nil, fmt.Errorf("truncated hash at entry %d", i)
+		}
+		hash := string(data[off : off+hashLen])
+		off += hashLen
+
+		if off+8 > len(data) {
+			return nil, fmt.Errorf("truncated size at entry %d", i)
+		}
+		fileSize := int64(binary.BigEndian.Uint64(data[off : off+8]))
+		off += 8
+
+		if off+4 > len(data) {
+			return nil, fmt.Errorf("truncated path length at entry %d", i)
+		}
+		pathLen := int(binary.BigEndian.Uint32(data[off : off+4]))
+		off += 4
+		if off+pathLen > len(data) {
+			return nil, fmt.Errorf("truncated path at entry %d", i)
+		}
+		remotePath := string(data[off : off+pathLen])
+		off += pathLen
+
+		files = append(files, common.FileMetadata{
+			Name:       name,
+			Hash:       hash,
+			Size:       fileSize,
+			RemotePath: remotePath,
+		})
+	}
+	return files, nil
+}
+
+// MergeFileMetadataLists merges multiple file lists and deduplicates by hash.
+func MergeFileMetadataLists(lists ...[]common.FileMetadata) []common.FileMetadata {
+	seen := make(map[string]bool)
+	var merged []common.FileMetadata
+	for _, list := range lists {
+		for _, f := range list {
+			if !seen[f.Hash] {
+				seen[f.Hash] = true
+				merged = append(merged, f)
+			}
+		}
+	}
+	return merged
+}

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -219,7 +219,6 @@ func ChangeReplicationModeClient(factory *transport.ProtocolFactory, replication
 		return
 	}
 
-
 	// ⚡ Bolt: Use sync.Pool to minimize allocations during cluster-wide broadcasts.
 	payload := payloadPool.Get().([]byte)
 	payload = payload[:0]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -85,8 +85,10 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 	cmap := &common.ClusterMap{Nodes: nodes}
 
 	// P2P Transport & Gossip (coexists with existing listener when enabled)
+	var scatterGather *p2p.ScatterGather
+	var leaseManager *p2p.LeaseManager
 	if cfg.P2P.Enabled {
-		bootstrapP2P(ctx, cfg, serverId, daemons)
+		scatterGather, leaseManager = bootstrapP2P(ctx, cfg, serverId, daemons, store)
 	}
 
 	// 🛡️ Sentinel: Enforce a limit on concurrent connections to prevent resource exhaustion (DoS).
@@ -129,6 +131,20 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 			// Inject storage store if the communicator supports it (e.g. S3 for list/delete)
 			if s3Comm, ok := comm.(interface{ SetStore(storage.Store) }); ok {
 				s3Comm.SetStore(store)
+			}
+
+			// Inject scatter-gather and lease capabilities if P2P is enabled
+			if scatterGather != nil {
+				if glComm, ok := comm.(interface{ SetGlobalLister(transport.GlobalLister) }); ok {
+					glComm.SetGlobalLister(NewScatterGatherLister(scatterGather,
+						time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
+				}
+			}
+			if leaseManager != nil {
+				if laComm, ok := comm.(interface{ SetLeaseAcquirer(transport.LeaseAcquirer) }); ok {
+					laComm.SetLeaseAcquirer(NewLeaseAcquirerAdapter(leaseManager,
+						time.Duration(cfg.P2P.LeaseTimeout)*time.Second))
+				}
 			}
 
 			// 🛡️ Sentinel: Apply a strict absolute deadline for the handshake phase to prevent Slowloris trickle attacks.
@@ -402,7 +418,8 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 // bootstrapP2P starts the P2P transport and gossip protocol alongside the main daemon.
 // It connects to all configured daemon peers as bootstrap seeds and begins
 // exchanging heartbeats for dynamic membership discovery.
-func bootstrapP2P(ctx context.Context, cfg common.Configuration, serverId int, daemons []*common.Daemon) *p2p.Gossiper {
+// Returns the ScatterGather and LeaseManager instances for use by the server.
+func bootstrapP2P(ctx context.Context, cfg common.Configuration, serverId int, daemons []*common.Daemon, store storage.Store) (*p2p.ScatterGather, *p2p.LeaseManager) {
 	gossipAddr := daemons[serverId].Host
 	host, _, err := net.SplitHostPort(gossipAddr)
 	if err != nil {
@@ -422,7 +439,7 @@ func bootstrapP2P(ctx context.Context, cfg common.Configuration, serverId int, d
 
 	if err := transport.Listen(gossipAddr); err != nil {
 		log.Printf("P2P: failed to listen on %s: %v", gossipAddr, err)
-		return nil
+		return nil, nil
 	}
 
 	gossipCfg := p2p.GossipConfig{
@@ -440,6 +457,13 @@ func bootstrapP2P(ctx context.Context, cfg common.Configuration, serverId int, d
 		log.Printf("P2P: peer %d left cluster", peerID)
 	})
 
+	queryHandler := NewStorageQueryHandler(store)
+	scatterGather := p2p.NewScatterGather(int32(serverId), transport, queryHandler)
+	leaseManager := p2p.NewLeaseManager(int32(serverId), transport)
+
+	gossip.SetScatterGather(scatterGather)
+	gossip.SetLeaseManager(leaseManager)
+
 	for i, d := range daemons {
 		if i == serverId {
 			continue
@@ -452,15 +476,17 @@ func bootstrapP2P(ctx context.Context, cfg common.Configuration, serverId int, d
 		}
 	}
 
+	leaseManager.Start()
 	gossip.Run()
 
 	log.Printf("P2P: gossip started, node %d, %d peers connected", serverId, transport.Peers().Count())
 
 	go func() {
 		<-ctx.Done()
+		leaseManager.Stop()
 		gossip.Close()
 		transport.Close()
 	}()
 
-	return gossip
+	return scatterGather, leaseManager
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -343,7 +343,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 					nextHop := placement[myPos+1]
 					blobPath, _ := store.GetBlobPath(fileName)
 					log.Printf("AUDIT: Chain forwarding from Node %d to Node %d", serverId, nextHop.ID)
-					
+
 					// 🛡️ Zero-Crash: Wrap Chain forwarding in a goroutine with recovery for consistency and safety.
 					go func(id int, path string) {
 						defer func() {
@@ -443,7 +443,7 @@ func bootstrapP2P(ctx context.Context, cfg common.Configuration, serverId int, d
 	}
 
 	gossipCfg := p2p.GossipConfig{
-		LocalID:          int32(serverId),
+		LocalID:           int32(serverId),
 		HeartbeatInterval: time.Duration(cfg.P2P.GossipInterval) * time.Second,
 		SuspicionTimeout:  time.Duration(cfg.P2P.SuspicionTimeout) * time.Second,
 		Fanout:            cfg.P2P.Fanout,

--- a/src/server/server_daemon_test.go
+++ b/src/server/server_daemon_test.go
@@ -49,7 +49,7 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 			io.ReadFull(conn, authBuf)
 			// Send back a replication mode to complete handshake
 			conn.Write([]byte("0"))
-			
+
 			// ⚡ Bolt: Consume the JSON payload and send OK
 			buf := make([]byte, 1024)
 			conn.Read(buf)
@@ -77,7 +77,7 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 	}()
 
 	go ChangeReplicationModeServer(ctx, cfg, 0, time.Now().UnixNano())
-	
+
 	// 🛡️ Zero-Crash: Use a retry loop to wait for the replication server to bind.
 	var conn net.Conn
 	var err error
@@ -133,7 +133,7 @@ func TestDaemonReal(t *testing.T) {
 	defer cancel()
 
 	go Daemon(ctx, cfg, 0)
-	
+
 	// 🛡️ Zero-Crash: Use a robust retry loop instead of a fixed sleep to wait for the daemon to bind.
 	var conn net.Conn
 	var err error

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -1,5 +1,6 @@
 // Package server provides the core functionality for the momo server.
 package server
+
 import (
 	"context"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"github.com/alsotoes/momo/src/transport"
 	"go.uber.org/goleak"
 )
+
 // mockConnect is a mock implementation of Connect for testing.
 func mockConnect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
 	defer wg.Done()
@@ -47,7 +49,7 @@ func handleConnection(t *testing.T, connection net.Conn, cfg common.Configuratio
 	}()
 
 	expectedAuthToken := []byte(common.PadString(cfg.Global.AuthToken, common.AuthTokenLength))
-	
+
 	// HandshakeServer performs the server-side handshake: receives AuthToken + Timestamp + RequestedMode
 	replicationMode, timestamp, err := comm.HandshakeServer(expectedAuthToken)
 	if err != nil {

--- a/src/transport/communicator.go
+++ b/src/transport/communicator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	"github.com/quic-go/quic-go"
@@ -22,6 +23,19 @@ const (
 	// MetadataStatusSkipPayload indicates the server already has the content (deduplication).
 	MetadataStatusSkipPayload = 2
 )
+
+// GlobalLister enables scatter-gather list queries across the cluster.
+// When set on a Communicator, list operations aggregate results from all peers.
+type GlobalLister interface {
+	GlobalList(timeout time.Duration) ([]common.FileMetadata, error)
+}
+
+// LeaseAcquirer enables lease-based consensus for destructive operations.
+// When set on a Communicator, delete operations acquire a lease before proceeding.
+type LeaseAcquirer interface {
+	AcquireLease(key string, timeout time.Duration) error
+	ReleaseLease(key string) error
+}
 
 // Communicator defines a transport-agnostic interface for Momo protocol operations.
 // It encapsulates the handshake, metadata exchange, and file transfer logic.

--- a/src/transport/communicator.go
+++ b/src/transport/communicator.go
@@ -53,7 +53,6 @@ type Communicator interface {
 	// validates the token, and returns the timestamp and requested mode.
 	HandshakeServer(expectedAuthToken []byte) (replicationMode int, timestamp int64, err error)
 
-
 	// SendReplicationMode sends the chosen replication mode back to the client.
 	SendReplicationMode(mode int) error
 

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -241,7 +241,7 @@ func TestMomoQUICCommunicator_Metadata_And_Payload(t *testing.T) {
 func TestMomoQUICCommunicator_EdgeCases(t *testing.T) {
 	// 1. Panic recovery tests (Rule 4) via nil communicator
 	var nilComm *MomoQUICCommunicator
-	
+
 	_, _, err := nilComm.HandshakeServer([]byte("token"))
 	if err == nil {
 		t.Errorf("Expected HandshakeServer on nilComm to fail")

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -29,8 +29,10 @@ import (
 // MomoQUICCommunicator implements the Communicator interface for the Momo protocol over QUIC.
 type MomoQUICCommunicator struct {
 	*quic.Stream
-	conn  *quic.Conn
-	store storage.Store
+	conn          *quic.Conn
+	store         storage.Store
+	globalLister  GlobalLister
+	leaseAcquirer LeaseAcquirer
 }
 
 // NewMomoQUICCommunicator creates a new MomoQUICCommunicator.
@@ -43,6 +45,16 @@ func NewMomoQUICCommunicator(stream *quic.Stream, conn *quic.Conn) *MomoQUICComm
 
 func (m *MomoQUICCommunicator) SetStore(store storage.Store) {
 	m.store = store
+}
+
+// SetGlobalLister sets the scatter-gather list capability.
+func (m *MomoQUICCommunicator) SetGlobalLister(gl GlobalLister) {
+	m.globalLister = gl
+}
+
+// SetLeaseAcquirer sets the lease-based consensus capability.
+func (m *MomoQUICCommunicator) SetLeaseAcquirer(la LeaseAcquirer) {
+	m.leaseAcquirer = la
 }
 
 func (m *MomoQUICCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
@@ -151,7 +163,12 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
-		files, err := m.store.List()
+		var files []common.FileMetadata
+		if m.globalLister != nil {
+			files, err = m.globalLister.GlobalList(5 * time.Second)
+		} else {
+			files, err = m.store.List()
+		}
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to list files: %w", err)
 		}
@@ -207,6 +224,15 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("invalid delete target traversal: %s: %w", fileName, syscall.EBADMSG)
+		}
+
+		if m.leaseAcquirer != nil {
+			if err := m.leaseAcquirer.AcquireLease(fileName, 10*time.Second); err != nil {
+				m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				m.Write([]byte{'1'}) // error status
+				return 0, 0, fmt.Errorf("failed to acquire lease for delete: %w", err)
+			}
+			defer m.leaseAcquirer.ReleaseLease(fileName)
 		}
 
 		err = m.store.Delete(fileName)

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -330,7 +330,7 @@ func (m *MomoQUICCommunicator) SendMetadata(meta *common.FileMetadata) (status i
 
 	var metadataBuffer [hashLength + common.FileInfoLength + common.FileInfoLength]byte
 	copy(metadataBuffer[0:hashLength], meta.Hash)
-	
+
 	wireName := meta.Name
 	if meta.RemotePath != "" {
 		normalized, normErr := common.NormalizeVirtualPath(meta.RemotePath)

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -23,7 +23,9 @@ const hashLength = 64
 // MomoTCPCommunicator implements the Communicator interface for the legacy Momo TCP protocol.
 type MomoTCPCommunicator struct {
 	*common.IdleTimeoutConn
-	store storage.Store
+	store        storage.Store
+	globalLister GlobalLister
+	leaseAcquirer LeaseAcquirer
 }
 
 // NewMomoTCPCommunicator creates a new MomoTCPCommunicator wrapping a net.Conn.
@@ -35,6 +37,16 @@ func NewMomoTCPCommunicator(conn net.Conn) *MomoTCPCommunicator {
 
 func (m *MomoTCPCommunicator) SetStore(store storage.Store) {
 	m.store = store
+}
+
+// SetGlobalLister sets the scatter-gather list capability.
+func (m *MomoTCPCommunicator) SetGlobalLister(gl GlobalLister) {
+	m.globalLister = gl
+}
+
+// SetLeaseAcquirer sets the lease-based consensus capability.
+func (m *MomoTCPCommunicator) SetLeaseAcquirer(la LeaseAcquirer) {
+	m.leaseAcquirer = la
 }
 
 func (m *MomoTCPCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
@@ -142,7 +154,12 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
-		files, err := m.store.List()
+		var files []common.FileMetadata
+		if m.globalLister != nil {
+			files, err = m.globalLister.GlobalList(5 * time.Second)
+		} else {
+			files, err = m.store.List()
+		}
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to list files: %w", err)
 		}
@@ -198,6 +215,15 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("invalid delete target traversal: %s: %w", fileName, syscall.EBADMSG)
+		}
+
+		if m.leaseAcquirer != nil {
+			if err := m.leaseAcquirer.AcquireLease(fileName, 10*time.Second); err != nil {
+				m.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				m.Write([]byte{'1'}) // error status
+				return 0, 0, fmt.Errorf("failed to acquire lease for delete: %w", err)
+			}
+			defer m.leaseAcquirer.ReleaseLease(fileName)
 		}
 
 		err = m.store.Delete(fileName)

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -23,8 +23,8 @@ const hashLength = 64
 // MomoTCPCommunicator implements the Communicator interface for the legacy Momo TCP protocol.
 type MomoTCPCommunicator struct {
 	*common.IdleTimeoutConn
-	store        storage.Store
-	globalLister GlobalLister
+	store         storage.Store
+	globalLister  GlobalLister
 	leaseAcquirer LeaseAcquirer
 }
 
@@ -83,7 +83,7 @@ func (m *MomoTCPCommunicator) HandshakeClient(authToken string, timestamp int64,
 	if err := common.AppendPaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
 		return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 	}
-	
+
 	// Write the requested mode (1 byte) at the end
 	handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode + '0')
 
@@ -322,7 +322,7 @@ func (m *MomoTCPCommunicator) SendMetadata(meta *common.FileMetadata) (status in
 
 	var metadataBuffer [hashLength + common.FileInfoLength + common.FileInfoLength]byte
 	copy(metadataBuffer[0:hashLength], meta.Hash)
-	
+
 	wireName := meta.Name
 	if meta.RemotePath != "" {
 		normalized, normErr := common.NormalizeVirtualPath(meta.RemotePath)

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -105,7 +105,7 @@ func TestMomoTCPCommunicator_Deadline(t *testing.T) {
 	conn, _ := net.Pipe()
 	defer conn.Close()
 	comm := NewMomoTCPCommunicator(conn)
-	
+
 	err := comm.SetAbsoluteDeadline(time.Now().Add(time.Second))
 	if err != nil {
 		t.Errorf("SetAbsoluteDeadline failed: %v", err)
@@ -115,7 +115,7 @@ func TestMomoTCPCommunicator_Deadline(t *testing.T) {
 func TestMomoTCPCommunicator_EdgeCases(t *testing.T) {
 	// 1. Panic recovery tests (Rule 4) via nil communicator
 	var nilComm *MomoTCPCommunicator
-	
+
 	_, _, err := nilComm.HandshakeServer([]byte("token"))
 	if err == nil {
 		t.Errorf("Expected HandshakeServer on nilComm to fail")

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -63,6 +63,11 @@ type S3Communicator struct {
 
 	// Storage store for list, get, and delete operations
 	store storage.Store
+
+	// GlobalLister for scatter-gather list queries (optional)
+	globalLister GlobalLister
+	// LeaseAcquirer for lease-based consensus on deletes (optional)
+	leaseAcquirer LeaseAcquirer
 }
 
 func NewS3Communicator(conn net.Conn) *S3Communicator {
@@ -77,6 +82,16 @@ func NewS3Communicator(conn net.Conn) *S3Communicator {
 
 func (m *S3Communicator) SetStore(store storage.Store) {
 	m.store = store
+}
+
+// SetGlobalLister sets the scatter-gather list capability.
+func (m *S3Communicator) SetGlobalLister(gl GlobalLister) {
+	m.globalLister = gl
+}
+
+// SetLeaseAcquirer sets the lease-based consensus capability.
+func (m *S3Communicator) SetLeaseAcquirer(la LeaseAcquirer) {
+	m.leaseAcquirer = la
 }
 
 func (m *S3Communicator) Read(p []byte) (n int, err error) {
@@ -242,7 +257,12 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		isList := (key == "") || (q.Get("list-type") == "2")
 
 		if isList {
-			files, err := m.store.List()
+			var files []common.FileMetadata
+			if m.globalLister != nil {
+				files, err = m.globalLister.GlobalList(5 * time.Second)
+			} else {
+				files, err = m.store.List()
+			}
 			if err != nil {
 				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
@@ -336,6 +356,15 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 			return 0, 0, fmt.Errorf("missing key in DELETE request")
+		}
+
+		if m.leaseAcquirer != nil {
+			if err := m.leaseAcquirer.AcquireLease(key, 10*time.Second); err != nil {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				m.conn.Write([]byte("HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+				return 0, 0, fmt.Errorf("failed to acquire lease for delete %q: %w", key, err)
+			}
+			defer m.leaseAcquirer.ReleaseLease(key)
 		}
 
 		err := m.store.Delete(key)

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -44,7 +44,7 @@ func TestS3Communicator_HandshakeServer(t *testing.T) {
 
 	go func() {
 		clientConn.Write([]byte(reqBody))
-		// ⚡ Bolt: Read in a loop to avoid deadlock on net.Pipe. 
+		// ⚡ Bolt: Read in a loop to avoid deadlock on net.Pipe.
 		// http.Response.Write performs multiple writes which will block if not fully consumed.
 		buf := make([]byte, 1024)
 		for {
@@ -105,7 +105,7 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 
 	go func() {
 		clientConn.Write([]byte(reqBody))
-		// ⚡ Bolt: Read in a loop to avoid deadlock on net.Pipe. 
+		// ⚡ Bolt: Read in a loop to avoid deadlock on net.Pipe.
 		// http.Response.Write performs multiple writes which will block if not fully consumed.
 		buf := make([]byte, 1024)
 		for {
@@ -181,7 +181,7 @@ func TestS3Communicator_EdgeCases(t *testing.T) {
 
 	// 1. Panic recovery tests (Rule 4) via nil communicator
 	var nilComm *S3Communicator
-	
+
 	_, err := nilComm.Read(make([]byte, 10))
 	if err == nil {
 		t.Errorf("Expected Read on nilComm to fail")


### PR DESCRIPTION
Resolves #248

## Summary

Implements scatter-gather queries for a unified global directory and lease-based consensus for safe destructive operations, building on the P2P transport layer from PR #339 (issue #153).

## Phase 1: Scatter-Gather Query Framework

- **New message types**: `MsgQuery`, `MsgQueryResponse`, `MsgLeaseRequest`, `MsgLeaseGrant`, `MsgLeaseRelease` with binary encode/decode
- **`ScatterGather`** struct: broadcasts queries to all alive peers, collects responses with timeout, multiplexed on existing `Consume()` channel
- **Gossiper** routes query/lease RPCs via `SetScatterGather`/`SetLeaseManager`

## Phase 2: Global Directory (List Scatter-Gather)

- **`StorageQueryHandler`** wraps CAS store for `p2p.QueryHandler` interface
- **`ScatterGatherLister`** adapter for `transport.GlobalLister`
- S3 `ListObjectsV2` uses scatter-gather when P2P enabled — returns unified cluster-wide directory
- Native TCP/QUIC list handlers use scatter-gather when P2P enabled
- Results merged and deduplicated by content hash

## Phase 3: Lease-Based Consensus

- **`LeaseManager`**: `Acquire`/`Release`/`ReleaseByKey` with majority quorum (N/2+1)
- In-memory leases with auto-expiry (500ms cleanup loop)
- **`LeaseAcquirerAdapter`** for `transport.LeaseAcquirer` interface
- S3 `DELETE` acquires lease before proceeding (503 on failure)
- Native TCP/QUIC delete handlers acquire lease before deleting

## Configuration

```ini
[p2p]
enabled = true
scatter_gather_timeout = 5  # seconds
lease_timeout = 10          # seconds
```

## Tests

- 10 new tests: query/lease payload encode/decode, scatter-gather query with 2-node cluster, lease acquire/release with 3-node quorum, expiry cleanup, timeout handling
- All existing tests pass with `-race`
- `goleak.VerifyTestMain` for goroutine leak detection

## Files

| File | Action |
|---|---|
| `src/p2p/types.go` | Modified — 5 new message types + payload encode/decode |
| `src/p2p/scatter_gather.go` | New — ScatterGather struct |
| `src/p2p/lease.go` | New — LeaseManager |
| `src/p2p/gossip.go` | Modified — route new RPC types |
| `src/p2p/scatter_gather_test.go` | New — 8 tests |
| `src/p2p/lease_test.go` | New — 4 tests |
| `src/server/query_handler.go` | New — StorageQueryHandler + binary FileMetadata encode/decode |
| `src/server/p2p_adapters.go` | New — ScatterGatherLister + LeaseAcquirerAdapter |
| `src/server/server.go` | Modified — wire ScatterGather + LeaseManager into Daemon |
| `src/transport/communicator.go` | Modified — GlobalLister + LeaseAcquirer interfaces |
| `src/transport/s3_communicator.go` | Modified — scatter-gather list, lease delete |
| `src/transport/momo_tcp.go` | Modified — same |
| `src/transport/momo_quic.go` | Modified — same |
| `src/common/struct.go` | Modified — ScatterGatherTimeout, LeaseTimeout config |
| `src/common/config.go` | Modified — load new [p2p] fields |
| `conf/momo.conf` | Modified — new [p2p] options |
| `docs/P2P.md` | Modified — scatter-gather + lease documentation |