### PR TITLE
feat: CAS garbage collection with reference counting and P2P delete propagation

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -806,3 +806,10 @@ ea712a7,BenchmarkPadString-8,1.97,0.00,0.00
 260921d,BenchmarkIndexSearch-8,2.75,0.00,0.00
 260921d,BenchmarkLoadGlobalConfig-8,802.90,160.00,1.00
 260921d,BenchmarkPadString-8,2.05,0.00,0.00
+d7ca92b,BenchmarkCheckMetricsAndSwap-8,7.72,0.00,0.00
+d7ca92b,BenchmarkCrushOptimized-8,325.20,0.00,0.00
+d7ca92b,BenchmarkCrushOriginal-8,430.50,164.00,3.00
+d7ca92b,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+d7ca92b,BenchmarkIndexSearch-8,2.74,0.00,0.00
+d7ca92b,BenchmarkLoadGlobalConfig-8,774.50,160.00,1.00
+d7ca92b,BenchmarkPadString-8,2.05,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -799,3 +799,10 @@ ea712a7,BenchmarkPadString-8,1.97,0.00,0.00
 08da645,BenchmarkIndexSearch-8,3.02,0.00,0.00
 08da645,BenchmarkLoadGlobalConfig-8,724.70,160.00,1.00
 08da645,BenchmarkPadString-8,2.46,0.00,0.00
+260921d,BenchmarkCheckMetricsAndSwap-8,7.92,0.00,0.00
+260921d,BenchmarkCrushOptimized-8,320.90,0.00,0.00
+260921d,BenchmarkCrushOriginal-8,453.40,164.00,3.00
+260921d,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+260921d,BenchmarkIndexSearch-8,2.75,0.00,0.00
+260921d,BenchmarkLoadGlobalConfig-8,802.90,160.00,1.00
+260921d,BenchmarkPadString-8,2.05,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -792,3 +792,10 @@ ea712a7,BenchmarkPadString-8,1.97,0.00,0.00
 31e546a,BenchmarkIndexSearch-8,2.75,0.00,0.00
 31e546a,BenchmarkLoadGlobalConfig-8,738.40,160.00,1.00
 31e546a,BenchmarkPadString-8,1.94,0.00,0.00
+08da645,BenchmarkCheckMetricsAndSwap-8,10.13,0.00,0.00
+08da645,BenchmarkCrushOptimized-8,352.00,0.00,0.00
+08da645,BenchmarkCrushOriginal-8,416.40,164.00,3.00
+08da645,BenchmarkIndexDirectTracking-8,0.46,0.00,0.00
+08da645,BenchmarkIndexSearch-8,3.02,0.00,0.00
+08da645,BenchmarkLoadGlobalConfig-8,724.70,160.00,1.00
+08da645,BenchmarkPadString-8,2.46,0.00,0.00

--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -38,3 +38,7 @@ suspicion_timeout=5
 fanout=3
 scatter_gather_timeout=5
 lease_timeout=10
+
+[storage]
+gc_interval=300
+tombstone_retention=86400

--- a/docs/P2P.md
+++ b/docs/P2P.md
@@ -209,3 +209,47 @@ The `LeaseManager` provides time-bound, self-expiring leases for destructive ope
 lease_timeout = 10  # seconds
 ```
 ```
+
+## CAS Garbage Collection
+
+The `src/storage` package implements reference-counted garbage collection for content-addressable blobs, with P2P delete propagation via scatter-gather.
+
+### Reference Counting
+
+- Each blob in the `objects` bucket stores an `ObjectMeta` struct: `{Size, RefCount, DeletedAt}`
+- `Put` increments `RefCount` when the blob already exists (deduplication)
+- `Delete` decrements `RefCount` and writes a tombstone
+- When `RefCount` reaches 0, the blob is eligible for GC
+
+### Tombstones
+
+- A `tombstones` bucket maps `FileName -> deletion timestamp` (unix nano)
+- Tombstoned entries are hidden from `List`, `Get`, and `GetBlobPath`
+- Tombstones support **resurrection**: re-`Put` of a tombstoned name clears the tombstone
+- `GetTombstones()` and `ApplyTombstone()` enable P2P tombstone exchange for eventual consistency
+
+### GC Sweeper
+
+- Background goroutine runs every `gc_interval` seconds (default 300 = 5 minutes)
+- **Sweep orphaned blobs**: removes on-disk blob files and `objects` entries with `RefCount=0`
+- **Sweep expired tombstones**: removes tombstones older than `tombstone_retention` (default 86400 = 24 hours)
+
+### P2P Delete Propagation
+
+- `QueryDelete` (type 4) is sent via scatter-gather to all peers when a delete occurs
+- `ScatterGatherDeleter` adapts `ScatterGather` to the `transport.DeletePropagator` interface
+- S3 `DELETE` and native delete handlers fan out deletes to all peers (best-effort)
+- Each peer applies the delete locally, writing its own tombstone
+
+### Backward Compatibility
+
+- Legacy `objects` bucket entries (ASCII size only) are automatically migrated on read
+- `decodeObjectMeta` detects the 24-byte binary format vs. legacy ASCII and falls back gracefully
+
+### Configuration
+
+```ini
+[storage]
+gc_interval = 300          # seconds (5 minutes)
+tombstone_retention = 86400 # seconds (24 hours)
+```

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        419.2n ± ∞ ¹    397.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       302.3n ± ∞ ¹    332.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     725.6n ± ∞ ¹    738.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.969n ± ∞ ¹    1.938n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.202n ± ∞ ¹    7.643n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.873n ± ∞ ¹    2.749n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3355n ± ∞ ¹   0.3611n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.95n          20.33n        +1.91%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        397.7n ± ∞ ¹    416.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       332.2n ± ∞ ¹    352.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     738.4n ± ∞ ¹    724.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.938n ± ∞ ¹    2.463n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.643n ± ∞ ¹   10.130n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.749n ± ∞ ¹    3.024n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3611n ± ∞ ¹   0.4620n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.33n          23.28n        +14.51%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.64 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 332.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 397.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 738.40 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.13 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 352.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 416.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 724.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.46 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a]
-    line "CheckMetricsAndSwap" [7,8,8,10,7,8,9,7,7,8]
-    line "CrushOptimized" [348,309,404,320,301,300,299,357,302,332]
-    line "CrushOriginal" [425,417,505,379,390,402,403,469,419,398]
+    x-axis [8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645]
+    line "CheckMetricsAndSwap" [8,8,10,7,8,9,7,7,8,10]
+    line "CrushOptimized" [309,404,320,301,300,299,357,302,332,352]
+    line "CrushOriginal" [417,505,379,390,402,403,469,419,398,416]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [775,740,707,702,701,999,732,736,726,738]
-    line "PadString" [2,2,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [740,707,702,701,999,732,736,726,738,725]
+    line "PadString" [2,3,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a]
+    x-axis [8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [657f261,8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a]
+    x-axis [8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        397.7n ± ∞ ¹    416.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       332.2n ± ∞ ¹    352.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     738.4n ± ∞ ¹    724.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.938n ± ∞ ¹    2.463n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.643n ± ∞ ¹   10.130n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.749n ± ∞ ¹    3.024n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3611n ± ∞ ¹   0.4620n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.33n          23.28n        +14.51%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        416.4n ± ∞ ¹    453.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       352.0n ± ∞ ¹    320.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     724.7n ± ∞ ¹    802.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.463n ± ∞ ¹    2.050n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.130n ± ∞ ¹    7.921n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.024n ± ∞ ¹    2.745n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4620n ± ∞ ¹   0.3631n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                23.28n          21.15n        -9.16%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.13 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 352.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 416.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 724.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.92 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 320.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 453.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 802.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.05 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645]
-    line "CheckMetricsAndSwap" [8,8,10,7,8,9,7,7,8,10]
-    line "CrushOptimized" [309,404,320,301,300,299,357,302,332,352]
-    line "CrushOriginal" [417,505,379,390,402,403,469,419,398,416]
+    x-axis [972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d]
+    line "CheckMetricsAndSwap" [8,10,7,8,9,7,7,8,10,8]
+    line "CrushOptimized" [404,320,301,300,299,357,302,332,352,321]
+    line "CrushOriginal" [505,379,390,402,403,469,419,398,416,453]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [740,707,702,701,999,732,736,726,738,725]
-    line "PadString" [2,3,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [707,702,701,999,732,736,726,738,725,803]
+    line "PadString" [3,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645]
+    x-axis [972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [8e4d25c,972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645]
+    x-axis [972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        416.4n ± ∞ ¹    453.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       352.0n ± ∞ ¹    320.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     724.7n ± ∞ ¹    802.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.463n ± ∞ ¹    2.050n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.130n ± ∞ ¹    7.921n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.024n ± ∞ ¹    2.745n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4620n ± ∞ ¹   0.3631n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                23.28n          21.15n        -9.16%
+CrushOriginal-8                        453.4n ± ∞ ¹    430.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       320.9n ± ∞ ¹    325.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     802.9n ± ∞ ¹    774.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.050n ± ∞ ¹    2.046n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.921n ± ∞ ¹    7.719n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.745n ± ∞ ¹    2.739n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3631n ± ∞ ¹   0.3311n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.15n          20.56n        -2.77%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,12 +53,12 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.92 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 320.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 453.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 802.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.72 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 325.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 430.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 774.50 ns/op | 160.00 B/op | 1.00 allocs/op |
 | BenchmarkPadString-8 | 2.05 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d]
-    line "CheckMetricsAndSwap" [8,10,7,8,9,7,7,8,10,8]
-    line "CrushOptimized" [404,320,301,300,299,357,302,332,352,321]
-    line "CrushOriginal" [505,379,390,402,403,469,419,398,416,453]
+    x-axis [8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d,d7ca92b]
+    line "CheckMetricsAndSwap" [10,7,8,9,7,7,8,10,8,8]
+    line "CrushOptimized" [320,301,300,299,357,302,332,352,321,325]
+    line "CrushOriginal" [379,390,402,403,469,419,398,416,453,430]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [707,702,701,999,732,736,726,738,725,803]
-    line "PadString" [3,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [702,701,999,732,736,726,738,725,803,774]
+    line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d]
+    x-axis [8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d,d7ca92b]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [972663f,8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d]
+    x-axis [8c819ce,ae29a5a,a899eb7,0a4d49a,cbc36a6,ea712a7,31e546a,08da645,260921d,d7ca92b]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -17,6 +17,8 @@ const (
 	sectionMetrics = "metrics"
 	// sectionP2P is the name of the [p2p] section in the configuration file.
 	sectionP2P = "p2p"
+	// sectionStorage is the name of the [storage] section in the configuration file.
+	sectionStorage = "storage"
 	// prefixDaemon is the prefix for daemon sections in the configuration file (e.g., [daemon.0]).
 	prefixDaemon = "daemon."
 )
@@ -63,6 +65,17 @@ func GetConfig(path string) (Configuration, error) {
 		if err != nil {
 			return Configuration{}, fmt.Errorf("failed to load [%s] section: %w", sectionP2P, err)
 		}
+	}
+
+	// Load [storage] section (optional, defaults to standard GC settings)
+	storageSec, err := cfg.GetSection(sectionStorage)
+	if err == nil {
+		config.Storage, err = loadStorageConfig(storageSec)
+		if err != nil {
+			return Configuration{}, fmt.Errorf("failed to load [%s] section: %w", sectionStorage, err)
+		}
+	} else {
+		config.Storage = defaultStorageConfig()
 	}
 
 	return config, nil
@@ -231,6 +244,32 @@ func loadP2PConfig(section *ini.Section) (ConfigurationP2P, error) {
 	}
 
 	return p2pCfg, nil
+}
+
+// defaultStorageConfig returns the default storage configuration.
+func defaultStorageConfig() ConfigurationStorage {
+	return ConfigurationStorage{
+		GCInterval:         300,
+		TombstoneRetention: 86400,
+	}
+}
+
+// loadStorageConfig loads the [storage] section from the configuration.
+func loadStorageConfig(section *ini.Section) (ConfigurationStorage, error) {
+	cfg := defaultStorageConfig()
+	var err error
+
+	cfg.GCInterval, err = section.Key("gc_interval").Int()
+	if err != nil || cfg.GCInterval <= 0 {
+		cfg.GCInterval = 300
+	}
+
+	cfg.TombstoneRetention, err = section.Key("tombstone_retention").Int()
+	if err != nil || cfg.TombstoneRetention <= 0 {
+		cfg.TombstoneRetention = 86400
+	}
+
+	return cfg, nil
 }
 
 // loadDaemons loads all [daemon.*] sections from the configuration.

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -80,6 +80,14 @@ type ConfigurationP2P struct {
 	LeaseTimeout int
 }
 
+// ConfigurationStorage holds the storage and garbage collection configuration.
+type ConfigurationStorage struct {
+	// GCInterval is how often the garbage collector runs, in seconds.
+	GCInterval int
+	// TombstoneRetention is how long tombstones are kept, in seconds.
+	TombstoneRetention int
+}
+
 // Configuration holds the overall configuration for the application.
 type Configuration struct {
 	// Daemons is a list of daemons in the system.
@@ -90,4 +98,6 @@ type Configuration struct {
 	Metrics ConfigurationMetrics
 	// P2P is the P2P transport configuration.
 	P2P ConfigurationP2P
+	// Storage is the storage and GC configuration.
+	Storage ConfigurationStorage
 }

--- a/src/p2p/types.go
+++ b/src/p2p/types.go
@@ -204,9 +204,10 @@ func DecodeHeartbeatPayload(data []byte) (*HeartbeatPayload, error) {
 type QueryType uint8
 
 const (
-	QueryList QueryType = 1
-	QueryGet  QueryType = 2
-	QueryHas  QueryType = 3
+	QueryList   QueryType = 1
+	QueryGet    QueryType = 2
+	QueryHas    QueryType = 3
+	QueryDelete QueryType = 4
 )
 
 // QueryPayload is the payload of a MsgQuery RPC.

--- a/src/server/p2p_adapters.go
+++ b/src/server/p2p_adapters.go
@@ -72,3 +72,23 @@ func (l *LeaseAcquirerAdapter) ReleaseLease(key string) error {
 	}
 	return l.lm.ReleaseByKey(key)
 }
+
+// ScatterGatherDeleter adapts p2p.ScatterGather to the transport.DeletePropagator interface.
+type ScatterGatherDeleter struct {
+	sg      *p2p.ScatterGather
+	timeout time.Duration
+}
+
+// NewScatterGatherDeleter creates a new ScatterGatherDeleter adapter.
+func NewScatterGatherDeleter(sg *p2p.ScatterGather, timeout time.Duration) *ScatterGatherDeleter {
+	return &ScatterGatherDeleter{sg: sg, timeout: timeout}
+}
+
+// PropagateDelete fans out a delete operation to all peers via scatter-gather.
+func (d *ScatterGatherDeleter) PropagateDelete(key string, timeout time.Duration) error {
+	if d.sg == nil {
+		return nil
+	}
+	d.sg.Query(p2p.QueryDelete, []byte(key), timeout)
+	return nil
+}

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/binary"
 	"fmt"
+	"syscall"
 
 	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/p2p"
@@ -79,7 +80,7 @@ func (h *StorageQueryHandler) handleHas(data []byte) ([]byte, error) {
 // This is invoked by remote peers via scatter-gather to propagate deletes.
 func (h *StorageQueryHandler) handleDelete(data []byte) ([]byte, error) {
 	if len(data) == 0 {
-		return nil, fmt.Errorf("empty file name")
+		return nil, fmt.Errorf("empty file name: %w", syscall.EINVAL)
 	}
 	name := string(data)
 	if err := h.store.Delete(name); err != nil {

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -29,6 +29,8 @@ func (h *StorageQueryHandler) HandleQuery(qt p2p.QueryType, data []byte) ([]byte
 		return h.handleGet(data)
 	case p2p.QueryHas:
 		return h.handleHas(data)
+	case p2p.QueryDelete:
+		return h.handleDelete(data)
 	default:
 		return nil, fmt.Errorf("unknown query type: %d", qt)
 	}
@@ -70,6 +72,21 @@ func (h *StorageQueryHandler) handleHas(data []byte) ([]byte, error) {
 	if exists {
 		result[0] = 1
 	}
+	return result, nil
+}
+
+// handleDelete deletes a file by name from the local store.
+// This is invoked by remote peers via scatter-gather to propagate deletes.
+func (h *StorageQueryHandler) handleDelete(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty file name")
+	}
+	name := string(data)
+	if err := h.store.Delete(name); err != nil {
+		return nil, err
+	}
+	result := make([]byte, 1)
+	result[0] = 1
 	return result, nil
 }
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -48,6 +48,20 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 	}
 	defer store.Close()
 
+	// Start garbage collector
+	gcInterval := time.Duration(cfg.Storage.GCInterval) * time.Second
+	if gcInterval <= 0 {
+		gcInterval = 5 * time.Minute
+	}
+	tombstoneRetention := time.Duration(cfg.Storage.TombstoneRetention) * time.Second
+	if tombstoneRetention <= 0 {
+		tombstoneRetention = 24 * time.Hour
+	}
+	store.StartGC(storage.GCConfig{
+		Interval:           gcInterval,
+		TombstoneRetention: tombstoneRetention,
+	})
+
 	server, err := factory.Listen(daemons[serverId].Host)
 	if err != nil {
 		return fmt.Errorf("Error listening: %v", err)
@@ -137,6 +151,12 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 			if scatterGather != nil {
 				if glComm, ok := comm.(interface{ SetGlobalLister(transport.GlobalLister) }); ok {
 					glComm.SetGlobalLister(NewScatterGatherLister(scatterGather,
+						time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
+				}
+				if dpComm, ok := comm.(interface {
+					SetDeletePropagator(transport.DeletePropagator)
+				}); ok {
+					dpComm.SetDeletePropagator(NewScatterGatherDeleter(scatterGather,
 						time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
 				}
 			}

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -1,0 +1,198 @@
+package storage
+
+import (
+	"encoding/binary"
+	"log"
+	"os"
+	"time"
+
+	"go.etcd.io/bbolt"
+)
+
+// GCConfig configures the garbage collector.
+type GCConfig struct {
+	// Interval is how often the GC sweeper runs.
+	Interval time.Duration
+	// TombstoneRetention is how long tombstones are kept before expiring.
+	TombstoneRetention time.Duration
+}
+
+// DefaultGCConfig returns sensible defaults for the garbage collector.
+func DefaultGCConfig() GCConfig {
+	return GCConfig{
+		Interval:           5 * time.Minute,
+		TombstoneRetention: 24 * time.Hour,
+	}
+}
+
+// StartGC launches the background garbage collector goroutine.
+// It is safe to call at most once per CASStore instance.
+func (s *CASStore) StartGC(cfg GCConfig) {
+	s.gcWG.Add(1)
+	go s.gcLoop(cfg)
+}
+
+func (s *CASStore) gcLoop(cfg GCConfig) {
+	defer s.gcWG.Done()
+
+	ticker := time.NewTicker(cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.gcDone:
+			return
+		case <-ticker.C:
+			if err := s.runGC(cfg); err != nil {
+				log.Printf("CAS GC: sweep error: %v", err)
+			}
+		}
+	}
+}
+
+func (s *CASStore) runGC(cfg GCConfig) error {
+	if err := s.sweepOrphanedBlobs(); err != nil {
+		return err
+	}
+	return s.sweepExpiredTombstones(cfg.TombstoneRetention)
+}
+
+// sweepOrphanedBlobs removes blob files and objects entries with RefCount=0.
+func (s *CASStore) sweepOrphanedBlobs() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var orphanedHashes []string
+
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		obj := tx.Bucket(bucketObjects)
+		c := obj.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(v) != 24 {
+				continue
+			}
+			meta := decodeObjectMeta(v)
+			if meta.RefCount <= 0 {
+				hash := string(k)
+				blobPath := s.getBlobPath(hash)
+				if err := os.Remove(blobPath); err != nil && !os.IsNotExist(err) {
+					log.Printf("CAS GC: failed to remove blob %s: %v", blobPath, err)
+					continue
+				}
+				orphanedHashes = append(orphanedHashes, hash)
+			}
+		}
+
+		for _, hash := range orphanedHashes {
+			obj.Delete([]byte(hash))
+		}
+		return nil
+	})
+
+	if len(orphanedHashes) > 0 {
+		log.Printf("CAS GC: removed %d orphaned blob(s)", len(orphanedHashes))
+	}
+	return err
+}
+
+// sweepExpiredTombstones removes tombstones older than the retention period.
+func (s *CASStore) sweepExpiredTombstones(retention time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().Add(-retention).UnixNano()
+	var expiredNames [][]byte
+
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		ts := tx.Bucket(bucketTombstones)
+		c := ts.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(v) < 8 {
+				expiredNames = append(expiredNames, k)
+				continue
+			}
+			deletedAt := int64(binary.BigEndian.Uint64(v[:8]))
+			if deletedAt < cutoff {
+				expiredNames = append(expiredNames, k)
+			}
+		}
+
+		for _, name := range expiredNames {
+			ts.Delete(name)
+		}
+		return nil
+	})
+
+	if len(expiredNames) > 0 {
+		log.Printf("CAS GC: expired %d tombstone(s)", len(expiredNames))
+	}
+	return err
+}
+
+// GetTombstones returns all active tombstones (name -> deletion timestamp).
+// This enables P2P nodes to exchange delete information for eventual consistency.
+func (s *CASStore) GetTombstones() (map[string]int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tombstones := make(map[string]int64)
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		ts := tx.Bucket(bucketTombstones)
+		if ts == nil {
+			return nil
+		}
+		c := ts.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(v) >= 8 {
+				tombstones[string(k)] = int64(binary.BigEndian.Uint64(v[:8]))
+			}
+		}
+		return nil
+	})
+	return tombstones, err
+}
+
+// ApplyTombstone records a tombstone for a name that was deleted on a remote peer.
+// This is used during P2P tombstone exchange to propagate deletes.
+func (s *CASStore) ApplyTombstone(name string, deletedAt int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		ts := tx.Bucket(bucketTombstones)
+		existing := ts.Get([]byte(name))
+		if existing != nil {
+			existingTs := int64(binary.BigEndian.Uint64(existing[:8]))
+			if existingTs >= deletedAt {
+				return nil
+			}
+		}
+
+		var buf [8]byte
+		binary.BigEndian.PutUint64(buf[:], uint64(deletedAt))
+		if err := ts.Put([]byte(name), buf[:]); err != nil {
+			return err
+		}
+
+		ns := tx.Bucket(bucketNamespace)
+		paths := tx.Bucket(bucketPaths)
+		obj := tx.Bucket(bucketObjects)
+
+		h := ns.Get([]byte(name))
+		if h != nil {
+			hash := string(h)
+			if val := obj.Get([]byte(hash)); val != nil {
+				meta := decodeObjectMeta(val)
+				meta.RefCount--
+				if meta.RefCount <= 0 {
+					meta.RefCount = 0
+					meta.DeletedAt = deletedAt
+				}
+				obj.Put([]byte(hash), meta.encode())
+			}
+		}
+		ns.Delete([]byte(name))
+		paths.Delete([]byte(name))
+		return nil
+	})
+}

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -2,8 +2,10 @@ package storage
 
 import (
 	"encoding/binary"
+	"fmt"
 	"log"
 	"os"
+	"syscall"
 	"time"
 
 	"go.etcd.io/bbolt"
@@ -55,7 +57,13 @@ func (s *CASStore) gcLoop(cfg GCConfig) {
 	}
 }
 
-func (s *CASStore) runGC(cfg GCConfig) error {
+func (s *CASStore) runGC(cfg GCConfig) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CAS GC: runGC panic recovered: %v", r)
+			err = fmt.Errorf("CAS GC panic: %w", syscall.EIO)
+		}
+	}()
 	if err := s.sweepOrphanedBlobs(); err != nil {
 		return err
 	}

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -34,6 +34,11 @@ func (s *CASStore) StartGC(cfg GCConfig) {
 
 func (s *CASStore) gcLoop(cfg GCConfig) {
 	defer s.gcWG.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CAS GC: gcLoop panic recovered: %v", r)
+		}
+	}()
 
 	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()

--- a/src/storage/gc_test.go
+++ b/src/storage/gc_test.go
@@ -1,0 +1,439 @@
+package storage
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"go.etcd.io/bbolt"
+	"go.uber.org/goleak"
+)
+
+func TestRefcountDedupDelete(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("shared content")
+	hash := "aaa111bbb222ccc333ddd444eee555f"
+	store.Put("file_a.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+	store.Put("file_b.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	// Both names should resolve
+	rc, _, err := store.Get("file_a.txt")
+	if err != nil {
+		t.Fatalf("Get file_a.txt failed: %v", err)
+	}
+	rc.Close()
+
+	rc, _, err = store.Get("file_b.txt")
+	if err != nil {
+		t.Fatalf("Get file_b.txt failed: %v", err)
+	}
+	rc.Close()
+
+	// Delete one name — the other should still work
+	if err := store.Delete("file_a.txt"); err != nil {
+		t.Fatalf("Delete file_a.txt failed: %v", err)
+	}
+
+	// file_a should be gone
+	_, _, err = store.Get("file_a.txt")
+	if err == nil {
+		t.Fatal("Expected error getting deleted file_a.txt")
+	}
+
+	// file_b should still work
+	rc, _, err = store.Get("file_b.txt")
+	if err != nil {
+		t.Fatalf("Get file_b.txt after deleting file_a.txt failed: %v", err)
+	}
+	rc.Close()
+
+	// Blob file should still exist on disk
+	blobPath := store.getBlobPath(hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatal("Blob file removed while refcount > 0")
+	}
+}
+
+func TestTombstoneHidesFromListAndGet(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("tombstoned content")
+	hash := "bbb222ccc333ddd444eee555f666777"
+	store.Put("todelete.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	if err := store.Delete("todelete.txt"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// List should not include the deleted file
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	for _, f := range list {
+		if f.Name == "todelete.txt" {
+			t.Fatal("Deleted file appeared in List")
+		}
+	}
+
+	// Get should return ENOENT
+	_, _, err = store.Get("todelete.txt")
+	if err == nil {
+		t.Fatal("Expected error getting tombstoned file")
+	}
+
+	// GetBlobPath should also return ENOENT
+	_, err = store.GetBlobPath("todelete.txt")
+	if err == nil {
+		t.Fatal("Expected error getting blob path for tombstoned file")
+	}
+}
+
+func TestGCSweeperRemovesOrphanedBlobs(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("gc me")
+	hash := "ccc333ddd444eee555f666777888aaa"
+	store.Put("gc_target.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	blobPath := store.getBlobPath(hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatal("Blob file should exist before GC")
+	}
+
+	// Delete the only name — refcount drops to 0
+	if err := store.Delete("gc_target.txt"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Run GC sweep manually
+	if err := store.sweepOrphanedBlobs(); err != nil {
+		t.Fatalf("sweepOrphanedBlobs failed: %v", err)
+	}
+
+	// Blob file should be gone
+	if _, err := os.Stat(blobPath); !os.IsNotExist(err) {
+		t.Fatal("Blob file should be removed by GC")
+	}
+
+	// Has should return false
+	exists, _ := store.Has(hash)
+	if exists {
+		t.Fatal("Has should return false after GC removed the blob")
+	}
+}
+
+func TestGCSweeperKeepsReferencedBlobs(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("keep me")
+	hash := "ddd444eee555f666777888aaa999bbb"
+	store.Put("keep.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	// Run GC — nothing should be removed
+	if err := store.sweepOrphanedBlobs(); err != nil {
+		t.Fatalf("sweepOrphanedBlobs failed: %v", err)
+	}
+
+	blobPath := store.getBlobPath(hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatal("Blob file should still exist — refcount > 0")
+	}
+}
+
+func TestTombstoneExpiry(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("expire me")
+	hash := "eee555f666777888aaa999bbbccc111"
+	store.Put("expire.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+	store.Delete("expire.txt")
+
+	// Tombstone should exist
+	ts, err := store.GetTombstones()
+	if err != nil {
+		t.Fatalf("GetTombstones failed: %v", err)
+	}
+	if len(ts) != 1 {
+		t.Fatalf("Expected 1 tombstone, got %d", len(ts))
+	}
+
+	// Expire tombstones with 0 retention (everything expires)
+	if err := store.sweepExpiredTombstones(0); err != nil {
+		t.Fatalf("sweepExpiredTombstones failed: %v", err)
+	}
+
+	ts, err = store.GetTombstones()
+	if err != nil {
+		t.Fatalf("GetTombstones failed: %v", err)
+	}
+	if len(ts) != 0 {
+		t.Fatalf("Expected 0 tombstones after expiry, got %d", len(ts))
+	}
+}
+
+func TestResurrection(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("resurrect me")
+	hash := "fff666777888aaa999bbbccc111222"
+	store.Put("resurrect.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+	store.Delete("resurrect.txt")
+
+	// Should be tombstoned
+	_, _, err = store.Get("resurrect.txt")
+	if err == nil {
+		t.Fatal("Expected error after delete")
+	}
+
+	// Resurrect by putting again
+	store.Put("resurrect.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	// Should work again
+	rc, _, err := store.Get("resurrect.txt")
+	if err != nil {
+		t.Fatalf("Get after resurrection failed: %v", err)
+	}
+	rc.Close()
+
+	// Should appear in List
+	list, _ := store.List()
+	found := false
+	for _, f := range list {
+		if f.Name == "resurrect.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Resurrected file not found in List")
+	}
+
+	// Tombstone should be gone
+	ts, _ := store.GetTombstones()
+	if len(ts) != 0 {
+		t.Fatalf("Expected 0 tombstones after resurrection, got %d", len(ts))
+	}
+}
+
+func TestApplyTombstoneFromRemote(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("remote delete")
+	hash := "111777888aaa999bbbccc111222333"
+	store.Put("remote.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	// Apply tombstone from a remote peer
+	deletedAt := time.Now().UnixNano()
+	if err := store.ApplyTombstone("remote.txt", deletedAt); err != nil {
+		t.Fatalf("ApplyTombstone failed: %v", err)
+	}
+
+	// Should be hidden from List and Get
+	_, _, err = store.Get("remote.txt")
+	if err == nil {
+		t.Fatal("Expected error after applying remote tombstone")
+	}
+
+	list, _ := store.List()
+	for _, f := range list {
+		if f.Name == "remote.txt" {
+			t.Fatal("Tombstoned file appeared in List")
+		}
+	}
+
+	// Tombstone should exist
+	ts, _ := store.GetTombstones()
+	if len(ts) != 1 {
+		t.Fatalf("Expected 1 tombstone, got %d", len(ts))
+	}
+}
+
+func TestGCBackgroundSweeper(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("bg gc")
+	hash := "222888aaa999bbbccc111222333444"
+	store.Put("bg_gc.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+	store.Delete("bg_gc.txt")
+
+	blobPath := store.getBlobPath(hash)
+
+	// Start GC with very short interval
+	store.StartGC(GCConfig{
+		Interval:           100 * time.Millisecond,
+		TombstoneRetention: 1 * time.Hour,
+	})
+
+	// Wait for GC to run
+	time.Sleep(500 * time.Millisecond)
+
+	// Blob should be gone
+	if _, err := os.Stat(blobPath); !os.IsNotExist(err) {
+		t.Fatal("Blob file should be removed by background GC")
+	}
+}
+
+func TestQueryDeleteHandler(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("handler delete")
+	hash := "333999bbbccc111222333444555666"
+	store.Put("handler.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	// Verify it exists
+	rc, _, err := store.Get("handler.txt")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	rc.Close()
+
+	// Delete via store.Delete (simulating what QueryDelete handler does)
+	if err := store.Delete("handler.txt"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify it's gone
+	_, _, err = store.Get("handler.txt")
+	if err == nil {
+		t.Fatal("Expected error after delete")
+	}
+}
+
+func TestLegacyObjectMetaCompatibility(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	// Manually write a legacy-format object (ASCII size, no refcount)
+	hash := "444aaa111222333444555666777888"
+
+	store.mu.Lock()
+	store.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketObjects).Put([]byte(hash), []byte("6"))
+	})
+	store.mu.Unlock()
+
+	// Decode should handle legacy format
+	meta := decodeObjectMeta([]byte("6"))
+	if meta.Size != 6 || meta.RefCount != 1 || meta.DeletedAt != 0 {
+		t.Fatalf("Legacy decode wrong: %+v", meta)
+	}
+
+	// New format should encode/decode correctly
+	newMeta := ObjectMeta{Size: 42, RefCount: 3, DeletedAt: 12345}
+	encoded := newMeta.encode()
+	decoded := decodeObjectMeta(encoded)
+	if decoded != newMeta {
+		t.Fatalf("Round-trip failed: %+v != %+v", decoded, newMeta)
+	}
+}

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bufio"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
@@ -10,7 +11,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
-	"unsafe"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	"go.etcd.io/bbolt"
@@ -18,10 +19,43 @@ import (
 
 // Buckets used in Bbolt
 var (
-	bucketObjects   = []byte("objects")   // Maps ContentHash -> {Metadata JSON}
-	bucketNamespace = []byte("namespace") // Maps FileName -> ContentHash
-	bucketPaths     = []byte("paths")     // Maps FileName -> RemotePath
+	bucketObjects    = []byte("objects")    // Maps ContentHash -> {ObjectMeta binary}
+	bucketNamespace  = []byte("namespace")  // Maps FileName -> ContentHash
+	bucketPaths      = []byte("paths")      // Maps FileName -> RemotePath
+	bucketTombstones = []byte("tombstones") // Maps FileName -> deletion timestamp (unix nano)
 )
+
+// ObjectMeta is the binary metadata stored in the objects bucket.
+// Wire format: [8B size (big-endian)] [8B refCount (big-endian)] [8B deletedAt (big-endian)]
+type ObjectMeta struct {
+	Size      int64
+	RefCount  int64
+	DeletedAt int64 // unix nano; 0 = not deleted
+}
+
+// encodeObjectMeta serializes ObjectMeta into a fixed 24-byte binary slice.
+func (m ObjectMeta) encode() []byte {
+	buf := make([]byte, 24)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(m.Size))
+	binary.BigEndian.PutUint64(buf[8:16], uint64(m.RefCount))
+	binary.BigEndian.PutUint64(buf[16:24], uint64(m.DeletedAt))
+	return buf
+}
+
+// decodeObjectMeta deserializes a 24-byte binary slice into ObjectMeta.
+// Falls back to legacy ASCII size format for backward compatibility.
+func decodeObjectMeta(val []byte) ObjectMeta {
+	if len(val) == 24 {
+		return ObjectMeta{
+			Size:      int64(binary.BigEndian.Uint64(val[0:8])),
+			RefCount:  int64(binary.BigEndian.Uint64(val[8:16])),
+			DeletedAt: int64(binary.BigEndian.Uint64(val[16:24])),
+		}
+	}
+	// Legacy format: ASCII integer = size only, refCount=1, not deleted
+	size, _ := strconv.ParseInt(string(val), 10, 64)
+	return ObjectMeta{Size: size, RefCount: 1}
+}
 
 // Store defines the interface for object storage operations.
 type Store interface {
@@ -39,6 +73,8 @@ type CASStore struct {
 	mu     sync.RWMutex
 	db     *bbolt.DB
 	base   string
+	gcDone chan struct{}
+	gcWG   sync.WaitGroup
 }
 
 // NewCASStore initializes a new CAS storage backend.
@@ -61,7 +97,10 @@ func NewCASStore(dataDir string) (*CASStore, error) {
 		if _, err := tx.CreateBucketIfNotExists(bucketNamespace); err != nil {
 			return err
 		}
-		_, err := tx.CreateBucketIfNotExists(bucketPaths)
+		if _, err := tx.CreateBucketIfNotExists(bucketPaths); err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(bucketTombstones)
 		return err
 	})
 	if err != nil {
@@ -70,12 +109,17 @@ func NewCASStore(dataDir string) (*CASStore, error) {
 	}
 
 	return &CASStore{
-		db:   db,
-		base: dataDir,
+		db:     db,
+		base:   dataDir,
+		gcDone: make(chan struct{}),
 	}, nil
 }
 
 func (s *CASStore) Close() error {
+	if s.gcDone != nil {
+		close(s.gcDone)
+		s.gcWG.Wait()
+	}
 	return s.db.Close()
 }
 
@@ -115,7 +159,7 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 			os.Remove(tmpPath)
 			return fmt.Errorf("storage error: failed to write blob: %w", syscall.ENOSPC)
 		}
-		
+
 		if err := writer.Flush(); err != nil {
 			tmpFile.Close()
 			os.Remove(tmpPath)
@@ -137,13 +181,20 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 		}
 
 		obj := tx.Bucket(bucketObjects)
-		// ⚡ Bolt: Store size as a simple 8-byte binary value for speed.
-		// In a full implementation, we would store a JSON struct with RefCount.
-		// ⚡ Bolt: Eliminate heap allocation and GC overhead for number to byte slice conversion
-		var sizeBuf [32]byte
-		if err := obj.Put([]byte(hash), strconv.AppendInt(sizeBuf[:0], size, 10)); err != nil {
+		// Update or create object metadata with reference counting.
+		var meta ObjectMeta
+		if existing := obj.Get([]byte(hash)); existing != nil {
+			meta = decodeObjectMeta(existing)
+			meta.RefCount++
+		} else {
+			meta = ObjectMeta{Size: size, RefCount: 1}
+		}
+		if err := obj.Put([]byte(hash), meta.encode()); err != nil {
 			return fmt.Errorf("metadata error: %w", syscall.EIO)
 		}
+
+		// Remove any existing tombstone for this name (resurrection).
+		tx.Bucket(bucketTombstones).Delete([]byte(name))
 
 		// Store RemotePath
 		if remotePath != "" {
@@ -178,6 +229,10 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 
 	var hash string
 	err = s.db.View(func(tx *bbolt.Tx) error {
+		// Check tombstone first — deleted names should appear as not found.
+		if ts := tx.Bucket(bucketTombstones).Get([]byte(name)); ts != nil {
+			return syscall.ENOENT
+		}
 		h := tx.Bucket(bucketNamespace).Get([]byte(name))
 		if h == nil {
 			return syscall.ENOENT
@@ -206,19 +261,13 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 	var size int64
 	err = s.db.View(func(tx *bbolt.Tx) error {
 		val := tx.Bucket(bucketObjects).Get([]byte(hash))
-		// 🛡️ Zero-Crash: Guard against missing metadata to prevent nil pointer dereference in unsafe.SliceData.
 		if val == nil {
 			return fmt.Errorf("metadata missing for hash %s: %w", hash, syscall.ENOENT)
 		}
 
-		// ⚡ Bolt: Eliminate allocs and overhead of fmt.Sscanf by using strconv.ParseInt with unsafe.String.
-		var parseErr error
-		size, parseErr = strconv.ParseInt(unsafe.String(unsafe.SliceData(val), len(val)), 10, 64)
-		if parseErr != nil {
-			return fmt.Errorf("metadata corruption for hash %s: %w", hash, syscall.EBADMSG)
-		}
+		meta := decodeObjectMeta(val)
+		size = meta.Size
 
-		// 🛡️ Zero-Crash: Ensure size is non-negative to prevent downstream overflows or invalid allocations.
 		if size < 0 {
 			return fmt.Errorf("invalid size %d for hash %s: %w", size, hash, syscall.EBADMSG)
 		}
@@ -274,10 +323,44 @@ func (s *CASStore) Delete(name string) (err error) {
 		}
 	}()
 
-	// Simple deletion of the namespace entry. 
-	// Real CAS would implement reference counting and garbage collection for the blobs.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UnixNano()
 	return s.db.Update(func(tx *bbolt.Tx) error {
-		return tx.Bucket(bucketNamespace).Delete([]byte(name))
+		ns := tx.Bucket(bucketNamespace)
+		obj := tx.Bucket(bucketObjects)
+		paths := tx.Bucket(bucketPaths)
+		ts := tx.Bucket(bucketTombstones)
+
+		// Write tombstone (8-byte unix nano timestamp).
+		var tsBuf [8]byte
+		binary.BigEndian.PutUint64(tsBuf[:], uint64(now))
+		if err := ts.Put([]byte(name), tsBuf[:]); err != nil {
+			return fmt.Errorf("metadata error: %w", syscall.EIO)
+		}
+
+		// Look up the hash for this name to decrement refcount.
+		h := ns.Get([]byte(name))
+		if h != nil {
+			hash := string(h)
+			if val := obj.Get([]byte(hash)); val != nil {
+				meta := decodeObjectMeta(val)
+				meta.RefCount--
+				if meta.RefCount <= 0 {
+					meta.RefCount = 0
+					meta.DeletedAt = now
+				}
+				if err := obj.Put([]byte(hash), meta.encode()); err != nil {
+					return fmt.Errorf("metadata error: %w", syscall.EIO)
+				}
+			}
+		}
+
+		// Remove namespace and paths entries.
+		ns.Delete([]byte(name))
+		paths.Delete([]byte(name))
+		return nil
 	})
 }
 
@@ -301,22 +384,25 @@ func (s *CASStore) List() (list []common.FileMetadata, err error) {
 		}
 		obj := tx.Bucket(bucketObjects)
 		paths := tx.Bucket(bucketPaths)
+		ts := tx.Bucket(bucketTombstones)
 
 		c := ns.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			name := string(k)
 			hash := string(v)
+
+			// Skip tombstoned entries.
+			if ts != nil && ts.Get(k) != nil {
+				continue
+			}
+
 			var size int64 = 0
 			var remotePath string = ""
 
 			if obj != nil {
 				sizeBytes := obj.Get(v)
 				if len(sizeBytes) > 0 {
-					var parseErr error
-					size, parseErr = strconv.ParseInt(unsafe.String(unsafe.SliceData(sizeBytes), len(sizeBytes)), 10, 64)
-					if parseErr != nil {
-						log.Printf("WARNING: metadata corruption for hash %s in List: %v", hash, parseErr)
-					}
+					size = decodeObjectMeta(sizeBytes).Size
 				}
 			}
 
@@ -354,6 +440,9 @@ func (s *CASStore) GetBlobPath(name string) (path string, err error) {
 
 	var hash string
 	err = s.db.View(func(tx *bbolt.Tx) error {
+		if ts := tx.Bucket(bucketTombstones).Get([]byte(name)); ts != nil {
+			return syscall.ENOENT
+		}
 		h := tx.Bucket(bucketNamespace).Get([]byte(name))
 		if h == nil {
 			return syscall.ENOENT

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -163,7 +163,7 @@ func TestCASStore_EdgeCases(t *testing.T) {
 
 	// 4. Panic recovery tests (Rule 4) via nil database
 	nilStore := &CASStore{}
-	
+
 	_, _, err = nilStore.Get("test.txt")
 	if err == nil {
 		t.Errorf("Expected Get on nilStore to fail")

--- a/src/transport/communicator.go
+++ b/src/transport/communicator.go
@@ -37,6 +37,12 @@ type LeaseAcquirer interface {
 	ReleaseLease(key string) error
 }
 
+// DeletePropagator enables P2P propagation of delete operations across the cluster.
+// When set on a Communicator, delete operations fan out to all peers.
+type DeletePropagator interface {
+	PropagateDelete(key string, timeout time.Duration) error
+}
+
 // Communicator defines a transport-agnostic interface for Momo protocol operations.
 // It encapsulates the handshake, metadata exchange, and file transfer logic.
 type Communicator interface {

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -29,10 +29,11 @@ import (
 // MomoQUICCommunicator implements the Communicator interface for the Momo protocol over QUIC.
 type MomoQUICCommunicator struct {
 	*quic.Stream
-	conn          *quic.Conn
-	store         storage.Store
-	globalLister  GlobalLister
-	leaseAcquirer LeaseAcquirer
+	conn             *quic.Conn
+	store            storage.Store
+	globalLister     GlobalLister
+	leaseAcquirer    LeaseAcquirer
+	deletePropagator DeletePropagator
 }
 
 // NewMomoQUICCommunicator creates a new MomoQUICCommunicator.
@@ -55,6 +56,11 @@ func (m *MomoQUICCommunicator) SetGlobalLister(gl GlobalLister) {
 // SetLeaseAcquirer sets the lease-based consensus capability.
 func (m *MomoQUICCommunicator) SetLeaseAcquirer(la LeaseAcquirer) {
 	m.leaseAcquirer = la
+}
+
+// SetDeletePropagator sets the P2P delete propagation capability.
+func (m *MomoQUICCommunicator) SetDeletePropagator(dp DeletePropagator) {
+	m.deletePropagator = dp
 }
 
 func (m *MomoQUICCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
@@ -240,6 +246,10 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		if err != nil {
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("failed to delete file: %w", err)
+		}
+
+		if m.deletePropagator != nil {
+			_ = m.deletePropagator.PropagateDelete(fileName, 5*time.Second)
 		}
 
 		m.Write([]byte{'0'}) // success status

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -23,9 +23,10 @@ const hashLength = 64
 // MomoTCPCommunicator implements the Communicator interface for the legacy Momo TCP protocol.
 type MomoTCPCommunicator struct {
 	*common.IdleTimeoutConn
-	store         storage.Store
-	globalLister  GlobalLister
-	leaseAcquirer LeaseAcquirer
+	store            storage.Store
+	globalLister     GlobalLister
+	leaseAcquirer    LeaseAcquirer
+	deletePropagator DeletePropagator
 }
 
 // NewMomoTCPCommunicator creates a new MomoTCPCommunicator wrapping a net.Conn.
@@ -47,6 +48,11 @@ func (m *MomoTCPCommunicator) SetGlobalLister(gl GlobalLister) {
 // SetLeaseAcquirer sets the lease-based consensus capability.
 func (m *MomoTCPCommunicator) SetLeaseAcquirer(la LeaseAcquirer) {
 	m.leaseAcquirer = la
+}
+
+// SetDeletePropagator sets the P2P delete propagation capability.
+func (m *MomoTCPCommunicator) SetDeletePropagator(dp DeletePropagator) {
+	m.deletePropagator = dp
 }
 
 func (m *MomoTCPCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
@@ -231,6 +237,10 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		if err != nil {
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("failed to delete file: %w", err)
+		}
+
+		if m.deletePropagator != nil {
+			_ = m.deletePropagator.PropagateDelete(fileName, 5*time.Second)
 		}
 
 		m.Write([]byte{'0'}) // success status

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -68,6 +68,8 @@ type S3Communicator struct {
 	globalLister GlobalLister
 	// LeaseAcquirer for lease-based consensus on deletes (optional)
 	leaseAcquirer LeaseAcquirer
+	// DeletePropagator for P2P delete fan-out (optional)
+	deletePropagator DeletePropagator
 }
 
 func NewS3Communicator(conn net.Conn) *S3Communicator {
@@ -92,6 +94,11 @@ func (m *S3Communicator) SetGlobalLister(gl GlobalLister) {
 // SetLeaseAcquirer sets the lease-based consensus capability.
 func (m *S3Communicator) SetLeaseAcquirer(la LeaseAcquirer) {
 	m.leaseAcquirer = la
+}
+
+// SetDeletePropagator sets the P2P delete propagation capability.
+func (m *S3Communicator) SetDeletePropagator(dp DeletePropagator) {
+	m.deletePropagator = dp
 }
 
 func (m *S3Communicator) Read(p []byte) (n int, err error) {
@@ -372,6 +379,11 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 			return 0, 0, fmt.Errorf("failed to delete file %q: %w", key, err)
+		}
+
+		// Propagate delete to all peers via scatter-gather (best-effort).
+		if m.deletePropagator != nil {
+			_ = m.deletePropagator.PropagateDelete(key, 5*time.Second)
 		}
 
 		m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))


### PR DESCRIPTION
## Summary

Implements Phase 4 of the P2P roadmap: CAS garbage collection with reference counting, tombstones, and P2P delete propagation.

## Changes

### Storage Layer ()
- **ObjectMeta** struct with `Size`, `RefCount`, `DeletedAt` — replaces legacy ASCII size in the `objects` bucket (backward compatible via `decodeObjectMeta` fallback)
- **Tombstones bucket** — maps deleted file names to deletion timestamps; hides deleted entries from `List`, `Get`, `GetBlobPath`
- **Reference counting** — `Put` increments `RefCount` for existing blobs (deduplication); `Delete` decrements it
- **GC sweeper** (`gc.go`) — background goroutine that removes orphaned blobs (`RefCount=0`) from disk and expires old tombstones
- **Resurrection** — re-`Put` of a tombstoned name clears the tombstone
- **P2P tombstone exchange** — `GetTombstones()` and `ApplyTombstone()` for cross-node delete reconciliation

### P2P Delete Propagation
- `QueryDelete` (type 4) added to scatter-gather query types
- `ScatterGatherDeleter` adapter implements `transport.DeletePropagator`
- S3 `DELETE`, TCP delete, and QUIC delete handlers fan out to all peers (best-effort)

### Configuration
- New `[storage]` config section with `gc_interval` (default 300s) and `tombstone_retention` (default 86400s)
- GC starts automatically in `RunDaemon` with safe defaults for zero values

### Tests
- 10 new tests in `gc_test.go`: refcount dedup, tombstone hiding, GC sweep, orphan cleanup, tombstone expiry, resurrection, remote tombstone application, background GC, delete handler, legacy compatibility

Resolves #354
