### PR TITLE
fix: close leaked ReadCloser in scatter-gather GET handler

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -939,3 +939,10 @@ d6596ea,BenchmarkIndexDirectTracking-8,0.48,0.00,0.00
 d6596ea,BenchmarkIndexSearch-8,3.55,0.00,0.00
 d6596ea,BenchmarkLoadGlobalConfig-8,826.20,160.00,1.00
 d6596ea,BenchmarkPadString-8,2.23,0.00,0.00
+62cb604,BenchmarkCheckMetricsAndSwap-8,13.58,0.00,0.00
+62cb604,BenchmarkCrushOptimized-8,321.50,0.00,0.00
+62cb604,BenchmarkCrushOriginal-8,399.10,164.00,3.00
+62cb604,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+62cb604,BenchmarkIndexSearch-8,2.93,0.00,0.00
+62cb604,BenchmarkLoadGlobalConfig-8,713.00,160.00,1.00
+62cb604,BenchmarkPadString-8,2.67,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -932,3 +932,10 @@ fe6238e,BenchmarkPadString-8,2.15,0.00,0.00
 831359c,BenchmarkIndexSearch-8,3.02,0.00,0.00
 831359c,BenchmarkLoadGlobalConfig-8,705.00,160.00,1.00
 831359c,BenchmarkPadString-8,1.85,0.00,0.00
+d6596ea,BenchmarkCheckMetricsAndSwap-8,11.70,0.00,0.00
+d6596ea,BenchmarkCrushOptimized-8,351.40,0.00,0.00
+d6596ea,BenchmarkCrushOriginal-8,468.00,164.00,3.00
+d6596ea,BenchmarkIndexDirectTracking-8,0.48,0.00,0.00
+d6596ea,BenchmarkIndexSearch-8,3.55,0.00,0.00
+d6596ea,BenchmarkLoadGlobalConfig-8,826.20,160.00,1.00
+d6596ea,BenchmarkPadString-8,2.23,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -925,3 +925,10 @@ fe6238e,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
 fe6238e,BenchmarkIndexSearch-8,2.77,0.00,0.00
 fe6238e,BenchmarkLoadGlobalConfig-8,819.30,160.00,1.00
 fe6238e,BenchmarkPadString-8,2.15,0.00,0.00
+831359c,BenchmarkCheckMetricsAndSwap-8,7.39,0.00,0.00
+831359c,BenchmarkCrushOptimized-8,331.10,0.00,0.00
+831359c,BenchmarkCrushOriginal-8,581.60,164.00,3.00
+831359c,BenchmarkIndexDirectTracking-8,0.31,0.00,0.00
+831359c,BenchmarkIndexSearch-8,3.02,0.00,0.00
+831359c,BenchmarkLoadGlobalConfig-8,705.00,160.00,1.00
+831359c,BenchmarkPadString-8,1.85,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        581.6n ± ∞ ¹    468.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       331.1n ± ∞ ¹    351.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     705.0n ± ∞ ¹    826.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.849n ± ∞ ¹    2.235n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.391n ± ∞ ¹   11.700n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.020n ± ∞ ¹    3.552n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3125n ± ∞ ¹   0.4821n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.92n          24.99n        +19.47%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        468.0n ± ∞ ¹    399.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       351.4n ± ∞ ¹    321.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     826.2n ± ∞ ¹    713.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.235n ± ∞ ¹    2.673n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  11.70n ± ∞ ¹    13.58n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.552n ± ∞ ¹    2.933n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4821n ± ∞ ¹   0.3549n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.99n          23.05n        -7.76%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 351.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 468.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.48 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 826.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.23 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 13.58 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 321.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 399.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 713.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.67 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea]
-    line "CheckMetricsAndSwap" [7,11,7,8,7,10,7,8,7,12]
-    line "CrushOptimized" [319,306,322,331,314,307,316,366,331,351]
-    line "CrushOriginal" [432,419,412,468,404,405,397,454,582,468]
+    x-axis [7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604]
+    line "CheckMetricsAndSwap" [11,7,8,7,10,7,8,7,12,14]
+    line "CrushOptimized" [306,322,331,314,307,316,366,331,351,322]
+    line "CrushOriginal" [419,412,468,404,405,397,454,582,468,399]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,3,4]
-    line "LoadGlobalConfig" [800,757,741,774,714,913,686,819,705,826]
-    line "PadString" [2,2,2,2,2,2,2,2,2,2]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,4,3]
+    line "LoadGlobalConfig" [757,741,774,714,913,686,819,705,826,713]
+    line "PadString" [2,2,2,2,2,2,2,2,2,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea]
+    x-axis [7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea]
+    x-axis [7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        397.4n ± ∞ ¹    454.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       316.1n ± ∞ ¹    366.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     686.3n ± ∞ ¹    819.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.949n ± ∞ ¹    2.148n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.185n ± ∞ ¹    8.334n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.787n ± ∞ ¹    2.765n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3417n ± ∞ ¹   0.3336n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                19.70n          21.68n        +10.07%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        454.5n ± ∞ ¹    581.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       366.1n ± ∞ ¹    331.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     819.3n ± ∞ ¹    705.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.148n ± ∞ ¹    1.849n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.334n ± ∞ ¹    7.391n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.765n ± ∞ ¹    3.020n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3336n ± ∞ ¹   0.3125n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.68n          20.92n        -3.53%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 366.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 454.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.77 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 819.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 331.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 581.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 705.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.85 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6e93543,c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e]
-    line "CheckMetricsAndSwap" [7,9,7,11,7,8,7,10,7,8]
-    line "CrushOptimized" [348,334,319,306,322,331,314,307,316,366]
-    line "CrushOriginal" [441,441,432,419,412,468,404,405,397,454]
+    x-axis [c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c]
+    line "CheckMetricsAndSwap" [9,7,11,7,8,7,10,7,8,7]
+    line "CrushOptimized" [334,319,306,322,331,314,307,316,366,331]
+    line "CrushOriginal" [441,432,419,412,468,404,405,397,454,582]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [748,793,800,757,741,774,714,913,686,819]
+    line "LoadGlobalConfig" [793,800,757,741,774,714,913,686,819,705]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6e93543,c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e]
+    x-axis [c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6e93543,c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e]
+    x-axis [c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        454.5n ± ∞ ¹    581.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       366.1n ± ∞ ¹    331.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     819.3n ± ∞ ¹    705.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.148n ± ∞ ¹    1.849n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.334n ± ∞ ¹    7.391n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.765n ± ∞ ¹    3.020n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3336n ± ∞ ¹   0.3125n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                21.68n          20.92n        -3.53%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        581.6n ± ∞ ¹    468.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       331.1n ± ∞ ¹    351.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     705.0n ± ∞ ¹    826.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.849n ± ∞ ¹    2.235n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.391n ± ∞ ¹   11.700n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.020n ± ∞ ¹    3.552n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3125n ± ∞ ¹   0.4821n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.92n          24.99n        +19.47%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 331.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 581.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 705.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.85 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 351.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 468.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.48 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 826.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.23 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c]
-    line "CheckMetricsAndSwap" [9,7,11,7,8,7,10,7,8,7]
-    line "CrushOptimized" [334,319,306,322,331,314,307,316,366,331]
-    line "CrushOriginal" [441,432,419,412,468,404,405,397,454,582]
+    x-axis [2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea]
+    line "CheckMetricsAndSwap" [7,11,7,8,7,10,7,8,7,12]
+    line "CrushOptimized" [319,306,322,331,314,307,316,366,331,351]
+    line "CrushOriginal" [432,419,412,468,404,405,397,454,582,468]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [793,800,757,741,774,714,913,686,819,705]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,4]
+    line "LoadGlobalConfig" [800,757,741,774,714,913,686,819,705,826]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c]
+    x-axis [2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c06ea31,2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c]
+    x-axis [2140e40,7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 	"syscall"
 
 	"github.com/alsotoes/momo/src/common"
@@ -47,9 +48,16 @@ func (h *StorageQueryHandler) handleList() ([]byte, error) {
 }
 
 // handleGet returns metadata for a specific file.
-func (h *StorageQueryHandler) handleGet(data []byte) ([]byte, error) {
+func (h *StorageQueryHandler) handleGet(data []byte) (result []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in handleGet: %v", r)
+			err = fmt.Errorf("panic in handleGet: %v: %w", r, syscall.EIO)
+		}
+	}()
+
 	if len(data) == 0 {
-		return nil, fmt.Errorf("empty file name")
+		return nil, fmt.Errorf("empty file name: %w", syscall.EINVAL)
 	}
 	name := string(data)
 	rc, meta, err := h.store.Get(name)
@@ -57,7 +65,7 @@ func (h *StorageQueryHandler) handleGet(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	if rc != nil {
-		rc.Close()
+		defer rc.Close()
 	}
 	return EncodeFileMetadataList([]common.FileMetadata{meta}), nil
 }

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -52,9 +52,12 @@ func (h *StorageQueryHandler) handleGet(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("empty file name")
 	}
 	name := string(data)
-	_, meta, err := h.store.Get(name)
+	rc, meta, err := h.store.Get(name)
 	if err != nil {
 		return nil, err
+	}
+	if rc != nil {
+		rc.Close()
 	}
 	return EncodeFileMetadataList([]common.FileMetadata{meta}), nil
 }

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -104,6 +104,9 @@ func (h *StorageQueryHandler) handleDelete(data []byte) ([]byte, error) {
 
 // EncodeFileMetadataList serializes a list of FileMetadata into binary.
 // Format: [4B count] [for each: 4B nameLen + name + 4B hashLen + hash + 8B size + 4B pathLen + path]
+// Uses dynamic length prefixes (not fixed 64-byte buffers), so Rule 35's
+// 64-byte padding limit does not apply here. Buffer is pre-sized exactly
+// and copy() prevents overflow. Metadata comes from trusted local store.
 func EncodeFileMetadataList(files []common.FileMetadata) []byte {
 	size := 4
 	for _, f := range files {


### PR DESCRIPTION
Fixes #370

## Bug: File Descriptor Leak in Scatter-Gather GET Handler

**Severity:** High | **Category:** Resource leak | **Location:** `src/server/query_handler.go:55`

### Problem

`handleGet()` called `h.store.Get(name)` which returns an `io.ReadCloser` (an `*os.File` in the `CASStore` implementation). The `ReadCloser` was discarded with `_` and never closed. Every scatter-gather GET request leaked a file descriptor, eventually exhausting the process fd limit (`EMFILE`).

### Root Cause Code

```go
// query_handler.go:55 (BEFORE)
_, meta, err := h.store.Get(name)  // ReadCloser discarded, never closed
```

### Fix

```go
// query_handler.go (AFTER)
rc, meta, err := h.store.Get(name)
if err != nil {
    return nil, err
}
if rc != nil {
    defer rc.Close()
}
```

### Changelog (reviewer awareness)

#### Commit 1 (`d6596ea`) — Initial fix
- Captured the `ReadCloser` from `store.Get()` and closed it explicitly
- Basic fix: `rc.Close()` after the call since only metadata is needed

#### Commit 2 (`62cb604`) — Reviewer feedback (Rules 4, 37, 43)
- **Rule 37**: Added `defer recover()` with `syscall.EIO` error mapping for panic safety
- **Rule 43**: Changed `rc.Close()` to `defer rc.Close()` for panic-safe resource releasing
- **Rule 10**: Mapped empty file name error to `syscall.EINVAL` (POSIX compliance)
- Added `log` import for panic recovery logging

#### Commit 3 (`5d99f5c`) — Reviewer feedback (Rule 35 clarification)
- Added comment to `EncodeFileMetadataList` clarifying it uses dynamic 4B length prefixes
- Rule 35's 64-byte padding limit applies to TCP/QUIC wire protocol (`getMetadata` in `file.go`), not to scatter-gather serialization
- Buffer is pre-sized exactly and `copy()` prevents overflow
- Metadata comes from trusted local store, not untrusted wire input

### Reviewer Status
- **Review 1**: ❌ Required rework — missing defer recover, defer close, syscall mapping
- **Review 2**: Conditional ✅ — asked to verify Rule 35 for EncodeFileMetadataList
- **Review 3**: ✅ All Project Steering Rules and architectural patterns are respected

### Testing
- `go build ./src/server/...` — passes
- `go test ./src/server/...` — all tests pass
- CI: all 14 checks passing (build, smoke tests, E2E, load tests, gossip, contract)