### PR TITLE
fix: cap untrusted count in DecodeFileMetadataList to prevent OOM

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -946,3 +946,10 @@ d6596ea,BenchmarkPadString-8,2.23,0.00,0.00
 62cb604,BenchmarkIndexSearch-8,2.93,0.00,0.00
 62cb604,BenchmarkLoadGlobalConfig-8,713.00,160.00,1.00
 62cb604,BenchmarkPadString-8,2.67,0.00,0.00
+2014a26,BenchmarkCheckMetricsAndSwap-8,8.15,0.00,0.00
+2014a26,BenchmarkCrushOptimized-8,339.20,0.00,0.00
+2014a26,BenchmarkCrushOriginal-8,400.70,164.00,3.00
+2014a26,BenchmarkIndexDirectTracking-8,0.42,0.00,0.00
+2014a26,BenchmarkIndexSearch-8,2.87,0.00,0.00
+2014a26,BenchmarkLoadGlobalConfig-8,780.10,160.00,1.00
+2014a26,BenchmarkPadString-8,1.89,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        468.0n ± ∞ ¹    399.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       351.4n ± ∞ ¹    321.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     826.2n ± ∞ ¹    713.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.235n ± ∞ ¹    2.673n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  11.70n ± ∞ ¹    13.58n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.552n ± ∞ ¹    2.933n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4821n ± ∞ ¹   0.3549n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.99n          23.05n        -7.76%
+CrushOriginal-8                        399.1n ± ∞ ¹    400.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       321.5n ± ∞ ¹    339.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     713.0n ± ∞ ¹    780.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.673n ± ∞ ¹    1.889n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 13.580n ± ∞ ¹    8.147n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.933n ± ∞ ¹    2.869n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3549n ± ∞ ¹   0.4207n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                23.05n          21.27n        -7.72%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 13.58 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 321.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 399.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.93 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 713.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.67 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 339.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 400.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 780.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604]
-    line "CheckMetricsAndSwap" [11,7,8,7,10,7,8,7,12,14]
-    line "CrushOptimized" [306,322,331,314,307,316,366,331,351,322]
-    line "CrushOriginal" [419,412,468,404,405,397,454,582,468,399]
+    x-axis [2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604,2014a26]
+    line "CheckMetricsAndSwap" [7,8,7,10,7,8,7,12,14,8]
+    line "CrushOptimized" [322,331,314,307,316,366,331,351,322,339]
+    line "CrushOriginal" [412,468,404,405,397,454,582,468,399,401]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,4,3]
-    line "LoadGlobalConfig" [757,741,774,714,913,686,819,705,826,713]
-    line "PadString" [2,2,2,2,2,2,2,2,2,3]
+    line "IndexSearch" [3,3,3,3,3,3,3,4,3,3]
+    line "LoadGlobalConfig" [741,774,714,913,686,819,705,826,713,780]
+    line "PadString" [2,2,2,2,2,2,2,2,3,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604]
+    x-axis [2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604,2014a26]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7b0e503,2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604]
+    x-axis [2936ad6,972705a,cd8c1a4,a5be9c2,4a46695,fe6238e,831359c,d6596ea,62cb604,2014a26]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -135,12 +135,23 @@ func EncodeFileMetadataList(files []common.FileMetadata) []byte {
 }
 
 // DecodeFileMetadataList deserializes a binary FileMetadata list.
-func DecodeFileMetadataList(data []byte) ([]common.FileMetadata, error) {
+func DecodeFileMetadataList(data []byte) (result []common.FileMetadata, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in DecodeFileMetadataList: %v", r)
+			err = fmt.Errorf("panic in DecodeFileMetadataList: %v: %w", r, syscall.EIO)
+		}
+	}()
+
 	if len(data) < 4 {
-		return nil, fmt.Errorf("file metadata list too short")
+		return nil, fmt.Errorf("file metadata list too short: %w", syscall.EINVAL)
 	}
 	count := int(binary.BigEndian.Uint32(data[0:4]))
 	off := 4
+	maxCount := (len(data) - 4) / 20
+	if count > maxCount {
+		count = maxCount
+	}
 	files := make([]common.FileMetadata, 0, count)
 	for i := 0; i < count; i++ {
 		if off+4 > len(data) {


### PR DESCRIPTION
Fixes #372

## Bug: OOM via Untrusted Count in DecodeFileMetadataList

**Severity:** High | **Category:** DoS / Integer overflow | **Location:** `src/server/query_handler.go:142`

### Problem

`DecodeFileMetadataList` reads `count` from the wire as `uint32` (up to ~4.3 billion) and uses it directly as `make([]common.FileMetadata, 0, count)`. A malicious peer sends `count=0xFFFFFFFF` in a 4-byte payload → 240 GB allocation → OOM panic.

### Root Cause

```go
count := int(binary.BigEndian.Uint32(data[0:4]))
files := make([]common.FileMetadata, 0, count)  // count up to 4B, unvalidated
```

### Fix

Cap `count` to the maximum possible entries given the data length. Each entry requires at least 20 bytes (4B nameLen + 4B hashLen + 8B size + 4B pathLen):

```go
maxCount := (len(data) - 4) / 20
if count > maxCount {
    count = maxCount
}
```

Also added `defer recover()` with `syscall.EIO` (Rules 4, 37) and `syscall.EINVAL` for short data (Rule 10).

### Changelog (reviewer awareness)

#### Commit 1 (`036f43a`) — Initial fix
- Cap `count` to `(len(data)-4)/20` (minimum 20 bytes per entry) to prevent OOM from malicious wire input
- Add `defer recover()` with `syscall.EIO` error mapping (Rule 37)
- Map short data error to `syscall.EINVAL` (Rule 10)

### Reviewer Status
- **Review 1**: ✅ All Project Steering Rules and architectural patterns are respected.

### Testing
- `go build ./src/server/...` — passes
- `go test ./src/server/...` — all tests pass