### PR TITLE
fix: validate ReplicationOrder non-empty after parsing to prevent panic

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -995,3 +995,10 @@ f4d7d78,BenchmarkPadString-8,1.90,0.00,0.00
 199f02e,BenchmarkIndexSearch-8,2.77,0.00,0.00
 199f02e,BenchmarkLoadGlobalConfig-8,852.10,160.00,1.00
 199f02e,BenchmarkPadString-8,2.29,0.00,0.00
+9c83051,BenchmarkCheckMetricsAndSwap-8,8.53,0.00,0.00
+9c83051,BenchmarkCrushOptimized-8,333.00,0.00,0.00
+9c83051,BenchmarkCrushOriginal-8,446.50,164.00,3.00
+9c83051,BenchmarkIndexDirectTracking-8,0.44,0.00,0.00
+9c83051,BenchmarkIndexSearch-8,3.28,0.00,0.00
+9c83051,BenchmarkLoadGlobalConfig-8,775.60,160.00,1.00
+9c83051,BenchmarkPadString-8,2.01,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        449.7n ± ∞ ¹    422.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       382.2n ± ∞ ¹    324.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     801.4n ± ∞ ¹    852.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.964n ± ∞ ¹    2.294n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.179n ± ∞ ¹    7.939n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.755n ± ∞ ¹    2.770n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3823n ± ∞ ¹   0.3941n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                21.79n          21.77n        -0.07%
+CrushOriginal-8                        422.6n ± ∞ ¹    446.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       324.0n ± ∞ ¹    333.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     852.1n ± ∞ ¹    775.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.294n ± ∞ ¹    2.009n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.939n ± ∞ ¹    8.526n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.770n ± ∞ ¹    3.279n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3941n ± ∞ ¹   0.4440n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.77n          22.45n        +3.12%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.94 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 324.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 422.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.77 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 852.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 333.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 446.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.28 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 775.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.01 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [831359c,d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e]
-    line "CheckMetricsAndSwap" [7,12,14,8,8,8,8,7,8,8]
-    line "CrushOptimized" [331,351,322,339,300,380,374,312,382,324]
-    line "CrushOriginal" [582,468,399,401,419,540,525,403,450,423]
+    x-axis [d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051]
+    line "CheckMetricsAndSwap" [12,14,8,8,8,8,7,8,8,9]
+    line "CrushOptimized" [351,322,339,300,380,374,312,382,324,333]
+    line "CrushOriginal" [468,399,401,419,540,525,403,450,423,446]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,4,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [705,826,713,780,754,766,758,744,801,852]
-    line "PadString" [2,2,3,2,2,2,2,2,2,2]
+    line "IndexSearch" [4,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [826,713,780,754,766,758,744,801,852,776]
+    line "PadString" [2,3,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [831359c,d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e]
+    x-axis [d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [831359c,d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e]
+    x-axis [d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"gopkg.in/ini.v1"
 )
@@ -133,6 +134,10 @@ func loadGlobalConfig(section *ini.Section) (ConfigurationGlobal, error) {
 			return ConfigurationGlobal{}, fmt.Errorf("failed to parse 'replication_order' part %q: %w", trimmedPart, err)
 		}
 		globalCfg.ReplicationOrder = append(globalCfg.ReplicationOrder, order)
+	}
+
+	if len(globalCfg.ReplicationOrder) == 0 {
+		return ConfigurationGlobal{}, fmt.Errorf("'replication_order' contains no valid entries: %w", syscall.EINVAL)
 	}
 
 	globalCfg.PolymorphicSystem, err = section.Key("polymorphic_system").Bool()


### PR DESCRIPTION
Fixes #376

## Bug: Panic on Empty ReplicationOrder from Config

**Severity:** High | **Category:** Logic error / missing validation | **Location:** `src/common/config.go:112-136`

### Problem

The `replication_order` parsing loop skips empty/whitespace parts with `continue`, but there is no post-loop check that at least one valid order was parsed. A config value like `replication_order = ",,,"` passes the non-empty string check but produces an empty `ReplicationOrder` slice. This is then indexed in `metrics/metrics.go:111` → `panic: index out of range`.

### Fix

Add a post-loop validation check:
```go
if len(globalCfg.ReplicationOrder) == 0 {
    return ConfigurationGlobal{}, fmt.Errorf("replication_order contains no valid entries: %w", syscall.EINVAL)
}
```

### Changelog

#### Commit 1 (`8bce9e0`) — Initial fix
- Add post-loop validation returning `syscall.EINVAL` if no valid entries were parsed (Rule 10, Rule 32)
- Add `syscall` import to `config.go`

### Testing
- `go build ./src/common/...` — passes
- `go test ./src/common/...` — all tests pass