### PR TITLE
fix: add bounds check and error handling in ApplyTombstone

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1002,3 +1002,10 @@ f4d7d78,BenchmarkPadString-8,1.90,0.00,0.00
 9c83051,BenchmarkIndexSearch-8,3.28,0.00,0.00
 9c83051,BenchmarkLoadGlobalConfig-8,775.60,160.00,1.00
 9c83051,BenchmarkPadString-8,2.01,0.00,0.00
+654b156,BenchmarkCheckMetricsAndSwap-8,6.96,0.00,0.00
+654b156,BenchmarkCrushOptimized-8,351.70,0.00,0.00
+654b156,BenchmarkCrushOriginal-8,582.70,164.00,3.00
+654b156,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+654b156,BenchmarkIndexSearch-8,2.72,0.00,0.00
+654b156,BenchmarkLoadGlobalConfig-8,730.60,160.00,1.00
+654b156,BenchmarkPadString-8,1.84,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        422.6n ± ∞ ¹    446.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       324.0n ± ∞ ¹    333.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     852.1n ± ∞ ¹    775.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.294n ± ∞ ¹    2.009n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.939n ± ∞ ¹    8.526n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.770n ± ∞ ¹    3.279n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3941n ± ∞ ¹   0.4440n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                21.77n          22.45n        +3.12%
+CrushOriginal-8                        446.5n ± ∞ ¹    582.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       333.0n ± ∞ ¹    351.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     775.6n ± ∞ ¹    730.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.009n ± ∞ ¹    1.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.526n ± ∞ ¹    6.961n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.279n ± ∞ ¹    2.718n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4440n ± ∞ ¹   0.3344n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                22.45n          20.91n        -6.88%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 333.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 446.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.28 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 775.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.01 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 351.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 582.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.72 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 730.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.84 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051]
-    line "CheckMetricsAndSwap" [12,14,8,8,8,8,7,8,8,9]
-    line "CrushOptimized" [351,322,339,300,380,374,312,382,324,333]
-    line "CrushOriginal" [468,399,401,419,540,525,403,450,423,446]
+    x-axis [62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156]
+    line "CheckMetricsAndSwap" [14,8,8,8,8,7,8,8,9,7]
+    line "CrushOptimized" [322,339,300,380,374,312,382,324,333,352]
+    line "CrushOriginal" [399,401,419,540,525,403,450,423,446,583]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [4,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [826,713,780,754,766,758,744,801,852,776]
-    line "PadString" [2,3,2,2,2,2,2,2,2,2]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [713,780,754,766,758,744,801,852,776,731]
+    line "PadString" [3,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051]
+    x-axis [62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [d6596ea,62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051]
+    x-axis [62cb604,2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -167,7 +167,14 @@ func (s *CASStore) GetTombstones() (map[string]int64, error) {
 
 // ApplyTombstone records a tombstone for a name that was deleted on a remote peer.
 // This is used during P2P tombstone exchange to propagate deletes.
-func (s *CASStore) ApplyTombstone(name string, deletedAt int64) error {
+func (s *CASStore) ApplyTombstone(name string, deletedAt int64) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in ApplyTombstone: %v", r)
+			err = fmt.Errorf("panic in ApplyTombstone: %v: %w", r, syscall.EIO)
+		}
+	}()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -175,9 +182,11 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) error {
 		ts := tx.Bucket(bucketTombstones)
 		existing := ts.Get([]byte(name))
 		if existing != nil {
-			existingTs := int64(binary.BigEndian.Uint64(existing[:8]))
-			if existingTs >= deletedAt {
-				return nil
+			if len(existing) >= 8 {
+				existingTs := int64(binary.BigEndian.Uint64(existing[:8]))
+				if existingTs >= deletedAt {
+					return nil
+				}
 			}
 		}
 
@@ -201,7 +210,9 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) error {
 					meta.RefCount = 0
 					meta.DeletedAt = deletedAt
 				}
-				obj.Put([]byte(hash), meta.encode())
+				if err := obj.Put([]byte(hash), meta.encode()); err != nil {
+					return fmt.Errorf("metadata update error: %w", syscall.EIO)
+				}
 			}
 		}
 		ns.Delete([]byte(name))


### PR DESCRIPTION
Fixes #378

## Bug: Panic in ApplyTombstone on Short/Corrupted Tombstone Value

**Severity:** High | **Category:** Index out of range / swallowed error | **Location:** `src/storage/gc.go:178`

### Problem

1. `ApplyTombstone()` accesses `existing[:8]` without checking `len(existing) >= 8`. Corrupted/legacy tombstone with `len < 8` → panic. No `defer/recover` → process crash.
2. `obj.Put([]byte(hash), meta.encode())` at line 204 swallows the error — if the bbolt put fails, refcount is left inconsistent.

### Fix

1. Add `len(existing) >= 8` check before `existing[:8]`
2. Check error from `obj.Put` and return `syscall.EIO` on failure
3. Add `defer recover()` with `syscall.EIO` (Rule 37)

### Changelog

#### Commit 1 (`0273d2d`) — Initial fix
- Add `len(existing) >= 8` bounds check before `existing[:8]` access
- Check error from `obj.Put` and return `syscall.EIO` on failure (was swallowed)
- Add `defer recover()` with `syscall.EIO` error mapping (Rule 37)

### Testing
- `go build ./src/storage/...` — passes
- `go test ./src/storage/...` — all tests pass