### PR TITLE
fix: S3 ListObjectsV2 IsTruncated now reflects actual truncation

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1016,3 +1016,10 @@ bf80087,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
 bf80087,BenchmarkIndexSearch-8,2.97,0.00,0.00
 bf80087,BenchmarkLoadGlobalConfig-8,794.00,160.00,1.00
 bf80087,BenchmarkPadString-8,2.10,0.00,0.00
+72967cb,BenchmarkCheckMetricsAndSwap-8,8.12,0.00,0.00
+72967cb,BenchmarkCrushOptimized-8,322.00,0.00,0.00
+72967cb,BenchmarkCrushOriginal-8,461.40,164.00,3.00
+72967cb,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+72967cb,BenchmarkIndexSearch-8,3.29,0.00,0.00
+72967cb,BenchmarkLoadGlobalConfig-8,770.90,160.00,1.00
+72967cb,BenchmarkPadString-8,2.36,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        582.7n ± ∞ ¹    442.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       351.7n ± ∞ ¹    347.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     730.6n ± ∞ ¹    794.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.843n ± ∞ ¹    2.103n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.961n ± ∞ ¹    8.758n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.718n ± ∞ ¹    2.970n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3344n ± ∞ ¹   0.3664n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.91n          21.94n        +4.96%
+CrushOriginal-8                        442.6n ± ∞ ¹    461.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       347.9n ± ∞ ¹    322.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     794.0n ± ∞ ¹    770.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.103n ± ∞ ¹    2.359n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.758n ± ∞ ¹    8.115n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.970n ± ∞ ¹    3.293n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3664n ± ∞ ¹   0.3208n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.94n          21.77n        -0.80%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.76 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 347.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 442.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 794.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.12 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 322.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 461.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 770.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.36 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087]
-    line "CheckMetricsAndSwap" [8,8,8,8,7,8,8,9,7,9]
-    line "CrushOptimized" [339,300,380,374,312,382,324,333,352,348]
-    line "CrushOriginal" [401,419,540,525,403,450,423,446,583,443]
+    x-axis [e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb]
+    line "CheckMetricsAndSwap" [8,8,8,7,8,8,9,7,9,8]
+    line "CrushOptimized" [300,380,374,312,382,324,333,352,348,322]
+    line "CrushOriginal" [419,540,525,403,450,423,446,583,443,461]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [780,754,766,758,744,801,852,776,731,794]
+    line "LoadGlobalConfig" [754,766,758,744,801,852,776,731,794,771]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087]
+    x-axis [e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [2014a26,e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087]
+    x-axis [e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -781,10 +781,9 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 	buf.Write(strconv.AppendInt(intBuf[:0], int64(maxKeys), 10))
 	buf.WriteString(`</MaxKeys>`)
 
-	buf.WriteString(`<IsTruncated>false</IsTruncated>`)
-
 	commonPrefixes := make(map[string]bool)
 	keyCount := 0
+	truncated := false
 
 	for _, file := range files {
 		// 🛡️ Sentinel: Validate that the metadata fields conform to the project's strict size limits (64 bytes)
@@ -815,6 +814,11 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 			}
 		}
 
+		if maxKeys > 0 && keyCount >= maxKeys {
+			truncated = true
+			break
+		}
+
 		buf.WriteString(`<Contents>`)
 		buf.WriteString(`<Key>`)
 		xmlEscape(&buf, key)
@@ -829,10 +833,6 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 		buf.WriteString(`<StorageClass>STANDARD</StorageClass>`)
 		buf.WriteString(`</Contents>`)
 		keyCount++
-
-		if maxKeys > 0 && keyCount >= maxKeys {
-			break
-		}
 	}
 
 	for cp := range commonPrefixes {
@@ -843,6 +843,14 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 		buf.WriteString(`</CommonPrefixes>`)
 		keyCount++
 	}
+
+	buf.WriteString(`<IsTruncated>`)
+	if truncated {
+		buf.WriteString(`true`)
+	} else {
+		buf.WriteString(`false`)
+	}
+	buf.WriteString(`</IsTruncated>`)
 
 	buf.WriteString(`<KeyCount>`)
 	buf.Write(strconv.AppendInt(intBuf[:0], int64(keyCount), 10))


### PR DESCRIPTION
Fixes #382

## Bug: S3 ListObjectsV2 IsTruncated Always False

**Severity:** High | **Category:** Logic error | **Location:** `src/transport/s3_communicator.go:784`

### Problem

`FormatListObjectsV2XML` hardcoded `<IsTruncated>false</IsTruncated>` BEFORE the loop. The loop breaks early when `keyCount >= maxKeys`, but `IsTruncated` is always `false`. S3 clients rely on `IsTruncated` for pagination — with it always false, clients silently miss all keys beyond the first page.

### Fix

1. Remove hardcoded `<IsTruncated>false</IsTruncated>` before the loop
2. Track `truncated` bool — set to `true` when loop breaks early at `maxKeys`
3. Move `maxKeys` check BEFORE writing `<Contents>` to avoid writing one extra entry beyond `maxKeys`
4. Write `<IsTruncated>` after the loop based on the `truncated` flag

### Changelog

#### Commit 1 (`151637f`) — Initial fix
- Move `IsTruncated` write from before loop to after loop
- Add `truncated` bool tracking, set when loop breaks at `maxKeys`
- Move `maxKeys` check before `<Contents>` write to respect the limit exactly

### Testing
- `go build ./src/transport/...` — passes
- `go test ./src/transport/...` — all tests pass