### PR TITLE
fix: validate hash, auth token, and host for CRLF in S3 SendMetadata

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1023,3 +1023,10 @@ bf80087,BenchmarkPadString-8,2.10,0.00,0.00
 72967cb,BenchmarkIndexSearch-8,3.29,0.00,0.00
 72967cb,BenchmarkLoadGlobalConfig-8,770.90,160.00,1.00
 72967cb,BenchmarkPadString-8,2.36,0.00,0.00
+d3a108d,BenchmarkCheckMetricsAndSwap-8,7.18,0.00,0.00
+d3a108d,BenchmarkCrushOptimized-8,289.10,0.00,0.00
+d3a108d,BenchmarkCrushOriginal-8,390.00,164.00,3.00
+d3a108d,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+d3a108d,BenchmarkIndexSearch-8,2.70,0.00,0.00
+d3a108d,BenchmarkLoadGlobalConfig-8,693.30,160.00,1.00
+d3a108d,BenchmarkPadString-8,1.94,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        442.6n ± ∞ ¹    461.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       347.9n ± ∞ ¹    322.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     794.0n ± ∞ ¹    770.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.103n ± ∞ ¹    2.359n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.758n ± ∞ ¹    8.115n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.970n ± ∞ ¹    3.293n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3664n ± ∞ ¹   0.3208n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                21.94n          21.77n        -0.80%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        461.4n ± ∞ ¹    390.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       322.0n ± ∞ ¹    289.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     770.9n ± ∞ ¹    693.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.359n ± ∞ ¹    1.936n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.115n ± ∞ ¹    7.184n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.293n ± ∞ ¹    2.697n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3208n ± ∞ ¹   0.3269n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                21.77n          19.19n        -11.84%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.12 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 322.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 461.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.29 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 770.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.18 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 289.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 390.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 693.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb]
-    line "CheckMetricsAndSwap" [8,8,8,7,8,8,9,7,9,8]
-    line "CrushOptimized" [300,380,374,312,382,324,333,352,348,322]
-    line "CrushOriginal" [419,540,525,403,450,423,446,583,443,461]
+    x-axis [f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d]
+    line "CheckMetricsAndSwap" [8,8,7,8,8,9,7,9,8,7]
+    line "CrushOptimized" [380,374,312,382,324,333,352,348,322,289]
+    line "CrushOriginal" [540,525,403,450,423,446,583,443,461,390]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [754,766,758,744,801,852,776,731,794,771]
+    line "LoadGlobalConfig" [766,758,744,801,852,776,731,794,771,693]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb]
+    x-axis [f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e1281cc,f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb]
+    x-axis [f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -525,6 +525,17 @@ func (m *S3Communicator) SendMetadata(meta *common.FileMetadata) (status int, er
 		return 0, fmt.Errorf("invalid characters in path: %w", syscall.EBADMSG)
 	}
 
+	// 🛡️ Sentinel: Validate hash, auth token, and host for CRLF to prevent HTTP header injection.
+	if strings.ContainsAny(meta.Hash, "\r\n") {
+		return 0, fmt.Errorf("invalid characters in hash: %w", syscall.EBADMSG)
+	}
+	if strings.ContainsAny(m.clientAuthToken, "\r\n") {
+		return 0, fmt.Errorf("invalid characters in auth token: %w", syscall.EBADMSG)
+	}
+	if strings.ContainsAny(host, "\r\n") {
+		return 0, fmt.Errorf("invalid characters in host: %w", syscall.EBADMSG)
+	}
+
 	// ⚡ Bolt: Eliminate fmt.Sprintf and string allocations using stack-allocated buffer
 	var buf [512]byte
 	b := buf[:0]


### PR DESCRIPTION
Fixes #384

## Bug: CRLF Injection in S3 SendMetadata Headers

**Severity:** High | **Category:** Security (HTTP request smuggling) | **Location:** `src/transport/s3_communicator.go:539-545`

### Problem

`meta.Hash`, `m.clientAuthToken`, and `host` are appended to HTTP headers without CRLF validation. A malicious hash with `\r\n` can inject arbitrary headers, enabling HTTP request smuggling, cache poisoning, and SSRF.

### Fix

Validate all three with `strings.ContainsAny(..., "\r\n")` before writing to header block, returning `syscall.EBADMSG` if found.

### Changelog

#### Commit 1 (`59998e7`) — Initial fix
- Add CRLF validation for `meta.Hash`, `m.clientAuthToken`, and `host` in `SendMetadata`
- Return `syscall.EBADMSG` on validation failure

### Testing
- `go build ./src/transport/...` — passes
- `go test ./src/transport/...` — all tests pass