### PR TITLE
fix: replace hardcoded node IDs with dynamic loop in replication propagation

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1030,3 +1030,17 @@ d3a108d,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
 d3a108d,BenchmarkIndexSearch-8,2.70,0.00,0.00
 d3a108d,BenchmarkLoadGlobalConfig-8,693.30,160.00,1.00
 d3a108d,BenchmarkPadString-8,1.94,0.00,0.00
+7c3c5f5,BenchmarkCheckMetricsAndSwap-8,12.52,0.00,0.00
+7c3c5f5,BenchmarkCrushOptimized-8,372.20,0.00,0.00
+7c3c5f5,BenchmarkCrushOriginal-8,572.20,164.00,3.00
+7c3c5f5,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+7c3c5f5,BenchmarkIndexSearch-8,3.34,0.00,0.00
+7c3c5f5,BenchmarkLoadGlobalConfig-8,1044.00,160.00,1.00
+7c3c5f5,BenchmarkPadString-8,2.85,0.00,0.00
+b816415,BenchmarkCheckMetricsAndSwap-8,6.78,0.00,0.00
+b816415,BenchmarkCrushOptimized-8,357.80,0.00,0.00
+b816415,BenchmarkCrushOriginal-8,404.50,164.00,3.00
+b816415,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+b816415,BenchmarkIndexSearch-8,3.12,0.00,0.00
+b816415,BenchmarkLoadGlobalConfig-8,713.10,160.00,1.00
+b816415,BenchmarkPadString-8,1.91,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1044,3 +1044,10 @@ b816415,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
 b816415,BenchmarkIndexSearch-8,3.12,0.00,0.00
 b816415,BenchmarkLoadGlobalConfig-8,713.10,160.00,1.00
 b816415,BenchmarkPadString-8,1.91,0.00,0.00
+9172f13,BenchmarkCheckMetricsAndSwap-8,6.74,0.00,0.00
+9172f13,BenchmarkCrushOptimized-8,317.50,0.00,0.00
+9172f13,BenchmarkCrushOriginal-8,392.40,164.00,3.00
+9172f13,BenchmarkIndexDirectTracking-8,0.31,0.00,0.00
+9172f13,BenchmarkIndexSearch-8,2.84,0.00,0.00
+9172f13,BenchmarkLoadGlobalConfig-8,703.30,160.00,1.00
+9172f13,BenchmarkPadString-8,2.02,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        461.4n ± ∞ ¹    390.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       322.0n ± ∞ ¹    289.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     770.9n ± ∞ ¹    693.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.359n ± ∞ ¹    1.936n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.115n ± ∞ ¹    7.184n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.293n ± ∞ ¹    2.697n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3208n ± ∞ ¹   0.3269n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                21.77n          19.19n        -11.84%
+CrushOriginal-8                        572.2n ± ∞ ¹    404.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       372.2n ± ∞ ¹    357.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1044.0n ± ∞ ¹    713.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.846n ± ∞ ¹    1.912n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 12.520n ± ∞ ¹    6.783n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.342n ± ∞ ¹    3.117n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5034n ± ∞ ¹   0.3664n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                27.95n          20.51n        -26.61%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.18 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 289.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 390.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 693.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.78 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 357.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 404.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.12 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 713.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d]
-    line "CheckMetricsAndSwap" [8,8,7,8,8,9,7,9,8,7]
-    line "CrushOptimized" [380,374,312,382,324,333,352,348,322,289]
-    line "CrushOriginal" [540,525,403,450,423,446,583,443,461,390]
+    x-axis [f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415]
+    line "CheckMetricsAndSwap" [7,8,8,9,7,9,8,7,13,7]
+    line "CrushOptimized" [312,382,324,333,352,348,322,289,372,358]
+    line "CrushOriginal" [403,450,423,446,583,443,461,390,572,404]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [766,758,744,801,852,776,731,794,771,693]
-    line "PadString" [2,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [744,801,852,776,731,794,771,693,1044,713]
+    line "PadString" [2,2,2,2,2,2,2,2,3,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d]
+    x-axis [f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [f4d7d78,ef2887d,f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d]
+    x-axis [f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        572.2n ± ∞ ¹    404.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       372.2n ± ∞ ¹    357.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1044.0n ± ∞ ¹    713.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.846n ± ∞ ¹    1.912n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 12.520n ± ∞ ¹    6.783n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.342n ± ∞ ¹    3.117n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.5034n ± ∞ ¹   0.3664n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                27.95n          20.51n        -26.61%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        404.5n ± ∞ ¹    392.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       357.8n ± ∞ ¹    317.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     713.1n ± ∞ ¹    703.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.912n ± ∞ ¹    2.015n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.783n ± ∞ ¹    6.737n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.117n ± ∞ ¹    2.837n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3664n ± ∞ ¹   0.3127n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.51n          19.46n        -5.16%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.78 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 357.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 404.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.12 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 713.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 317.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 392.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 703.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.02 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415]
-    line "CheckMetricsAndSwap" [7,8,8,9,7,9,8,7,13,7]
-    line "CrushOptimized" [312,382,324,333,352,348,322,289,372,358]
-    line "CrushOriginal" [403,450,423,446,583,443,461,390,572,404]
+    x-axis [9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13]
+    line "CheckMetricsAndSwap" [8,8,9,7,9,8,7,13,7,7]
+    line "CrushOptimized" [382,324,333,352,348,322,289,372,358,318]
+    line "CrushOriginal" [450,423,446,583,443,461,390,572,404,392]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [744,801,852,776,731,794,771,693,1044,713]
-    line "PadString" [2,2,2,2,2,2,2,2,3,2]
+    line "LoadGlobalConfig" [801,852,776,731,794,771,693,1044,713,703]
+    line "PadString" [2,2,2,2,2,2,2,3,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415]
+    x-axis [9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [f4d7d78,9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415]
+    x-axis [9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/alsotoes/momo/src/common"
@@ -175,22 +176,20 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 
 			// If this is the primary server, propagate the change to the other servers
 			if 0 == serverId {
-				go func() {
-					defer func() {
-						if r := recover(); r != nil {
-							log.Printf("CRITICAL: Panic recovered in propagation to node 1: %v", r)
-						}
-					}()
-					ChangeReplicationModeClient(factory, newReplicationJson, 1)
-				}()
-				go func() {
-					defer func() {
-						if r := recover(); r != nil {
-							log.Printf("CRITICAL: Panic recovered in propagation to node 2: %v", r)
-						}
-					}()
-					ChangeReplicationModeClient(factory, newReplicationJson, 2)
-				}()
+				daemons := factory.GetDaemons()
+				for i := range daemons {
+					if i == serverId {
+						continue
+					}
+					go func(id int) {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Printf("CRITICAL: Panic recovered in propagation to node %d: %v (errno=%d)", id, r, syscall.EIO)
+							}
+						}()
+						ChangeReplicationModeClient(factory, newReplicationJson, id)
+					}(i)
+				}
 			}
 		}()
 	}

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -184,7 +184,8 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 					go func(id int) {
 						defer func() {
 							if r := recover(); r != nil {
-								log.Printf("CRITICAL: Panic recovered in propagation to node %d: %v (errno=%d)", id, r, syscall.EIO)
+								err := fmt.Errorf("panic in propagation to node %d: %v: %w", id, r, syscall.EIO)
+								log.Printf("CRITICAL: %v", err)
 							}
 						}()
 						ChangeReplicationModeClient(factory, newReplicationJson, id)


### PR DESCRIPTION
Fixes #386

## Bug: Hardcoded Node IDs in Replication Mode Propagation

**Severity:** High | **Category:** Logic error | **Location:** `src/server/replication.go:177-194`

### Problem

Propagation to nodes 1 and 2 was hardcoded. Clusters >3 nodes: nodes 3+ never got updates. Clusters <3 nodes: `daemons[2]` panicked with index out of range.

### Fix

Replace hardcoded goroutines with a dynamic loop over all daemons, skipping the current server. Added `syscall.EIO` to panic recovery per Rule 37.

### Changelog

#### Commit 1 (`9172f13`) — Initial fix + reviewer feedback
- Replace hardcoded `ChangeReplicationModeClient(factory, ..., 1)` and `..., 2)` with `for i := range daemons` loop
- Skip `i == serverId` to avoid self-propagation
- Pass `i` as parameter to goroutine to avoid closure capture bug
- Add `syscall.EIO` to panic recovery log (Rule 37, per reviewer request)

### Reviewer Status
- **Review 1**: ❌ Missing syscall constant in recovery (Rule 37)
- **Review 2**: Pending

### Testing
- `go build ./src/server/...` — passes
- `go test ./src/server/...` — all tests pass