### PR TITLE
fix: call AuthFunc in handleConn to prevent peer identity spoofing

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1051,3 +1051,10 @@ b816415,BenchmarkPadString-8,1.91,0.00,0.00
 9172f13,BenchmarkIndexSearch-8,2.84,0.00,0.00
 9172f13,BenchmarkLoadGlobalConfig-8,703.30,160.00,1.00
 9172f13,BenchmarkPadString-8,2.02,0.00,0.00
+523dcbd,BenchmarkCheckMetricsAndSwap-8,7.25,0.00,0.00
+523dcbd,BenchmarkCrushOptimized-8,313.90,0.00,0.00
+523dcbd,BenchmarkCrushOriginal-8,437.90,164.00,3.00
+523dcbd,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+523dcbd,BenchmarkIndexSearch-8,2.87,0.00,0.00
+523dcbd,BenchmarkLoadGlobalConfig-8,737.50,160.00,1.00
+523dcbd,BenchmarkPadString-8,2.10,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1065,3 +1065,10 @@ ba923a4,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
 ba923a4,BenchmarkIndexSearch-8,2.91,0.00,0.00
 ba923a4,BenchmarkLoadGlobalConfig-8,714.00,160.00,1.00
 ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
+15c81ac,BenchmarkCheckMetricsAndSwap-8,7.19,0.00,0.00
+15c81ac,BenchmarkCrushOptimized-8,346.90,0.00,0.00
+15c81ac,BenchmarkCrushOriginal-8,401.70,164.00,3.00
+15c81ac,BenchmarkIndexDirectTracking-8,0.30,0.00,0.00
+15c81ac,BenchmarkIndexSearch-8,3.14,0.00,0.00
+15c81ac,BenchmarkLoadGlobalConfig-8,717.10,160.00,1.00
+15c81ac,BenchmarkPadString-8,2.08,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1058,3 +1058,10 @@ b816415,BenchmarkPadString-8,1.91,0.00,0.00
 523dcbd,BenchmarkIndexSearch-8,2.87,0.00,0.00
 523dcbd,BenchmarkLoadGlobalConfig-8,737.50,160.00,1.00
 523dcbd,BenchmarkPadString-8,2.10,0.00,0.00
+ba923a4,BenchmarkCheckMetricsAndSwap-8,6.96,0.00,0.00
+ba923a4,BenchmarkCrushOptimized-8,291.80,0.00,0.00
+ba923a4,BenchmarkCrushOriginal-8,398.70,164.00,3.00
+ba923a4,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+ba923a4,BenchmarkIndexSearch-8,2.91,0.00,0.00
+ba923a4,BenchmarkLoadGlobalConfig-8,714.00,160.00,1.00
+ba923a4,BenchmarkPadString-8,1.89,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        437.9n ± ∞ ¹    398.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       313.9n ± ∞ ¹    291.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     737.5n ± ∞ ¹    714.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.101n ± ∞ ¹    1.886n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.255n ± ∞ ¹    6.963n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.872n ± ∞ ¹    2.913n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3314n ± ∞ ¹   0.4984n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.40n          20.62n        +1.06%
+CrushOriginal-8                        398.7n ± ∞ ¹    401.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       291.8n ± ∞ ¹    346.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     714.0n ± ∞ ¹    717.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.886n ± ∞ ¹    2.076n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.963n ± ∞ ¹    7.192n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.913n ± ∞ ¹    3.144n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4984n ± ∞ ¹   0.2997n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.62n          20.27n        -1.69%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.96 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 291.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 398.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 714.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.19 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 346.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 401.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.14 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 717.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.08 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4]
-    line "CheckMetricsAndSwap" [9,7,9,8,7,13,7,7,7,7]
-    line "CrushOptimized" [333,352,348,322,289,372,358,318,314,292]
-    line "CrushOriginal" [446,583,443,461,390,572,404,392,438,399]
+    x-axis [654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac]
+    line "CheckMetricsAndSwap" [7,9,8,7,13,7,7,7,7,7]
+    line "CrushOptimized" [352,348,322,289,372,358,318,314,292,347]
+    line "CrushOriginal" [583,443,461,390,572,404,392,438,399,402]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [776,731,794,771,693,1044,713,703,738,714]
-    line "PadString" [2,2,2,2,2,3,2,2,2,2]
+    line "LoadGlobalConfig" [731,794,771,693,1044,713,703,738,714,717]
+    line "PadString" [2,2,2,2,3,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4]
+    x-axis [654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4]
+    x-axis [654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        404.5n ± ∞ ¹    392.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       357.8n ± ∞ ¹    317.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     713.1n ± ∞ ¹    703.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.912n ± ∞ ¹    2.015n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.783n ± ∞ ¹    6.737n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.117n ± ∞ ¹    2.837n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3664n ± ∞ ¹   0.3127n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.51n          19.46n        -5.16%
+CrushOriginal-8                        392.4n ± ∞ ¹    437.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       317.5n ± ∞ ¹    313.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     703.3n ± ∞ ¹    737.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.015n ± ∞ ¹    2.101n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.737n ± ∞ ¹    7.255n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.837n ± ∞ ¹    2.872n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3127n ± ∞ ¹   0.3314n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.46n          20.40n        +4.86%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 317.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 392.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 703.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.25 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 313.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 437.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 737.50 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.10 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13]
-    line "CheckMetricsAndSwap" [8,8,9,7,9,8,7,13,7,7]
-    line "CrushOptimized" [382,324,333,352,348,322,289,372,358,318]
-    line "CrushOriginal" [450,423,446,583,443,461,390,572,404,392]
+    x-axis [199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd]
+    line "CheckMetricsAndSwap" [8,9,7,9,8,7,13,7,7,7]
+    line "CrushOptimized" [324,333,352,348,322,289,372,358,318,314]
+    line "CrushOriginal" [423,446,583,443,461,390,572,404,392,438]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [801,852,776,731,794,771,693,1044,713,703]
-    line "PadString" [2,2,2,2,2,2,2,3,2,2]
+    line "LoadGlobalConfig" [852,776,731,794,771,693,1044,713,703,738]
+    line "PadString" [2,2,2,2,2,2,3,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13]
+    x-axis [199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [9fc909c,199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13]
+    x-axis [199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        392.4n ± ∞ ¹    437.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       317.5n ± ∞ ¹    313.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     703.3n ± ∞ ¹    737.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.015n ± ∞ ¹    2.101n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.737n ± ∞ ¹    7.255n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.837n ± ∞ ¹    2.872n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3127n ± ∞ ¹   0.3314n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.46n          20.40n        +4.86%
+CrushOriginal-8                        437.9n ± ∞ ¹    398.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       313.9n ± ∞ ¹    291.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     737.5n ± ∞ ¹    714.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.101n ± ∞ ¹    1.886n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.255n ± ∞ ¹    6.963n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.872n ± ∞ ¹    2.913n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3314n ± ∞ ¹   0.4984n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.40n          20.62n        +1.06%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.25 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 313.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 437.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 737.50 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 291.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 398.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 714.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd]
-    line "CheckMetricsAndSwap" [8,9,7,9,8,7,13,7,7,7]
-    line "CrushOptimized" [324,333,352,348,322,289,372,358,318,314]
-    line "CrushOriginal" [423,446,583,443,461,390,572,404,392,438]
+    x-axis [9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4]
+    line "CheckMetricsAndSwap" [9,7,9,8,7,13,7,7,7,7]
+    line "CrushOptimized" [333,352,348,322,289,372,358,318,314,292]
+    line "CrushOriginal" [446,583,443,461,390,572,404,392,438,399]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [852,776,731,794,771,693,1044,713,703,738]
-    line "PadString" [2,2,2,2,2,2,3,2,2,2]
+    line "LoadGlobalConfig" [776,731,794,771,693,1044,713,703,738,714]
+    line "PadString" [2,2,2,2,2,3,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd]
+    x-axis [9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [199f02e,9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd]
+    x-axis [9c83051,654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -100,7 +100,8 @@ func (t *TCPTransport) handleConn(conn net.Conn) {
 	defer conn.Close()
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("P2P handleConn panic recovered: %v (errno=%d)", r, syscall.EIO)
+			err := fmt.Errorf("panic in handleConn: %v: %w", r, syscall.EIO)
+			log.Printf("CRITICAL: %v", err)
 		}
 	}()
 
@@ -124,6 +125,10 @@ func (t *TCPTransport) handleConn(conn net.Conn) {
 
 		if peer == nil {
 			peerID = rpc.From
+			if peerID < 0 {
+				log.Printf("P2P rejected invalid peer ID %d from %s (errno=%d)", peerID, conn.RemoteAddr(), syscall.EBADMSG)
+				return
+			}
 			if t.cfg.AuthFunc != nil && !t.cfg.AuthFunc(peerID) {
 				log.Printf("P2P rejected unauthenticated peer %d from %s (errno=%d)", peerID, conn.RemoteAddr(), syscall.EACCES)
 				return

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -95,12 +95,12 @@ func (t *TCPTransport) acceptLoop() {
 
 // handleConn reads RPCs from a single connection and delivers them to rpcCh.
 // The peer ID is extracted from the first RPC received.
-func (t *TCPTransport) handleConn(conn net.Conn) {
+func (t *TCPTransport) handleConn(conn net.Conn) (err error) {
 	defer t.wg.Done()
 	defer conn.Close()
 	defer func() {
 		if r := recover(); r != nil {
-			err := fmt.Errorf("panic in handleConn: %v: %w", r, syscall.EIO)
+			err = fmt.Errorf("panic in handleConn: %v: %w", r, syscall.EIO)
 			log.Printf("CRITICAL: %v", err)
 		}
 	}()
@@ -110,15 +110,15 @@ func (t *TCPTransport) handleConn(conn net.Conn) {
 
 	for {
 		conn.SetReadDeadline(time.Now().Add(p2pReadTimeout))
-		rpc, err := DecodeRPC(conn)
-		if err != nil {
+		rpc, decErr := DecodeRPC(conn)
+		if decErr != nil {
 			select {
 			case <-t.done:
 				return
 			default:
 			}
 			if peerID >= 0 {
-				log.Printf("P2P peer %d disconnected: %v (errno=%d)", peerID, err, syscall.ECONNRESET)
+				log.Printf("P2P peer %d disconnected: %v (errno=%d)", peerID, decErr, syscall.ECONNRESET)
 			}
 			return
 		}

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -124,6 +124,10 @@ func (t *TCPTransport) handleConn(conn net.Conn) {
 
 		if peer == nil {
 			peerID = rpc.From
+			if t.cfg.AuthFunc != nil && !t.cfg.AuthFunc(peerID) {
+				log.Printf("P2P rejected unauthenticated peer %d from %s (errno=%d)", peerID, conn.RemoteAddr(), syscall.EACCES)
+				return
+			}
 			peer = NewPeer(peerID, conn.RemoteAddr().String())
 			peer.SetConn(conn)
 			t.peerMap.Add(peer)


### PR DESCRIPTION
Fixes #388

## Bug: AuthFunc Never Called — Peer Identity Spoofing

**Severity:** High | **Category:** Security | **Location:** `src/p2p/transport.go:38`, `src/p2p/tcp_transport.go:126`

### Problem

`AuthFunc` was defined in `TCPTransportConfig` but never called. In `handleConn`, the peer ID was taken directly from the RPC `From` field with no validation. Any node could claim any peer ID → identity spoofing, cluster hijacking.

### Fix

Call `t.cfg.AuthFunc(peerID)` in `handleConn` before accepting the peer. If `AuthFunc` is nil, allow all (backward compatibility). If it returns false, reject with `syscall.EACCES` and close the connection.

### Changelog

#### Commit 1 (`ba923a4`) — Initial fix
- Call `t.cfg.AuthFunc(peerID)` in `handleConn` before accepting peer
- If AuthFunc returns false, log rejection with `syscall.EACCES` and return
- If AuthFunc is nil, allow all (backward compatibility)

### Testing
- `go build ./src/p2p/...` — passes
- `go test ./src/p2p/...` — all tests pass