### PR TITLE
fix: delete corrupted file on hash mismatch to prevent data poisoning

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1072,3 +1072,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 15c81ac,BenchmarkIndexSearch-8,3.14,0.00,0.00
 15c81ac,BenchmarkLoadGlobalConfig-8,717.10,160.00,1.00
 15c81ac,BenchmarkPadString-8,2.08,0.00,0.00
+0a26155,BenchmarkCheckMetricsAndSwap-8,7.02,0.00,0.00
+0a26155,BenchmarkCrushOptimized-8,292.20,0.00,0.00
+0a26155,BenchmarkCrushOriginal-8,420.70,164.00,3.00
+0a26155,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+0a26155,BenchmarkIndexSearch-8,3.05,0.00,0.00
+0a26155,BenchmarkLoadGlobalConfig-8,675.60,160.00,1.00
+0a26155,BenchmarkPadString-8,2.19,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        398.7n ± ∞ ¹    401.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       291.8n ± ∞ ¹    346.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     714.0n ± ∞ ¹    717.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.886n ± ∞ ¹    2.076n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.963n ± ∞ ¹    7.192n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.913n ± ∞ ¹    3.144n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4984n ± ∞ ¹   0.2997n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.62n          20.27n        -1.69%
+CrushOriginal-8                        401.7n ± ∞ ¹    420.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       346.9n ± ∞ ¹    292.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     717.1n ± ∞ ¹    675.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.076n ± ∞ ¹    2.186n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.192n ± ∞ ¹    7.019n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.144n ± ∞ ¹    3.047n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.2997n ± ∞ ¹   0.3167n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.27n          19.89n        -1.89%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.19 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 346.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 401.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.14 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 717.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.08 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 292.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 420.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.05 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 675.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.19 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac]
-    line "CheckMetricsAndSwap" [7,9,8,7,13,7,7,7,7,7]
-    line "CrushOptimized" [352,348,322,289,372,358,318,314,292,347]
-    line "CrushOriginal" [583,443,461,390,572,404,392,438,399,402]
+    x-axis [bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155]
+    line "CheckMetricsAndSwap" [9,8,7,13,7,7,7,7,7,7]
+    line "CrushOptimized" [348,322,289,372,358,318,314,292,347,292]
+    line "CrushOriginal" [443,461,390,572,404,392,438,399,402,421]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [731,794,771,693,1044,713,703,738,714,717]
-    line "PadString" [2,2,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [794,771,693,1044,713,703,738,714,717,676]
+    line "PadString" [2,2,2,3,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac]
+    x-axis [bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [654b156,bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac]
+    x-axis [bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/file.go
+++ b/src/server/file.go
@@ -116,6 +116,7 @@ func getFile(comm transport.Communicator, store storage.Store, fileName string, 
 	hash := string(hexBuf[:])
 
 	if hash != expectedHash {
+		store.Delete(fileName)
 		err = fmt.Errorf("file hash mismatch: expected %s, got %s: %w", expectedHash, hash, syscall.EBADMSG)
 		return err
 	}


### PR DESCRIPTION
Fixes #390

## Bug: Corrupted File Persists After Hash Mismatch

**Severity:** High | **Category:** Data integrity | **Location:** `src/server/file.go:108-121`

### Problem

`store.Put()` writes content to disk under `expectedHash` BEFORE SHA-256 is verified. On hash mismatch, corrupted content remains in store. Next upload with same hash gets dedup hit → serves corrupted data.

### Fix

Call `store.Delete(fileName)` on hash mismatch before returning the error.

### Changelog

#### Commit 1 (`bd34d63`) — Initial fix
- Add `store.Delete(fileName)` before returning hash mismatch error

### Testing
- `go build ./src/server/...` — passes
- `go test ./src/server/...` — all tests pass