### PR TITLE
fix: add per-peer write mutex to prevent wire protocol corruption

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1079,3 +1079,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 0a26155,BenchmarkIndexSearch-8,3.05,0.00,0.00
 0a26155,BenchmarkLoadGlobalConfig-8,675.60,160.00,1.00
 0a26155,BenchmarkPadString-8,2.19,0.00,0.00
+4d5cf1e,BenchmarkCheckMetricsAndSwap-8,7.70,0.00,0.00
+4d5cf1e,BenchmarkCrushOptimized-8,342.90,0.00,0.00
+4d5cf1e,BenchmarkCrushOriginal-8,429.10,164.00,3.00
+4d5cf1e,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+4d5cf1e,BenchmarkIndexSearch-8,3.05,0.00,0.00
+4d5cf1e,BenchmarkLoadGlobalConfig-8,785.60,160.00,1.00
+4d5cf1e,BenchmarkPadString-8,1.94,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1086,3 +1086,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 4d5cf1e,BenchmarkIndexSearch-8,3.05,0.00,0.00
 4d5cf1e,BenchmarkLoadGlobalConfig-8,785.60,160.00,1.00
 4d5cf1e,BenchmarkPadString-8,1.94,0.00,0.00
+9dba11e,BenchmarkCheckMetricsAndSwap-8,13.20,0.00,0.00
+9dba11e,BenchmarkCrushOptimized-8,311.00,0.00,0.00
+9dba11e,BenchmarkCrushOriginal-8,389.00,164.00,3.00
+9dba11e,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+9dba11e,BenchmarkIndexSearch-8,3.02,0.00,0.00
+9dba11e,BenchmarkLoadGlobalConfig-8,1168.00,160.00,1.00
+9dba11e,BenchmarkPadString-8,2.40,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,19 +6,18 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        420.7n ± ∞ ¹    429.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       292.2n ± ∞ ¹    342.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     675.6n ± ∞ ¹    785.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.186n ± ∞ ¹    1.940n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.019n ± ∞ ¹    7.702n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.047n ± ∞ ¹    3.047n ± ∞ ¹       ~ (p=1.000 n=1) ³
-IndexDirectTracking-8                 0.3167n ± ∞ ¹   0.3537n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.89n          21.10n        +6.10%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        429.1n ± ∞ ¹    389.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       342.9n ± ∞ ¹    311.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     785.6n ± ∞ ¹   1168.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.940n ± ∞ ¹    2.404n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.702n ± ∞ ¹   13.200n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.047n ± ∞ ¹    3.022n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3537n ± ∞ ¹   0.3287n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                21.10n          23.90n        +13.27%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
-³ all samples are equal
 
                       │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                       │            B/op             │    B/op      vs base                │
@@ -54,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 342.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 429.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.05 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 785.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 13.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 311.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 389.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1168.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.40 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -83,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e]
-    line "CheckMetricsAndSwap" [8,7,13,7,7,7,7,7,7,8]
-    line "CrushOptimized" [322,289,372,358,318,314,292,347,292,343]
-    line "CrushOriginal" [461,390,572,404,392,438,399,402,421,429]
+    x-axis [d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e]
+    line "CheckMetricsAndSwap" [7,13,7,7,7,7,7,7,8,13]
+    line "CrushOptimized" [289,372,358,318,314,292,347,292,343,311]
+    line "CrushOriginal" [390,572,404,392,438,399,402,421,429,389]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [771,693,1044,713,703,738,714,717,676,786]
-    line "PadString" [2,2,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [693,1044,713,703,738,714,717,676,786,1168]
+    line "PadString" [2,3,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -100,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e]
+    x-axis [d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -117,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e]
+    x-axis [d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,16 +8,17 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        401.7n ± ∞ ¹    420.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       346.9n ± ∞ ¹    292.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     717.1n ± ∞ ¹    675.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.076n ± ∞ ¹    2.186n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.192n ± ∞ ¹    7.019n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.144n ± ∞ ¹    3.047n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.2997n ± ∞ ¹   0.3167n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.27n          19.89n        -1.89%
+CrushOriginal-8                        420.7n ± ∞ ¹    429.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       292.2n ± ∞ ¹    342.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     675.6n ± ∞ ¹    785.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.186n ± ∞ ¹    1.940n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.019n ± ∞ ¹    7.702n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.047n ± ∞ ¹    3.047n ± ∞ ¹       ~ (p=1.000 n=1) ³
+IndexDirectTracking-8                 0.3167n ± ∞ ¹   0.3537n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.89n          21.10n        +6.10%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
+³ all samples are equal
 
                       │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                       │            B/op             │    B/op      vs base                │
@@ -53,13 +54,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 292.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 420.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 342.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 429.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 3.05 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 675.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.19 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 785.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +83,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155]
-    line "CheckMetricsAndSwap" [9,8,7,13,7,7,7,7,7,7]
-    line "CrushOptimized" [348,322,289,372,358,318,314,292,347,292]
-    line "CrushOriginal" [443,461,390,572,404,392,438,399,402,421]
+    x-axis [72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e]
+    line "CheckMetricsAndSwap" [8,7,13,7,7,7,7,7,7,8]
+    line "CrushOptimized" [322,289,372,358,318,314,292,347,292,343]
+    line "CrushOriginal" [461,390,572,404,392,438,399,402,421,429]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [794,771,693,1044,713,703,738,714,717,676]
-    line "PadString" [2,2,2,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [771,693,1044,713,703,738,714,717,676,786]
+    line "PadString" [2,2,3,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +100,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155]
+    x-axis [72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +117,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bf80087,72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155]
+    x-axis [72967cb,d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -217,7 +217,14 @@ func (t *TCPTransport) Consume() <-chan RPC {
 }
 
 // Broadcast sends an RPC to all active peers. Returns the number of peers contacted.
-func (t *TCPTransport) Broadcast(rpc *RPC) int {
+func (t *TCPTransport) Broadcast(rpc *RPC) (result int) {
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("panic in Broadcast: %v: %w", r, syscall.EIO)
+			log.Printf("CRITICAL: %v", err)
+		}
+	}()
+
 	peers := t.peerMap.All()
 	encoded := rpc.Encode()
 	sent := 0
@@ -229,21 +236,29 @@ func (t *TCPTransport) Broadcast(rpc *RPC) int {
 		if conn == nil {
 			continue
 		}
-		p.writeMu.Lock()
-		conn.SetWriteDeadline(time.Now().Add(p2pWriteTimeout))
-		_, err := conn.Write(encoded)
-		p.writeMu.Unlock()
-		if err != nil {
-			log.Printf("P2P broadcast to peer %d failed: %v (errno=%d)", p.ID, err, syscall.EPIPE)
-			continue
-		}
-		sent++
+		func() {
+			p.writeMu.Lock()
+			defer p.writeMu.Unlock()
+			conn.SetWriteDeadline(time.Now().Add(p2pWriteTimeout))
+			if _, err := conn.Write(encoded); err != nil {
+				log.Printf("P2P broadcast to peer %d failed: %v (errno=%d)", p.ID, err, syscall.EPIPE)
+				return
+			}
+			sent++
+		}()
 	}
 	return sent
 }
 
 // Send sends an RPC to a specific peer by ID.
-func (t *TCPTransport) Send(peerID int32, rpc *RPC) error {
+func (t *TCPTransport) Send(peerID int32, rpc *RPC) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in Send to peer %d: %v: %w", peerID, r, syscall.EIO)
+			log.Printf("CRITICAL: %v", err)
+		}
+	}()
+
 	peer := t.peerMap.Get(peerID)
 	if peer == nil {
 		return fmt.Errorf("peer %d not found: %w", peerID, syscall.ENOENT)
@@ -254,10 +269,9 @@ func (t *TCPTransport) Send(peerID int32, rpc *RPC) error {
 	}
 	encoded := rpc.Encode()
 	peer.writeMu.Lock()
+	defer peer.writeMu.Unlock()
 	conn.SetWriteDeadline(time.Now().Add(p2pWriteTimeout))
-	_, err := conn.Write(encoded)
-	peer.writeMu.Unlock()
-	if err != nil {
+	if _, err := conn.Write(encoded); err != nil {
 		return fmt.Errorf("send to peer %d failed: %v: %w", peerID, err, syscall.EPIPE)
 	}
 	return nil

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -229,8 +229,11 @@ func (t *TCPTransport) Broadcast(rpc *RPC) int {
 		if conn == nil {
 			continue
 		}
+		p.writeMu.Lock()
 		conn.SetWriteDeadline(time.Now().Add(p2pWriteTimeout))
-		if _, err := conn.Write(encoded); err != nil {
+		_, err := conn.Write(encoded)
+		p.writeMu.Unlock()
+		if err != nil {
 			log.Printf("P2P broadcast to peer %d failed: %v (errno=%d)", p.ID, err, syscall.EPIPE)
 			continue
 		}
@@ -250,8 +253,11 @@ func (t *TCPTransport) Send(peerID int32, rpc *RPC) error {
 		return fmt.Errorf("peer %d has no connection: %w", peerID, syscall.ENOTCONN)
 	}
 	encoded := rpc.Encode()
+	peer.writeMu.Lock()
 	conn.SetWriteDeadline(time.Now().Add(p2pWriteTimeout))
-	if _, err := conn.Write(encoded); err != nil {
+	_, err := conn.Write(encoded)
+	peer.writeMu.Unlock()
+	if err != nil {
 		return fmt.Errorf("send to peer %d failed: %v: %w", peerID, err, syscall.EPIPE)
 	}
 	return nil

--- a/src/p2p/types.go
+++ b/src/p2p/types.go
@@ -33,6 +33,7 @@ type Peer struct {
 	lastSeen atomic.Int64
 	conn     net.Conn
 	mu       sync.Mutex
+	writeMu  sync.Mutex
 }
 
 // NewPeer creates a new Peer with the given ID and address.


### PR DESCRIPTION
Fixes #392

## Bug: Concurrent Writes Corrupt P2P Wire Protocol

**Severity:** High | **Category:** Race condition | **Location:** `src/p2p/tcp_transport.go:223-245`

### Problem

`Send()` and `Broadcast()` called `conn.Write()` without a per-connection write lock. Concurrent goroutines could interleave frames on the wire, corrupting the length-prefixed protocol.

### Fix

Add `writeMu sync.Mutex` to `Peer` struct. Hold it around `SetWriteDeadline` + `Write` in both `Send` and `Broadcast`. Added `defer recover()` (Rule 37) and `defer unlock()` (Rule 43).

### Changelog

#### Commit 1 (`9dba11e`) — Initial fix
- Add `writeMu sync.Mutex` field to `Peer` struct
- Lock/unlock around writes in `Broadcast` and `Send`

#### Commit 2 (`651ad71`) — Reviewer feedback (Rules 37, 43)
- Add `defer recover()` with named return + `syscall.EIO` to `Send` and `Broadcast`
- Use `defer p.writeMu.Unlock()` to prevent deadlock on panic
- Wrap `Broadcast` per-peer write in closure for safe defer unlock

### Reviewer Status
- **Review 1**: ❌ Missing defer recover, lock not panic-safe
- **Review 2**: Pending

### Testing
- `go build ./src/p2p/...` — passes
- `go test ./src/p2p/...` — all tests pass