### PR TITLE
fix: keep pending ping alive during indirect ping to receive ack

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1107,3 +1107,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 93c96c2,BenchmarkIndexSearch-8,2.96,0.00,0.00
 93c96c2,BenchmarkLoadGlobalConfig-8,748.60,160.00,1.00
 93c96c2,BenchmarkPadString-8,2.06,0.00,0.00
+92e297a,BenchmarkCheckMetricsAndSwap-8,8.91,0.00,0.00
+92e297a,BenchmarkCrushOptimized-8,320.00,0.00,0.00
+92e297a,BenchmarkCrushOriginal-8,493.20,164.00,3.00
+92e297a,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+92e297a,BenchmarkIndexSearch-8,3.23,0.00,0.00
+92e297a,BenchmarkLoadGlobalConfig-8,888.80,160.00,1.00
+92e297a,BenchmarkPadString-8,2.33,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1100,3 +1100,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 51e10cc,BenchmarkIndexSearch-8,3.02,0.00,0.00
 51e10cc,BenchmarkLoadGlobalConfig-8,783.80,160.00,1.00
 51e10cc,BenchmarkPadString-8,2.46,0.00,0.00
+93c96c2,BenchmarkCheckMetricsAndSwap-8,7.21,0.00,0.00
+93c96c2,BenchmarkCrushOptimized-8,354.00,0.00,0.00
+93c96c2,BenchmarkCrushOriginal-8,453.10,164.00,3.00
+93c96c2,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+93c96c2,BenchmarkIndexSearch-8,2.96,0.00,0.00
+93c96c2,BenchmarkLoadGlobalConfig-8,748.60,160.00,1.00
+93c96c2,BenchmarkPadString-8,2.06,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1093,3 +1093,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 9dba11e,BenchmarkIndexSearch-8,3.02,0.00,0.00
 9dba11e,BenchmarkLoadGlobalConfig-8,1168.00,160.00,1.00
 9dba11e,BenchmarkPadString-8,2.40,0.00,0.00
+51e10cc,BenchmarkCheckMetricsAndSwap-8,8.69,0.00,0.00
+51e10cc,BenchmarkCrushOptimized-8,313.00,0.00,0.00
+51e10cc,BenchmarkCrushOriginal-8,432.90,164.00,3.00
+51e10cc,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+51e10cc,BenchmarkIndexSearch-8,3.02,0.00,0.00
+51e10cc,BenchmarkLoadGlobalConfig-8,783.80,160.00,1.00
+51e10cc,BenchmarkPadString-8,2.46,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        389.0n ± ∞ ¹    432.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       311.0n ± ∞ ¹    313.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1168.0n ± ∞ ¹    783.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.404n ± ∞ ¹    2.456n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 13.200n ± ∞ ¹    8.687n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.022n ± ∞ ¹    3.015n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3287n ± ∞ ¹   0.3460n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                23.90n          21.83n        -8.65%
+CrushOriginal-8                        432.9n ± ∞ ¹    453.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       313.0n ± ∞ ¹    354.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     783.8n ± ∞ ¹    748.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.456n ± ∞ ¹    2.064n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.687n ± ∞ ¹    7.205n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.015n ± ∞ ¹    2.962n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3460n ± ∞ ¹   0.3547n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.83n          21.12n        -3.25%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 313.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 432.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.21 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 354.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 453.10 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 783.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 748.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc]
-    line "CheckMetricsAndSwap" [13,7,7,7,7,7,7,8,13,9]
-    line "CrushOptimized" [372,358,318,314,292,347,292,343,311,313]
-    line "CrushOriginal" [572,404,392,438,399,402,421,429,389,433]
+    x-axis [b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2]
+    line "CheckMetricsAndSwap" [7,7,7,7,7,7,8,13,9,7]
+    line "CrushOptimized" [358,318,314,292,347,292,343,311,313,354]
+    line "CrushOriginal" [404,392,438,399,402,421,429,389,433,453]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [1044,713,703,738,714,717,676,786,1168,784]
-    line "PadString" [3,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [713,703,738,714,717,676,786,1168,784,749]
+    line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc]
+    x-axis [b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc]
+    x-axis [b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        432.9n ± ∞ ¹    453.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       313.0n ± ∞ ¹    354.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     783.8n ± ∞ ¹    748.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.456n ± ∞ ¹    2.064n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.687n ± ∞ ¹    7.205n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.015n ± ∞ ¹    2.962n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3460n ± ∞ ¹   0.3547n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                21.83n          21.12n        -3.25%
+CrushOriginal-8                        453.1n ± ∞ ¹    493.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       354.0n ± ∞ ¹    320.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     748.6n ± ∞ ¹    888.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.064n ± ∞ ¹    2.327n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.205n ± ∞ ¹    8.913n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.962n ± ∞ ¹    3.225n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3547n ± ∞ ¹   0.3475n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.12n          22.86n        +8.22%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.21 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 354.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 453.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 320.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 493.20 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.96 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 748.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.23 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 888.80 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.33 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2]
-    line "CheckMetricsAndSwap" [7,7,7,7,7,7,8,13,9,7]
-    line "CrushOptimized" [358,318,314,292,347,292,343,311,313,354]
-    line "CrushOriginal" [404,392,438,399,402,421,429,389,433,453]
+    x-axis [9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a]
+    line "CheckMetricsAndSwap" [7,7,7,7,7,8,13,9,7,9]
+    line "CrushOptimized" [318,314,292,347,292,343,311,313,354,320]
+    line "CrushOriginal" [392,438,399,402,421,429,389,433,453,493]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [713,703,738,714,717,676,786,1168,784,749]
+    line "LoadGlobalConfig" [703,738,714,717,676,786,1168,784,749,889]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2]
+    x-axis [9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2]
+    x-axis [9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        429.1n ± ∞ ¹    389.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       342.9n ± ∞ ¹    311.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     785.6n ± ∞ ¹   1168.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.940n ± ∞ ¹    2.404n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.702n ± ∞ ¹   13.200n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.047n ± ∞ ¹    3.022n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3537n ± ∞ ¹   0.3287n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                21.10n          23.90n        +13.27%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        389.0n ± ∞ ¹    432.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       311.0n ± ∞ ¹    313.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1168.0n ± ∞ ¹    783.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.404n ± ∞ ¹    2.456n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 13.200n ± ∞ ¹    8.687n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.022n ± ∞ ¹    3.015n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3287n ± ∞ ¹   0.3460n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                23.90n          21.83n        -8.65%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 13.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 311.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 389.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 313.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 432.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 3.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1168.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 783.80 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.46 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e]
-    line "CheckMetricsAndSwap" [7,13,7,7,7,7,7,7,8,13]
-    line "CrushOptimized" [289,372,358,318,314,292,347,292,343,311]
-    line "CrushOriginal" [390,572,404,392,438,399,402,421,429,389]
+    x-axis [7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc]
+    line "CheckMetricsAndSwap" [13,7,7,7,7,7,7,8,13,9]
+    line "CrushOptimized" [372,358,318,314,292,347,292,343,311,313]
+    line "CrushOriginal" [572,404,392,438,399,402,421,429,389,433]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [693,1044,713,703,738,714,717,676,786,1168]
-    line "PadString" [2,3,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [1044,713,703,738,714,717,676,786,1168,784]
+    line "PadString" [3,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e]
+    x-axis [7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [d3a108d,7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e]
+    x-axis [7c3c5f5,b816415,9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -230,9 +230,13 @@ func (g *Gossiper) pingLoop() {
 // sendPing sends a direct ping to one random alive peer and waits for an ack.
 // On timeout, it initiates an indirect ping through K other peers.
 func (g *Gossiper) sendPing() {
+	var pingID uint64
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("Gossip sendPing panic recovered: %v", r)
+			log.Printf("Gossip sendPing panic recovered: %v (errno=%d)", r, syscall.EIO)
+			if pingID != 0 {
+				g.removePendingPing(pingID)
+			}
 		}
 	}()
 
@@ -241,7 +245,7 @@ func (g *Gossiper) sendPing() {
 		return
 	}
 	target := peers[0]
-	pingID := atomic.AddUint64(&g.nextPingID, 1)
+	pingID = atomic.AddUint64(&g.nextPingID, 1)
 	now := time.Now().UnixNano()
 
 	payload := &PingPayload{

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -230,6 +230,12 @@ func (g *Gossiper) pingLoop() {
 // sendPing sends a direct ping to one random alive peer and waits for an ack.
 // On timeout, it initiates an indirect ping through K other peers.
 func (g *Gossiper) sendPing() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Gossip sendPing panic recovered: %v", r)
+		}
+	}()
+
 	peers := g.transport.Peers().RandomPeers(1, g.cfg.LocalID)
 	if len(peers) == 0 {
 		return

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -271,8 +271,17 @@ func (g *Gossiper) sendPing() {
 		g.rtt.Update(target.ID, rtt)
 		g.removePendingPing(pingID)
 	case <-time.After(g.cfg.PingTimeout):
-		g.removePendingPing(pingID)
 		g.sendIndirectPing(target.ID, pingID, now)
+		select {
+		case <-pp.ackCh:
+			rtt := time.Since(pp.sentAt)
+			g.rtt.Update(target.ID, rtt)
+		case <-time.After(g.cfg.PingTimeout):
+		case <-g.done:
+			g.removePendingPing(pingID)
+			return
+		}
+		g.removePendingPing(pingID)
 	case <-g.done:
 		g.removePendingPing(pingID)
 		return


### PR DESCRIPTION
Resolves #394

## Bug: Indirect Ping Ack Permanently Lost

**Severity:** High | **Category:** Logic error | **Location:** `src/p2p/gossip.go:273-275`

### Problem

`removePendingPing` was called BEFORE `sendIndirectPing`, so when the indirect ack arrived, `handleAck` found no pending entry and silently dropped it. The indirect ping path could never restore a peer to ALIVE.

### Fix

Move `removePendingPing` to AFTER `sendIndirectPing`. Wait briefly for the indirect ack before cleaning up. This gives the indirect ping mechanism a chance to receive and process the ack.

### Changelog

#### Commit 1 (`93c96c2`) — Initial fix
- Remove `removePendingPing` from before `sendIndirectPing`
- Add a second `select` after `sendIndirectPing` to wait for the indirect ack
- Clean up pending ping after the indirect ack wait completes

#### Commit 2 (`92e297a`) — Reviewer round 1
- Add `defer recover()` to `sendPing` (Rule 37: Unified Observable Panic Recovery)
- `ackCh` is buffered (cap=1) + `removePendingPing` removes map entry → no goroutine leak on late ACK
- Nested `select` already handles `case <-g.done` → no timer leak

#### Commit 3 (`4ea038a`) — Reviewer round 2
- Log `recover()` with `syscall.EIO` context (Rule 37)
- Call `g.removePendingPing(pingID)` in recover block to release pending channel state (Rule 43: Panic-Safe Resource Releasing)
- Hoist `var pingID uint64` before defer for recover access; guard with `if pingID != 0`