### PR TITLE
Bug #10: Fix indirect ping suspect marking based on helper contact, not target ack

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1114,3 +1114,10 @@ ba923a4,BenchmarkPadString-8,1.89,0.00,0.00
 92e297a,BenchmarkIndexSearch-8,3.23,0.00,0.00
 92e297a,BenchmarkLoadGlobalConfig-8,888.80,160.00,1.00
 92e297a,BenchmarkPadString-8,2.33,0.00,0.00
+67dd805,BenchmarkCheckMetricsAndSwap-8,7.84,0.00,0.00
+67dd805,BenchmarkCrushOptimized-8,356.70,0.00,0.00
+67dd805,BenchmarkCrushOriginal-8,450.50,164.00,3.00
+67dd805,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+67dd805,BenchmarkIndexSearch-8,2.81,0.00,0.00
+67dd805,BenchmarkLoadGlobalConfig-8,827.10,160.00,1.00
+67dd805,BenchmarkPadString-8,2.32,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        453.1n ± ∞ ¹    493.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       354.0n ± ∞ ¹    320.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     748.6n ± ∞ ¹    888.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.064n ± ∞ ¹    2.327n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.205n ± ∞ ¹    8.913n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.962n ± ∞ ¹    3.225n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3547n ± ∞ ¹   0.3475n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                21.12n          22.86n        +8.22%
+CrushOriginal-8                        493.2n ± ∞ ¹    450.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       320.0n ± ∞ ¹    356.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     888.8n ± ∞ ¹    827.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.327n ± ∞ ¹    2.316n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.913n ± ∞ ¹    7.845n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.225n ± ∞ ¹    2.814n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3475n ± ∞ ¹   0.3378n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                22.86n          21.74n        -4.89%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 320.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 493.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.23 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 888.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 356.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 450.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.81 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 827.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.32 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a]
-    line "CheckMetricsAndSwap" [7,7,7,7,7,8,13,9,7,9]
-    line "CrushOptimized" [318,314,292,347,292,343,311,313,354,320]
-    line "CrushOriginal" [392,438,399,402,421,429,389,433,453,493]
+    x-axis [523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a,67dd805]
+    line "CheckMetricsAndSwap" [7,7,7,7,8,13,9,7,9,8]
+    line "CrushOptimized" [314,292,347,292,343,311,313,354,320,357]
+    line "CrushOriginal" [438,399,402,421,429,389,433,453,493,450]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [703,738,714,717,676,786,1168,784,749,889]
+    line "LoadGlobalConfig" [738,714,717,676,786,1168,784,749,889,827]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a]
+    x-axis [523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a,67dd805]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [9172f13,523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a]
+    x-axis [523dcbd,ba923a4,15c81ac,0a26155,4d5cf1e,9dba11e,51e10cc,93c96c2,92e297a,67dd805]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -281,12 +281,28 @@ func (g *Gossiper) sendPing() {
 		g.rtt.Update(target.ID, rtt)
 		g.removePendingPing(pingID)
 	case <-time.After(g.cfg.PingTimeout):
-		g.sendIndirectPing(target.ID, pingID, now)
+		helperContacted := g.sendIndirectPing(target.ID, pingID, now)
+		if !helperContacted {
+			if peer := g.transport.Peers().Get(target.ID); peer != nil {
+				if peer.State() == PeerStateAlive {
+					peer.SetState(PeerStateSuspect)
+					log.Printf("Gossip: peer %d marked SUSPECT (ping failed, no helper contacted)", target.ID)
+				}
+			}
+			g.removePendingPing(pingID)
+			return
+		}
 		select {
 		case <-pp.ackCh:
 			rtt := time.Since(pp.sentAt)
 			g.rtt.Update(target.ID, rtt)
 		case <-time.After(g.cfg.PingTimeout):
+			if peer := g.transport.Peers().Get(target.ID); peer != nil {
+				if peer.State() == PeerStateAlive {
+					peer.SetState(PeerStateSuspect)
+					log.Printf("Gossip: peer %d marked SUSPECT (ping + indirect ping ack timeout)", target.ID)
+				}
+			}
 		case <-g.done:
 			g.removePendingPing(pingID)
 			return
@@ -299,10 +315,11 @@ func (g *Gossiper) sendPing() {
 }
 
 // sendIndirectPing asks K random peers to ping the target on our behalf.
-func (g *Gossiper) sendIndirectPing(targetID int32, pingID uint64, timestamp int64) {
+// Returns true if at least one helper peer was successfully contacted.
+func (g *Gossiper) sendIndirectPing(targetID int32, pingID uint64, timestamp int64) bool {
 	peers := g.transport.Peers().RandomPeers(g.cfg.IndirectPingCount, g.cfg.LocalID)
 	if len(peers) == 0 {
-		return
+		return false
 	}
 
 	payload := &PingPayload{
@@ -339,14 +356,7 @@ func (g *Gossiper) sendIndirectPing(targetID int32, pingID uint64, timestamp int
 	}
 	wg.Wait()
 
-	if len(indirectAck) == 0 {
-		if peer := g.transport.Peers().Get(targetID); peer != nil {
-			if peer.State() == PeerStateAlive {
-				peer.SetState(PeerStateSuspect)
-				log.Printf("Gossip: peer %d marked SUSPECT (ping + indirect ping failed)", targetID)
-			}
-		}
-	}
+	return len(indirectAck) > 0
 }
 
 // removePendingPing removes a pending ping entry safely.


### PR DESCRIPTION
Resolves #396

## Bug: Indirect Ping Suspect Marking Based on Helper Contact, Not Target Ack

**Severity:** High | **Category:** Logic error | **Location:** `src/p2p/gossip.go:342-349`

### Problem

`sendIndirectPing` marked the target peer as SUSPECT only when `len(indirectAck) == 0` (no helper could be contacted). But `indirectAck` tracks helper contact success, NOT target ack. If helpers were contacted but target was unreachable, the peer stayed ALIVE.

### Fix

1. `sendIndirectPing` now returns `bool` (whether any helper was contacted).
2. Suspect marking moved to `sendPing`:
   - If no helper contacted → mark SUSPECT immediately.
   - If helpers contacted but indirect ack times out → mark SUSPECT.
3. Both cases check `peer.State() == PeerStateAlive` before setting SUSPECT.