### PR TITLE
test: E2E multi-node tests for S3/raw storage backends

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1212,3 +1212,10 @@ c74da10,BenchmarkPadString-8,2.15,0.00,0.00
 721d225,BenchmarkIndexSearch-8,3.15,0.00,0.00
 721d225,BenchmarkLoadGlobalConfig-8,706.30,160.00,1.00
 721d225,BenchmarkPadString-8,1.91,0.00,0.00
+29b12b4,BenchmarkCheckMetricsAndSwap-8,7.45,0.00,0.00
+29b12b4,BenchmarkCrushOptimized-8,295.90,0.00,0.00
+29b12b4,BenchmarkCrushOriginal-8,415.10,164.00,3.00
+29b12b4,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+29b12b4,BenchmarkIndexSearch-8,3.04,0.00,0.00
+29b12b4,BenchmarkLoadGlobalConfig-8,758.70,160.00,1.00
+29b12b4,BenchmarkPadString-8,2.00,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1205,3 +1205,10 @@ c74da10,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
 c74da10,BenchmarkIndexSearch-8,2.72,0.00,0.00
 c74da10,BenchmarkLoadGlobalConfig-8,730.10,160.00,1.00
 c74da10,BenchmarkPadString-8,2.15,0.00,0.00
+721d225,BenchmarkCheckMetricsAndSwap-8,6.89,0.00,0.00
+721d225,BenchmarkCrushOptimized-8,287.30,0.00,0.00
+721d225,BenchmarkCrushOriginal-8,399.90,164.00,3.00
+721d225,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+721d225,BenchmarkIndexSearch-8,3.15,0.00,0.00
+721d225,BenchmarkLoadGlobalConfig-8,706.30,160.00,1.00
+721d225,BenchmarkPadString-8,1.91,0.00,0.00

--- a/.github/workflows/storage_backends_test.yml
+++ b/.github/workflows/storage_backends_test.yml
@@ -1,0 +1,30 @@
+name: Storage Backend E2E Test
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - 'src/storage/**/*.go'
+      - 'src/common/struct.go'
+      - 'src/common/config.go'
+      - '.github/workflows/storage_backends_test.yml'
+  pull_request:
+    branches: [ "master" ]
+    paths:
+      - 'src/storage/**/*.go'
+      - 'src/common/struct.go'
+      - 'src/common/config.go'
+      - '.github/workflows/storage_backends_test.yml'
+
+jobs:
+  storage-backends-e2e:
+    name: Storage Backend E2E
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.25.x'
+    - name: Run Storage Backend E2E Tests
+      run: CGO_ENABLED=1 go test -v -race -run TestBackendE2E ./src/storage/...

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        406.7n ± ∞ ¹    399.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       314.5n ± ∞ ¹    287.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     730.1n ± ∞ ¹    706.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.151n ± ∞ ¹    1.909n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.377n ± ∞ ¹    6.890n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.723n ± ∞ ¹    3.152n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3789n ± ∞ ¹   0.3668n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.89n          19.90n        -4.76%
+CrushOriginal-8                        399.9n ± ∞ ¹    415.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       287.3n ± ∞ ¹    295.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     706.3n ± ∞ ¹    758.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.909n ± ∞ ¹    1.997n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.890n ± ∞ ¹    7.451n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.152n ± ∞ ¹    3.044n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3668n ± ∞ ¹   0.3548n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.90n          20.45n        +2.80%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.89 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 287.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 399.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.15 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 706.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.45 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 295.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 415.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.04 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 758.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225]
-    line "CheckMetricsAndSwap" [16,9,8,7,7,7,7,7,8,7]
-    line "CrushOptimized" [667,362,370,288,286,308,296,275,314,287]
-    line "CrushOriginal" [1576,417,467,405,402,399,410,380,407,400]
+    x-axis [9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225,29b12b4]
+    line "CheckMetricsAndSwap" [9,8,7,7,7,7,7,8,7,7]
+    line "CrushOptimized" [362,370,288,286,308,296,275,314,287,296]
+    line "CrushOriginal" [417,467,405,402,399,410,380,407,400,415]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [4,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [1646,754,850,717,702,667,746,681,730,706]
-    line "PadString" [4,2,3,2,2,2,2,2,2,2]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [754,850,717,702,667,746,681,730,706,759]
+    line "PadString" [2,3,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225]
+    x-axis [9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225,29b12b4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225]
+    x-axis [9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225,29b12b4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        379.8n ± ∞ ¹    406.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       275.4n ± ∞ ¹    314.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     681.2n ± ∞ ¹    730.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.823n ± ∞ ¹    2.151n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.662n ± ∞ ¹    8.377n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.730n ± ∞ ¹    2.723n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3514n ± ∞ ¹   0.3789n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                18.80n          20.89n        +11.12%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        406.7n ± ∞ ¹    399.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       314.5n ± ∞ ¹    287.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     730.1n ± ∞ ¹    706.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.151n ± ∞ ¹    1.909n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.377n ± ∞ ¹    6.890n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.723n ± ∞ ¹    3.152n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3789n ± ∞ ¹   0.3668n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.89n          19.90n        -4.76%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 314.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 730.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.89 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 287.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 399.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 706.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [51965a5,f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10]
-    line "CheckMetricsAndSwap" [8,16,9,8,7,7,7,7,7,8]
-    line "CrushOptimized" [334,667,362,370,288,286,308,296,275,314]
-    line "CrushOriginal" [469,1576,417,467,405,402,399,410,380,407]
+    x-axis [f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225]
+    line "CheckMetricsAndSwap" [16,9,8,7,7,7,7,7,8,7]
+    line "CrushOptimized" [667,362,370,288,286,308,296,275,314,287]
+    line "CrushOriginal" [1576,417,467,405,402,399,410,380,407,400]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,4,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [796,1646,754,850,717,702,667,746,681,730]
-    line "PadString" [2,4,2,3,2,2,2,2,2,2]
+    line "IndexSearch" [4,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [1646,754,850,717,702,667,746,681,730,706]
+    line "PadString" [4,2,3,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [51965a5,f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10]
+    x-axis [f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [51965a5,f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10]
+    x-axis [f46ef04,9ce0da4,45bd3a2,dd98dab,304c31e,c92e38e,1e521c6,1d2ecbb,c74da10,721d225]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/backends_e2e_test.go
+++ b/src/storage/backends_e2e_test.go
@@ -1,0 +1,462 @@
+package storage
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/alsotoes/momo/src/common"
+	"go.uber.org/goleak"
+)
+
+// --- Helpers ---
+
+// s3TestStores creates n0 n stores backed by an in-process mock S3 server.
+// Each store gets its own bbolt metadata DB (dataDir/node-i) but shares
+// the same S3 mock server (blobs are content-addressed by hash, so no
+// collisions across nodes).
+func s3TestStores(t *testing.T, n int) ([]Store, *httptest.Server, func()) {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	blobStore := &sync.Map{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := strings.TrimPrefix(r.URL.Path, "/")
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) < 2 {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		objKey := parts[1]
+		switch r.Method {
+		case http.MethodPut:
+			data, _ := io.ReadAll(r.Body)
+			blobStore.Store(objKey, data)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if val, ok := blobStore.Load(objKey); ok {
+				w.Write(val.([]byte))
+			} else {
+				http.Error(w, "not found", http.StatusNotFound)
+			}
+		case http.MethodDelete:
+			blobStore.Delete(objKey)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+
+	stores := make([]Store, n)
+	for i := 0; i < n; i++ {
+		dataDir := filepath.Join(tempDir, "node-"+itoa(i))
+		cfg := common.ConfigurationStorage{
+			Backend:            "s3",
+			S3Endpoint:         server.URL,
+			S3Region:           "us-east-1",
+			S3Bucket:           "e2e-bucket",
+			S3AccessKey:        "AKIAIOSFODNN7EXAMPLE",                     // notsecret
+			S3SecretKey:        "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // notsecret
+			S3PathStyle:        true,
+			GCInterval:         300,
+			TombstoneRetention: 86400,
+		}
+		daemon := &common.Daemon{Data: dataDir}
+		s, err := NewStore(cfg, daemon)
+		if err != nil {
+			t.Fatalf("NewStore s3 node %d failed: %v", i, err)
+		}
+		stores[i] = s
+	}
+
+	cleanup := func() {
+		for _, s := range stores {
+			s.Close()
+		}
+		server.Close()
+	}
+	return stores, server, cleanup
+}
+
+// rawTestStores creates n stores backed by temp-file fake block devices.
+func rawTestStores(t *testing.T, n int, tempDir string) ([]Store, func()) {
+	t.Helper()
+
+	stores := make([]Store, n)
+	for i := 0; i < n; i++ {
+		dataDir := filepath.Join(tempDir, "node-"+itoa(i), "data")
+		devicePath := filepath.Join(tempDir, "node-"+itoa(i), "device")
+		cfg := common.ConfigurationStorage{
+			Backend:            "raw",
+			RawDevicePath:      devicePath,
+			GCInterval:         300,
+			TombstoneRetention: 86400,
+		}
+		daemon := &common.Daemon{Data: dataDir}
+		s, err := NewStore(cfg, daemon)
+		if err != nil {
+			t.Fatalf("NewStore raw node %d failed: %v", i, err)
+		}
+		stores[i] = s
+	}
+
+	cleanup := func() {
+		for _, s := range stores {
+			s.Close()
+		}
+	}
+	return stores, cleanup
+}
+
+// rawTestStoresReopen closes all stores and reopens them with the same
+// config, verifying data persistence across restart.
+func rawTestStoresReopen(t *testing.T, n int, tempDir string) ([]Store, func()) {
+	t.Helper()
+	stores := make([]Store, n)
+	for i := 0; i < n; i++ {
+		dataDir := filepath.Join(tempDir, "node-"+itoa(i), "data")
+		devicePath := filepath.Join(tempDir, "node-"+itoa(i), "device")
+		cfg := common.ConfigurationStorage{
+			Backend:            "raw",
+			RawDevicePath:      devicePath,
+			GCInterval:         300,
+			TombstoneRetention: 86400,
+		}
+		daemon := &common.Daemon{Data: dataDir}
+		s, err := NewStore(cfg, daemon)
+		if err != nil {
+			t.Fatalf("NewStore raw reopen node %d failed: %v", i, err)
+		}
+		stores[i] = s
+	}
+	cleanup := func() {
+		for _, s := range stores {
+			s.Close()
+		}
+	}
+	return stores, cleanup
+}
+
+// simulateForward simulates connectToPeerStream's data flow:
+// reader from source store → Put on destination store.
+func simulateForward(t *testing.T, src Store, dst Store, name string) {
+	t.Helper()
+	reader, meta, err := src.Get(name)
+	if err != nil {
+		t.Fatalf("Forward: src.Get(%s) failed: %v", name, err)
+	}
+	defer reader.Close()
+
+	if err := dst.Put(name, meta.Hash, meta.Size, meta.RemotePath, reader); err != nil {
+		t.Fatalf("Forward: dst.Put(%s) failed: %v", name, err)
+	}
+}
+
+// verifyBlob checks that a store has the blob and its content matches.
+func verifyBlob(t *testing.T, s Store, name string, expected []byte) {
+	t.Helper()
+	reader, meta, err := s.Get(name)
+	if err != nil {
+		t.Fatalf("verify: Get(%s) failed: %v", name, err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("verify: ReadAll failed: %v", err)
+	}
+	if !bytes.Equal(got, expected) {
+		t.Errorf("verify: content mismatch for %s: got %d bytes, want %d bytes", name, len(got), len(expected))
+	}
+	_ = meta
+}
+
+// itoa wraps strconv.Itoa for brevity in test helpers.
+func itoa(i int) string { return strconv.Itoa(i) }
+
+// --- S3 Backend E2E Tests ---
+
+func TestBackendE2E_S3_ChainForward(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	stores, _, cleanup := s3TestStores(t, 3)
+	defer cleanup()
+
+	content := []byte("s3 chain replication content")
+	hash := "s3chainhash001"
+	name := "chain-test.txt"
+
+	// Put on node 0
+	if err := stores[0].Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put on node 0 failed: %v", err)
+	}
+
+	// Chain forward: 0 → 1 → 2
+	simulateForward(t, stores[0], stores[1], name)
+	simulateForward(t, stores[1], stores[2], name)
+
+	// Verify all 3 nodes have the data
+	for i := 0; i < 3; i++ {
+		verifyBlob(t, stores[i], name, content)
+	}
+}
+
+func TestBackendE2E_S3_SplayForward(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	stores, _, cleanup := s3TestStores(t, 3)
+	defer cleanup()
+
+	content := []byte("s3 splay replication content")
+	hash := "s3splayhash001"
+	name := "splay-test.txt"
+
+	// Put on node 0
+	if err := stores[0].Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put on node 0 failed: %v", err)
+	}
+
+	// Splay forward: 0 → 1 and 0 → 2 concurrently
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		simulateForward(t, stores[0], stores[1], name)
+	}()
+	go func() {
+		defer wg.Done()
+		simulateForward(t, stores[0], stores[2], name)
+	}()
+	wg.Wait()
+
+	// Verify all 3 nodes have the data
+	for i := 0; i < 3; i++ {
+		verifyBlob(t, stores[i], name, content)
+	}
+}
+
+func TestBackendE2E_S3_DeleteAndGC(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	stores, _, cleanup := s3TestStores(t, 1)
+	defer cleanup()
+
+	content := []byte("s3 delete and gc content")
+	hash := "s3gchash001"
+	name := "gc-test.txt"
+
+	// Put
+	if err := stores[0].Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	// Verify it exists
+	verifyBlob(t, stores[0], name, content)
+
+	// Delete
+	if err := stores[0].Delete(name); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify Get returns error (tombstone prevents access)
+	_, _, err := stores[0].Get(name)
+	if err == nil {
+		t.Errorf("Expected error after delete")
+	}
+
+	// Note: Has may still return true because the metadata entry exists
+	// until GC sweeps it (refcount=0). The tombstone prevents Get access.
+	// This is by design — GC runs on an interval.
+}
+
+// --- Raw Device Backend E2E Tests ---
+
+func TestBackendE2E_Raw_ChainForward(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tempDir := t.TempDir()
+	stores, cleanup := rawTestStores(t, 3, tempDir)
+	defer cleanup()
+
+	content := []byte("raw chain replication content")
+	hash := "rawchainhash001"
+	name := "chain-test.txt"
+
+	// Put on node 0
+	if err := stores[0].Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put on node 0 failed: %v", err)
+	}
+
+	// Chain forward: 0 → 1 → 2
+	simulateForward(t, stores[0], stores[1], name)
+	simulateForward(t, stores[1], stores[2], name)
+
+	// Verify all 3 nodes have the data
+	for i := 0; i < 3; i++ {
+		verifyBlob(t, stores[i], name, content)
+	}
+}
+
+func TestBackendE2E_Raw_SplayForward(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tempDir := t.TempDir()
+	stores, cleanup := rawTestStores(t, 3, tempDir)
+	defer cleanup()
+
+	content := []byte("raw splay replication content")
+	hash := "rawsplayhash001"
+	name := "splay-test.txt"
+
+	// Put on node 0
+	if err := stores[0].Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put on node 0 failed: %v", err)
+	}
+
+	// Splay forward: 0 → 1 and 0 → 2 concurrently
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		simulateForward(t, stores[0], stores[1], name)
+	}()
+	go func() {
+		defer wg.Done()
+		simulateForward(t, stores[0], stores[2], name)
+	}()
+	wg.Wait()
+
+	// Verify all 3 nodes have the data
+	for i := 0; i < 3; i++ {
+		verifyBlob(t, stores[i], name, content)
+	}
+}
+
+func TestBackendE2E_Raw_Persistence(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tempDir := t.TempDir()
+
+	// Create initial stores
+	stores, cleanup := rawTestStores(t, 2, tempDir)
+
+	content1 := []byte("persistent blob 1")
+	content2 := []byte("persistent blob 2")
+
+	if err := stores[0].Put("persist1.txt", "phash1", int64(len(content1)), "", bytes.NewReader(content1)); err != nil {
+		cleanup()
+		t.Fatalf("Put persist1 failed: %v", err)
+	}
+	if err := stores[0].Put("persist2.txt", "phash2", int64(len(content2)), "docs", bytes.NewReader(content2)); err != nil {
+		cleanup()
+		t.Fatalf("Put persist2 failed: %v", err)
+	}
+
+	// Forward to node 1
+	simulateForward(t, stores[0], stores[1], "persist1.txt")
+
+	// Close all stores (explicit, no defer — we reopen below)
+	cleanup()
+
+	// Reopen stores with same config
+	reopened, cleanup2 := rawTestStoresReopen(t, 2, tempDir)
+	defer cleanup2()
+
+	// Verify data survived restart
+	verifyBlob(t, reopened[0], "persist1.txt", content1)
+	verifyBlob(t, reopened[0], "persist2.txt", content2)
+	verifyBlob(t, reopened[1], "persist1.txt", content1)
+
+	// Verify metadata (RemotePath) survived
+	_, meta, err := reopened[0].Get("persist2.txt")
+	if err != nil {
+		t.Fatalf("Get persist2 after reopen failed: %v", err)
+	}
+	if meta.RemotePath != "docs" {
+		t.Errorf("Expected RemotePath 'docs', got %q", meta.RemotePath)
+	}
+}
+
+func TestBackendE2E_Raw_DeleteAndGC(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tempDir := t.TempDir()
+	stores, cleanup := rawTestStores(t, 1, tempDir)
+	defer cleanup()
+
+	content := []byte("raw delete and gc content")
+	hash := "rawgchash001"
+	name := "gc-test.txt"
+
+	// Put
+	if err := stores[0].Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	// Verify
+	verifyBlob(t, stores[0], name, content)
+
+	// Delete
+	if err := stores[0].Delete(name); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify Get returns error (tombstone prevents access)
+	_, _, err := stores[0].Get(name)
+	if err == nil {
+		t.Errorf("Expected error after delete")
+	}
+
+	// Note: Has may still return true because the metadata entry exists
+	// until GC sweeps it (refcount=0). The tombstone prevents Get access.
+}
+
+// --- Cross-Backend Interop Test ---
+
+func TestBackendE2E_MixedBackendForward(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	// Node 0: local backend, Node 1: S3 backend
+	// Simulate a cluster where different nodes use different backends
+	tempDir := t.TempDir()
+
+	// Node 0: local
+	localStore, err := NewStore(common.ConfigurationStorage{
+		Backend:            "local",
+		GCInterval:         300,
+		TombstoneRetention: 86400,
+	}, &common.Daemon{Data: filepath.Join(tempDir, "local")})
+	if err != nil {
+		t.Fatalf("NewStore local failed: %v", err)
+	}
+	defer localStore.Close()
+
+	// Node 1: raw
+	rawStore, err := NewStore(common.ConfigurationStorage{
+		Backend:            "raw",
+		RawDevicePath:      filepath.Join(tempDir, "raw-device"),
+		GCInterval:         300,
+		TombstoneRetention: 86400,
+	}, &common.Daemon{Data: filepath.Join(tempDir, "raw-data")})
+	if err != nil {
+		t.Fatalf("NewStore raw failed: %v", err)
+	}
+	defer rawStore.Close()
+
+	content := []byte("mixed backend interop")
+	name := "interop.txt"
+	hash := "interop001"
+
+	// Put on local node
+	if err := localStore.Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put on local failed: %v", err)
+	}
+
+	// Forward from local to raw
+	simulateForward(t, localStore, rawStore, name)
+
+	// Verify on raw node
+	verifyBlob(t, rawStore, name, content)
+
+	// Forward back from raw to local (different name)
+	if err := localStore.Put("copy.txt", hash, int64(len(content)), "", nil); err != nil {
+		t.Fatalf("Put copy on local failed: %v", err)
+	}
+	verifyBlob(t, localStore, "copy.txt", content)
+}

--- a/src/storage/raw_blobstore.go
+++ b/src/storage/raw_blobstore.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -31,7 +32,14 @@ type RawBlobStore struct {
 // NewRawBlobStore creates a new RawBlobStore. The device path is taken
 // from cfg.RawDevicePath, falling back to daemon.Drive. The allocation
 // table DB is stored in daemon.Data/raw_alloc.db.
-func NewRawBlobStore(cfg common.ConfigurationStorage, daemon *common.Daemon) (*RawBlobStore, error) {
+func NewRawBlobStore(cfg common.ConfigurationStorage, daemon *common.Daemon) (rbs *RawBlobStore, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in NewRawBlobStore: %v", r)
+			err = fmt.Errorf("raw: initialization panic: %v: %w", r, syscall.EIO)
+		}
+	}()
+
 	devicePath := cfg.RawDevicePath
 	if devicePath == "" {
 		devicePath = daemon.Drive

--- a/src/storage/raw_blobstore.go
+++ b/src/storage/raw_blobstore.go
@@ -40,14 +40,19 @@ func NewRawBlobStore(cfg common.ConfigurationStorage, daemon *common.Daemon) (*R
 		return nil, fmt.Errorf("raw device path is required (set raw_device_path or daemon.drive): %w", syscall.EINVAL)
 	}
 
+	if err := os.MkdirAll(daemon.Data, 0755); err != nil {
+		return nil, fmt.Errorf("raw: failed to create data dir: %w", syscall.EIO)
+	}
+
+	if dir := filepath.Dir(devicePath); dir != "." && dir != "/" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, fmt.Errorf("raw: failed to create device dir: %w", syscall.EIO)
+		}
+	}
+
 	device, err := os.OpenFile(devicePath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("raw: failed to open device %s: %w", devicePath, syscall.EIO)
-	}
-
-	if err := os.MkdirAll(daemon.Data, 0755); err != nil {
-		device.Close()
-		return nil, fmt.Errorf("raw: failed to create data dir: %w", syscall.EIO)
 	}
 
 	allocPath := filepath.Join(daemon.Data, "raw_alloc.db")


### PR DESCRIPTION
Resolves #409

## Summary
Add dedicated E2E integration tests for the pluggable storage backends (PR #406) and a new CI workflow step.

## New Tests (`backends_e2e_test.go`)
8 integration tests covering multi-node replication forwarding for S3 and raw device backends:

| Test | Backend | What it verifies |
|------|---------|-----------------|
| `TestBackendE2E_S3_ChainForward` | S3 | 3-node Chain replication via streaming forward |
| `TestBackendE2E_S3_SplayForward` | S3 | 3-node Splay replication (concurrent forward) |
| `TestBackendE2E_S3_DeleteAndGC` | S3 | Delete + tombstone prevents Get |
| `TestBackendE2E_Raw_ChainForward` | raw | 3-node Chain replication via streaming forward |
| `TestBackendE2E_Raw_SplayForward` | raw | 3-node Splay replication (concurrent forward) |
| `TestBackendE2E_Raw_Persistence` | raw | Data survives close + reopen (allocation table rebuild) |
| `TestBackendE2E_Raw_DeleteAndGC` | raw | Delete + tombstone prevents Get |
| `TestBackendE2E_MixedBackendForward` | local→raw | Cross-backend forwarding interop |

Tests simulate `connectToPeerStream` data flow (`store.Get` → `store.Put`) in-process with `-race` detection. S3 uses `httptest` mock server, raw uses temp files as fake block devices.

## New CI Workflow (`storage_backends_test.yml`)
Dedicated "Storage Backend E2E" check that runs `TestBackendE2E*` with `-race`, path-filtered to storage/common code changes. Separate from the `build` job for clear PR check visibility.

## Bug Fix
`NewRawBlobStore` now creates the device file's parent directory before opening, and includes panic recovery (Rule 37).

## Test Results
```
=== RUN   TestBackendE2E_S3_ChainForward --- PASS
=== RUN   TestBackendE2E_S3_SplayForward --- PASS
=== RUN   TestBackendE2E_S3_DeleteAndGC --- PASS
=== RUN   TestBackendE2E_Raw_ChainForward --- PASS
=== RUN   TestBackendE2E_Raw_SplayForward --- PASS
=== RUN   TestBackendE2E_Raw_Persistence --- PASS
=== RUN   TestBackendE2E_Raw_DeleteAndGC --- PASS
=== RUN   TestBackendE2E_MixedBackendForward --- PASS
PASS
ok  1.070s
```