### PR TITLE
fix: check Close() error and add Sync() before Rename in LocalBlobStore

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1345,3 +1345,10 @@ bc76d3f,BenchmarkPadString-8,2.34,0.00,0.00
 9bd2937,BenchmarkIndexSearch-8,1.74,0.00,0.00
 9bd2937,BenchmarkLoadGlobalConfig-8,739.30,160.00,1.00
 9bd2937,BenchmarkPadString-8,2.02,0.00,0.00
+7b6193c,BenchmarkCheckMetricsAndSwap-8,6.69,0.00,0.00
+7b6193c,BenchmarkCrushOptimized-8,318.20,0.00,0.00
+7b6193c,BenchmarkCrushOriginal-8,412.60,164.00,3.00
+7b6193c,BenchmarkIndexDirectTracking-8,0.41,0.00,0.00
+7b6193c,BenchmarkIndexSearch-8,1.64,0.00,0.00
+7b6193c,BenchmarkLoadGlobalConfig-8,787.30,160.00,1.00
+7b6193c,BenchmarkPadString-8,2.00,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1352,3 +1352,10 @@ bc76d3f,BenchmarkPadString-8,2.34,0.00,0.00
 7b6193c,BenchmarkIndexSearch-8,1.64,0.00,0.00
 7b6193c,BenchmarkLoadGlobalConfig-8,787.30,160.00,1.00
 7b6193c,BenchmarkPadString-8,2.00,0.00,0.00
+2a3cd10,BenchmarkCheckMetricsAndSwap-8,8.26,0.00,0.00
+2a3cd10,BenchmarkCrushOptimized-8,313.20,0.00,0.00
+2a3cd10,BenchmarkCrushOriginal-8,433.00,164.00,3.00
+2a3cd10,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+2a3cd10,BenchmarkIndexSearch-8,1.62,0.00,0.00
+2a3cd10,BenchmarkLoadGlobalConfig-8,780.10,160.00,1.00
+2a3cd10,BenchmarkPadString-8,1.98,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        415.4n ± ∞ ¹    407.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       302.4n ± ∞ ¹    295.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     725.6n ± ∞ ¹    739.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.965n ± ∞ ¹    2.020n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.449n ± ∞ ¹    7.760n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.600n ± ∞ ¹    1.737n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3289n ± ∞ ¹   0.3370n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.36n          18.75n        +2.17%
+CrushOriginal-8                        407.8n ± ∞ ¹    412.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       295.0n ± ∞ ¹    318.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     739.3n ± ∞ ¹    787.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.020n ± ∞ ¹    2.005n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.760n ± ∞ ¹    6.691n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.737n ± ∞ ¹    1.635n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3370n ± ∞ ¹   0.4102n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.75n          19.11n        +1.88%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.76 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 295.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 407.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 739.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 318.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 412.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 787.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [5c4f44a,a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937]
-    line "CheckMetricsAndSwap" [7,8,7,7,8,7,8,8,7,8]
-    line "CrushOptimized" [356,314,331,316,299,297,312,319,302,295]
-    line "CrushOriginal" [408,436,427,419,380,396,437,435,415,408]
+    x-axis [a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c]
+    line "CheckMetricsAndSwap" [8,7,7,8,7,8,8,7,8,7]
+    line "CrushOptimized" [314,331,316,299,297,312,319,302,295,318]
+    line "CrushOriginal" [436,427,419,380,396,437,435,415,408,413]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,1,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [676,710,723,803,766,750,1480,790,726,739]
+    line "IndexSearch" [3,3,1,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [710,723,803,766,750,1480,790,726,739,787]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,13 +99,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [5c4f44a,a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937]
+    x-axis [a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [160,160,160,168,168,160,304,160,160,160]
+    line "LoadGlobalConfig" [160,160,168,168,160,304,160,160,160,160]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -116,13 +116,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [5c4f44a,a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937]
+    x-axis [a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1,1,1,2,2,1,5,1,1,1]
+    line "LoadGlobalConfig" [1,1,2,2,1,5,1,1,1,1]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        407.8n ± ∞ ¹    412.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       295.0n ± ∞ ¹    318.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     739.3n ± ∞ ¹    787.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.020n ± ∞ ¹    2.005n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.760n ± ∞ ¹    6.691n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.737n ± ∞ ¹    1.635n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3370n ± ∞ ¹   0.4102n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.75n          19.11n        +1.88%
+CrushOriginal-8                        412.6n ± ∞ ¹    433.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       318.2n ± ∞ ¹    313.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     787.3n ± ∞ ¹    780.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.005n ± ∞ ¹    1.984n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.691n ± ∞ ¹    8.263n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.635n ± ∞ ¹    1.621n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4102n ± ∞ ¹   0.3425n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.11n          19.20n        +0.50%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 318.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 412.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 787.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.26 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 313.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 433.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.62 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 780.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c]
-    line "CheckMetricsAndSwap" [8,7,7,8,7,8,8,7,8,7]
-    line "CrushOptimized" [314,331,316,299,297,312,319,302,295,318]
-    line "CrushOriginal" [436,427,419,380,396,437,435,415,408,413]
+    x-axis [c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10]
+    line "CheckMetricsAndSwap" [7,7,8,7,8,8,7,8,7,8]
+    line "CrushOptimized" [331,316,299,297,312,319,302,295,318,313]
+    line "CrushOriginal" [427,419,380,396,437,435,415,408,413,433]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,1,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [710,723,803,766,750,1480,790,726,739,787]
+    line "IndexSearch" [3,1,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [723,803,766,750,1480,790,726,739,787,780]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,13 +99,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c]
+    x-axis [c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [160,160,168,168,160,304,160,160,160,160]
+    line "LoadGlobalConfig" [160,168,168,160,304,160,160,160,160,160]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -116,13 +116,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [a6ba68c,c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c]
+    x-axis [c2f3419,3ce1f67,a58b914,bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1,1,2,2,1,5,1,1,1,1]
+    line "LoadGlobalConfig" [1,2,2,1,5,1,1,1,1,1]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/storage/local_blobstore.go
+++ b/src/storage/local_blobstore.go
@@ -50,7 +50,17 @@ func (b *LocalBlobStore) PutBlob(hash string, content io.Reader) error {
 		os.Remove(tmpPath)
 		return fmt.Errorf("storage error: failed to flush blob: %w", syscall.EIO)
 	}
-	tmpFile.Close()
+
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("storage error: failed to fsync blob: %w", syscall.EIO)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("storage error: failed to close blob: %w", syscall.EIO)
+	}
 
 	if err := os.Rename(tmpPath, blobPath); err != nil {
 		os.Remove(tmpPath)

--- a/src/storage/local_blobstore.go
+++ b/src/storage/local_blobstore.go
@@ -4,9 +4,12 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/alsotoes/momo/src/common"
 )
 
 // LocalBlobStore implements BlobStore using the local filesystem with
@@ -25,17 +28,43 @@ func NewLocalBlobStore(dataDir string) (*LocalBlobStore, error) {
 }
 
 // PutBlob writes a blob atomically using temp file + rename.
-func (b *LocalBlobStore) PutBlob(hash string, content io.Reader) error {
+func (b *LocalBlobStore) PutBlob(hash string, content io.Reader) (err error) {
+	var tmpFile *os.File
+	var tmpPath string
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in LocalBlobStore.PutBlob: %v", r)
+			if tmpFile != nil {
+				tmpFile.Close()
+			}
+			if tmpPath != "" {
+				os.Remove(tmpPath)
+			}
+			err = fmt.Errorf("panic in PutBlob: %v: %w", r, syscall.EIO)
+		}
+	}()
+
+	if common.HasPathTraversalChars(hash) {
+		return fmt.Errorf("storage error: invalid hash contains path traversal characters: %w", syscall.EINVAL)
+	}
+
 	blobPath := b.blobPath(hash)
 	if err := os.MkdirAll(filepath.Dir(blobPath), 0755); err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("storage error: failed to create tiered dir: %w", syscall.EACCES)
+		}
 		return fmt.Errorf("storage error: failed to create tiered dir: %w", syscall.EIO)
 	}
 
-	tmpFile, err := os.CreateTemp(b.base, "blob-*.tmp")
+	tmpFile, err = os.CreateTemp(b.base, "blob-*.tmp")
 	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("storage error: failed to create temp file: %w", syscall.EACCES)
+		}
 		return fmt.Errorf("storage error: failed to create temp file: %w", syscall.EIO)
 	}
-	tmpPath := tmpFile.Name()
+	tmpPath = tmpFile.Name()
 
 	// ⚡ Bolt: Use a buffered writer to optimize disk I/O and minimize syscalls.
 	writer := bufio.NewWriterSize(tmpFile, 64*1024) // 64KB buffer
@@ -64,6 +93,9 @@ func (b *LocalBlobStore) PutBlob(hash string, content io.Reader) error {
 
 	if err := os.Rename(tmpPath, blobPath); err != nil {
 		os.Remove(tmpPath)
+		if os.IsPermission(err) {
+			return fmt.Errorf("storage error: failed to commit blob: %w", syscall.EACCES)
+		}
 		return fmt.Errorf("storage error: failed to commit blob: %w", syscall.EIO)
 	}
 	return nil

--- a/src/storage/local_blobstore_test.go
+++ b/src/storage/local_blobstore_test.go
@@ -1,0 +1,187 @@
+package storage
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestLocalBlobStore_PutGet(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-local-blob-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewLocalBlobStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create LocalBlobStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("hello world, this is a test blob")
+	hash := "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("PutBlob failed: %v", err)
+	}
+
+	reader, err := store.GetBlob(hash)
+	if err != nil {
+		t.Fatalf("GetBlob failed: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestLocalBlobStore_PutLargeBlob(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-local-blob-large-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewLocalBlobStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create LocalBlobStore: %v", err)
+	}
+	defer store.Close()
+
+	content := bytes.Repeat([]byte("x"), 256*1024)
+	hash := "largeblobhash1234567890abcdef"
+
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("PutBlob failed: %v", err)
+	}
+
+	reader, err := store.GetBlob(hash)
+	if err != nil {
+		t.Fatalf("GetBlob failed: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if len(got) != len(content) {
+		t.Errorf("Size mismatch: got %d, want %d", len(got), len(content))
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Content mismatch")
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	for _, e := range entries {
+		if bytes.HasPrefix([]byte(e.Name()), []byte("blob-")) && bytes.HasSuffix([]byte(e.Name()), []byte(".tmp")) {
+			t.Errorf("Temp file leaked: %s", e.Name())
+		}
+	}
+}
+
+func TestLocalBlobStore_Delete(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-local-blob-del-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewLocalBlobStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create LocalBlobStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("delete me")
+	hash := "deletehash1234567890abcdef"
+
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("PutBlob failed: %v", err)
+	}
+
+	if err := store.DeleteBlob(hash); err != nil {
+		t.Fatalf("DeleteBlob failed: %v", err)
+	}
+
+	if _, err := store.GetBlob(hash); err == nil {
+		t.Errorf("GetBlob should fail after delete")
+	}
+
+	if err := store.DeleteBlob(hash); err != nil {
+		t.Errorf("DeleteBlob should be no-op for missing blob, got: %v", err)
+	}
+}
+
+func TestLocalBlobStore_GetNotFound(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-local-blob-nf-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewLocalBlobStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create LocalBlobStore: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.GetBlob("nonexistenthash123456"); err == nil {
+		t.Errorf("GetBlob should fail for non-existent blob")
+	}
+}
+
+func TestLocalBlobStore_Dedup(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-local-blob-dedup-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewLocalBlobStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create LocalBlobStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("dedup content")
+	hash := "deduphash1234567890abcdef"
+
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("First PutBlob failed: %v", err)
+	}
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("Second PutBlob failed: %v", err)
+	}
+
+	reader, err := store.GetBlob(hash)
+	if err != nil {
+		t.Fatalf("GetBlob failed: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Content mismatch after dedup")
+	}
+}


### PR DESCRIPTION
Resolves #415
Also fixes #416

## Description

The atomic-write pattern in `LocalBlobStore.PutBlob` had two bugs in the same code path:

1. **#415**: `tmpFile.Close()` error was ignored before `os.Rename`. On NFS, `close()` can return `EIO`/`ESTALE` when flushing dirty pages fails. If `Close()` fails but `Rename` proceeds, a corrupt or truncated blob is committed.

2. **#416**: `tmpFile.Sync()` was never called. After a power loss, the renamed file can be empty or partially written while the bbolt metadata (which does fsync internally) is durable, creating a permanent metadata-to-blob inconsistency.

## Fix

- Added `tmpFile.Sync()` after `writer.Flush()` and before `Close()` — ensures data reaches disk before rename (fixes #416)
- Checked `tmpFile.Close()` error — returns `syscall.EIO` if close fails, preventing corrupt blob from being committed (fixes #415)
- Both error paths clean up the temp file via `os.Remove(tmpPath)`
- Added `defer recover()` with resource cleanup per Rule 4/37/43
- Added `common.HasPathTraversalChars(hash)` validation per reviewer finding
- Added `syscall.EACCES` mapping for permission errors per Rule 10

## Testing

- Added `src/storage/local_blobstore_test.go` with 5 tests:
  - `TestLocalBlobStore_PutGet` — round-trip content integrity
  - `TestLocalBlobStore_PutLargeBlob` — 256KB blob + temp file leak check
  - `TestLocalBlobStore_Delete` — blob removal + non-existent is no-op
  - `TestLocalBlobStore_GetNotFound` — error for missing blob
  - `TestLocalBlobStore_Dedup` — idempotent put with same hash
- All tests use `defer goleak.VerifyNone(t)` per Rule 5
- `go test -race` passes
- `go vet` clean

## Changelog

- `fix: check Close() error and add Sync() before Rename in LocalBlobStore (#415)` — Added fsync + error checking to atomic write pattern
- `fix: address reviewer feedback — add panic recovery, path traversal check, EACCES mapping` — Addressed 4 reviewer findings: panic recovery (Rule 4/37), resource cleanup on panic (Rule 43), path traversal validation, EACCES error mapping (Rule 10)