### PR TITLE
fix: check Placement and HashFile errors in client Connect

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1401,3 +1401,10 @@ ff0f7f4,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 ff0f7f4,BenchmarkIndexSearch-8,1.54,0.00,0.00
 ff0f7f4,BenchmarkLoadGlobalConfig-8,670.20,160.00,1.00
 ff0f7f4,BenchmarkPadString-8,1.93,0.00,0.00
+0469af7,BenchmarkCheckMetricsAndSwap-8,7.00,0.00,0.00
+0469af7,BenchmarkCrushOptimized-8,291.30,0.00,0.00
+0469af7,BenchmarkCrushOriginal-8,391.60,164.00,3.00
+0469af7,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+0469af7,BenchmarkIndexSearch-8,1.71,0.00,0.00
+0469af7,BenchmarkLoadGlobalConfig-8,715.20,160.00,1.00
+0469af7,BenchmarkPadString-8,1.91,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1387,3 +1387,10 @@ e441354,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
 e441354,BenchmarkIndexSearch-8,1.50,0.00,0.00
 e441354,BenchmarkLoadGlobalConfig-8,723.20,160.00,1.00
 e441354,BenchmarkPadString-8,1.96,0.00,0.00
+f1c52fe,BenchmarkCheckMetricsAndSwap-8,7.49,0.00,0.00
+f1c52fe,BenchmarkCrushOptimized-8,301.90,0.00,0.00
+f1c52fe,BenchmarkCrushOriginal-8,396.40,164.00,3.00
+f1c52fe,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+f1c52fe,BenchmarkIndexSearch-8,1.53,0.00,0.00
+f1c52fe,BenchmarkLoadGlobalConfig-8,750.90,160.00,1.00
+f1c52fe,BenchmarkPadString-8,2.17,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1380,3 +1380,10 @@ b1fc642,BenchmarkPadString-8,1.98,0.00,0.00
 3913228,BenchmarkIndexSearch-8,1.60,0.00,0.00
 3913228,BenchmarkLoadGlobalConfig-8,748.00,160.00,1.00
 3913228,BenchmarkPadString-8,1.99,0.00,0.00
+e441354,BenchmarkCheckMetricsAndSwap-8,6.92,0.00,0.00
+e441354,BenchmarkCrushOptimized-8,299.00,0.00,0.00
+e441354,BenchmarkCrushOriginal-8,406.80,164.00,3.00
+e441354,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+e441354,BenchmarkIndexSearch-8,1.50,0.00,0.00
+e441354,BenchmarkLoadGlobalConfig-8,723.20,160.00,1.00
+e441354,BenchmarkPadString-8,1.96,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1394,3 +1394,10 @@ f1c52fe,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
 f1c52fe,BenchmarkIndexSearch-8,1.53,0.00,0.00
 f1c52fe,BenchmarkLoadGlobalConfig-8,750.90,160.00,1.00
 f1c52fe,BenchmarkPadString-8,2.17,0.00,0.00
+ff0f7f4,BenchmarkCheckMetricsAndSwap-8,7.09,0.00,0.00
+ff0f7f4,BenchmarkCrushOptimized-8,326.50,0.00,0.00
+ff0f7f4,BenchmarkCrushOriginal-8,384.00,164.00,3.00
+ff0f7f4,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+ff0f7f4,BenchmarkIndexSearch-8,1.54,0.00,0.00
+ff0f7f4,BenchmarkLoadGlobalConfig-8,670.20,160.00,1.00
+ff0f7f4,BenchmarkPadString-8,1.93,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        406.8n ± ∞ ¹    396.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       299.0n ± ∞ ¹    301.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     723.2n ± ∞ ¹    750.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.964n ± ∞ ¹    2.166n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.924n ± ∞ ¹    7.488n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.495n ± ∞ ¹    1.529n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3489n ± ∞ ¹   0.3843n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.05n          18.88n        +4.63%
+CrushOriginal-8                        396.4n ± ∞ ¹    384.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       301.9n ± ∞ ¹    326.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     750.9n ± ∞ ¹    670.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.166n ± ∞ ¹    1.928n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.488n ± ∞ ¹    7.092n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.529n ± ∞ ¹    1.541n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3843n ± ∞ ¹   0.3387n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.88n          17.95n        -4.96%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.49 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 301.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 396.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 750.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.17 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.09 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 326.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 384.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.54 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 670.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe]
-    line "CheckMetricsAndSwap" [8,7,8,7,8,8,8,8,7,7]
-    line "CrushOptimized" [319,302,295,318,313,340,319,323,299,302]
-    line "CrushOriginal" [435,415,408,413,433,443,443,406,407,396]
+    x-axis [20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4]
+    line "CheckMetricsAndSwap" [7,8,7,8,8,8,8,7,7,7]
+    line "CrushOptimized" [302,295,318,313,340,319,323,299,302,326]
+    line "CrushOriginal" [415,408,413,433,443,443,406,407,396,384]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,1,2,2,2,2]
-    line "LoadGlobalConfig" [790,726,739,787,780,798,812,748,723,751]
+    line "IndexSearch" [2,2,2,2,1,2,2,2,2,2]
+    line "LoadGlobalConfig" [726,739,787,780,798,812,748,723,751,670]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe]
+    x-axis [20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe]
+    x-axis [20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        405.9n ± ∞ ¹    406.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       323.3n ± ∞ ¹    299.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     748.0n ± ∞ ¹    723.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.994n ± ∞ ¹    1.964n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.742n ± ∞ ¹    6.924n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.598n ± ∞ ¹    1.495n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3300n ± ∞ ¹   0.3489n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.70n          18.05n        -3.47%
+CrushOriginal-8                        406.8n ± ∞ ¹    396.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       299.0n ± ∞ ¹    301.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     723.2n ± ∞ ¹    750.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.964n ± ∞ ¹    2.166n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.924n ± ∞ ¹    7.488n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.495n ± ∞ ¹    1.529n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3489n ± ∞ ¹   0.3843n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.05n          18.88n        +4.63%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.92 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 299.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 723.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 301.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 396.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 750.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.17 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354]
-    line "CheckMetricsAndSwap" [8,8,7,8,7,8,8,8,8,7]
-    line "CrushOptimized" [312,319,302,295,318,313,340,319,323,299]
-    line "CrushOriginal" [437,435,415,408,413,433,443,443,406,407]
+    x-axis [bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe]
+    line "CheckMetricsAndSwap" [8,7,8,7,8,8,8,8,7,7]
+    line "CrushOptimized" [319,302,295,318,313,340,319,323,299,302]
+    line "CrushOriginal" [435,415,408,413,433,443,443,406,407,396]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,1,2,2,2]
-    line "LoadGlobalConfig" [1480,790,726,739,787,780,798,812,748,723]
+    line "IndexSearch" [2,2,2,2,2,1,2,2,2,2]
+    line "LoadGlobalConfig" [790,726,739,787,780,798,812,748,723,751]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,13 +99,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354]
+    x-axis [bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [304,160,160,160,160,160,160,160,160,160]
+    line "LoadGlobalConfig" [160,160,160,160,160,160,160,160,160,160]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -116,13 +116,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354]
+    x-axis [bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [5,1,1,1,1,1,1,1,1,1]
+    line "LoadGlobalConfig" [1,1,1,1,1,1,1,1,1,1]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        396.4n ± ∞ ¹    384.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       301.9n ± ∞ ¹    326.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     750.9n ± ∞ ¹    670.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.166n ± ∞ ¹    1.928n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.488n ± ∞ ¹    7.092n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.529n ± ∞ ¹    1.541n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3843n ± ∞ ¹   0.3387n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.88n          17.95n        -4.96%
+CrushOriginal-8                        384.0n ± ∞ ¹    391.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       326.5n ± ∞ ¹    291.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     670.2n ± ∞ ¹    715.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.928n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.092n ± ∞ ¹    6.997n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.541n ± ∞ ¹    1.713n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3387n ± ∞ ¹   0.3531n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                17.95n          18.20n        +1.38%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.09 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 326.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 384.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.54 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 670.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 291.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 391.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.71 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 715.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4]
-    line "CheckMetricsAndSwap" [7,8,7,8,8,8,8,7,7,7]
-    line "CrushOptimized" [302,295,318,313,340,319,323,299,302,326]
-    line "CrushOriginal" [415,408,413,433,443,443,406,407,396,384]
+    x-axis [9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7]
+    line "CheckMetricsAndSwap" [8,7,8,8,8,8,7,7,7,7]
+    line "CrushOptimized" [295,318,313,340,319,323,299,302,326,291]
+    line "CrushOriginal" [408,413,433,443,443,406,407,396,384,392]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,1,2,2,2,2,2]
-    line "LoadGlobalConfig" [726,739,787,780,798,812,748,723,751,670]
+    line "IndexSearch" [2,2,2,1,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [739,787,780,798,812,748,723,751,670,715]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4]
+    x-axis [9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4]
+    x-axis [9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        442.8n ± ∞ ¹    405.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       319.3n ± ∞ ¹    323.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     812.5n ± ∞ ¹    748.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.981n ± ∞ ¹    1.994n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.900n ± ∞ ¹    7.742n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.723n ± ∞ ¹    1.598n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4238n ± ∞ ¹   0.3300n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.07n          18.70n        -6.85%
+CrushOriginal-8                        405.9n ± ∞ ¹    406.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       323.3n ± ∞ ¹    299.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     748.0n ± ∞ ¹    723.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.994n ± ∞ ¹    1.964n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.742n ± ∞ ¹    6.924n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.598n ± ∞ ¹    1.495n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3300n ± ∞ ¹   0.3489n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.70n          18.05n        -3.47%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 323.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 405.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 748.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.92 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 299.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 406.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 723.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228]
-    line "CheckMetricsAndSwap" [7,8,8,7,8,7,8,8,8,8]
-    line "CrushOptimized" [297,312,319,302,295,318,313,340,319,323]
-    line "CrushOriginal" [396,437,435,415,408,413,433,443,443,406]
+    x-axis [bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354]
+    line "CheckMetricsAndSwap" [8,8,7,8,7,8,8,8,8,7]
+    line "CrushOptimized" [312,319,302,295,318,313,340,319,323,299]
+    line "CrushOriginal" [437,435,415,408,413,433,443,443,406,407]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,1,2,2]
-    line "LoadGlobalConfig" [750,1480,790,726,739,787,780,798,812,748]
+    line "IndexSearch" [2,2,2,2,2,2,1,2,2,2]
+    line "LoadGlobalConfig" [1480,790,726,739,787,780,798,812,748,723]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,13 +99,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228]
+    x-axis [bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [160,304,160,160,160,160,160,160,160,160]
+    line "LoadGlobalConfig" [304,160,160,160,160,160,160,160,160,160]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -116,13 +116,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bdde62d,bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228]
+    x-axis [bab2bf9,bc76d3f,20e5dc3,9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1,5,1,1,1,1,1,1,1,1]
+    line "LoadGlobalConfig" [5,1,1,1,1,1,1,1,1,1]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -15,11 +16,12 @@ import (
 // It first connects to a specified daemon to determine the replication mode.
 // If splay replication is active, it connects to all other daemons.
 // Finally, it sends the file to all established connections concurrently.
-func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
+func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) (err error) {
 	defer wg.Done()
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("CRITICAL: Panic recovered in client.Connect: %v", r)
+			err = fmt.Errorf("panic in Connect: %v: %w", r, syscall.EIO)
 		}
 	}()
 	daemons := cfg.Daemons
@@ -50,7 +52,8 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 
 	if replicationMode == common.ReplicationPrimarySplay {
 		// ⚡ Bolt: Use CRUSH to find the specific replicas for PrimarySplay.
-		fileHash, err := common.HashFile(filePath)
+		var fileHash string
+		fileHash, err = common.HashFile(filePath)
 		if err != nil {
 			log.Printf("Failed to hash file %s for CRUSH placement: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
 			return
@@ -118,7 +121,8 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 	// Validate RemotePath and length limit before transmission
 	wireName := meta.Name
 	if meta.RemotePath != "" {
-		normalized, err := common.NormalizeVirtualPath(meta.RemotePath)
+		var normalized string
+		normalized, err = common.NormalizeVirtualPath(meta.RemotePath)
 		if err != nil {
 			log.Printf("Failed to upload %s: invalid remote path %q: %v", common.SanitizeLog(filePath), common.SanitizeLog(meta.RemotePath), err)
 			return
@@ -140,6 +144,7 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		go sendFile(&wgSendFile, c, filePath, meta)
 	}
 	wgSendFile.Wait()
+	return
 }
 
 // sendFile sends a file over a network connection.

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -44,13 +44,20 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 
 	if replicationMode == common.ReplicationPrimarySplay {
 		// ⚡ Bolt: Use CRUSH to find the specific replicas for PrimarySplay.
-		fileHash, _ := common.HashFile(filePath)
+		fileHash, err := common.HashFile(filePath)
+		if err != nil {
+			log.Printf("Failed to hash file %s for CRUSH placement: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
+			return
+		}
 		nodes := make([]*common.Node, len(daemons))
 		for i, d := range daemons {
 			nodes[i] = &common.Node{ID: i, Weight: 1, Addr: d.Host}
 		}
 		cmap := &common.ClusterMap{Nodes: nodes}
-		placement, _ := cmap.Placement(fileHash, replicationFactor)
+		placement, err := cmap.Placement(fileHash, replicationFactor)
+		if err != nil {
+			log.Printf("WARNING: CRUSH placement failed for %s, replicating to initial daemon only: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
+		}
 
 		for _, node := range placement {
 			if node.ID == serverId {

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/transport"
@@ -16,6 +17,11 @@ import (
 // Finally, it sends the file to all established connections concurrently.
 func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
 	defer wg.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in client.Connect: %v", r)
+		}
+	}()
 	daemons := cfg.Daemons
 	if serverId < 0 || serverId >= len(daemons) {
 		log.Printf("Server ID %d is out of range", serverId)
@@ -56,7 +62,7 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		cmap := &common.ClusterMap{Nodes: nodes}
 		placement, err := cmap.Placement(fileHash, replicationFactor)
 		if err != nil {
-			log.Printf("WARNING: CRUSH placement failed for %s, replicating to initial daemon only: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
+			log.Printf("WARNING: CRUSH placement failed for %s, replicating to initial daemon only: %v (errno=%d)", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()), syscall.EHOSTUNREACH)
 		}
 
 		for _, node := range placement {

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -17,10 +17,14 @@ import (
 // If splay replication is active, it connects to all other daemons.
 // Finally, it sends the file to all established connections concurrently.
 func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) (err error) {
+	var communicators []transport.Communicator
 	defer wg.Done()
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("CRITICAL: Panic recovered in client.Connect: %v", r)
+			for _, c := range communicators {
+				c.Close()
+			}
 			err = fmt.Errorf("panic in Connect: %v: %w", r, syscall.EIO)
 		}
 	}()
@@ -31,7 +35,6 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 	}
 	authToken := cfg.Global.AuthToken
 	factory := transport.NewProtocolFactory(cfg)
-	var communicators []transport.Communicator
 	var wgSendFile sync.WaitGroup
 
 	// Connect to the initial daemon to check replication mode

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -19,9 +19,10 @@ import (
 )
 
 // mockConnect is a mock implementation of Connect for testing.
-func mockConnect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
+func mockConnect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) (err error) {
 	defer wg.Done()
 	// In a real test, you might add more logic here to simulate the client's behavior
+	return nil
 }
 
 // mockGetFile is a mock implementation of getFile for testing.


### PR DESCRIPTION
Resolves #423
Also fixes #451

## Description

Two errors were silently discarded in `client.Connect`:

1. **#423**: `cmap.Placement` error discarded at line 53. If CRUSH placement fails, `placement` is `nil`, the range is a no-op, and the file is sent only to the initial daemon. No log is emitted — the user believes they have `replicationFactor` replicas but has one.

2. **#451**: `common.HashFile` error discarded at line 47. On failure, `fileHash` is `""`, which feeds into `Placement` (which rejects empty hashes — but that error was also discarded).

## Fix

- Check `HashFile` error and return early if file cannot be hashed (avoids wasted network I/O)
- Check `Placement` error and log a warning (file still sent to initial daemon — graceful degradation)
- Both errors sanitized via `common.SanitizeLog` per existing pattern

## Testing

- `go build ./...` passes
- `go test -race ./src/client/` passes
- `go vet` clean

## Changelog

- `fix: check Placement and HashFile errors in client Connect (#423)` — Fixed silent replication failure when CRUSH placement or file hashing fails