### PR TITLE
fix: stream S3 PutBlob with UNSIGNED-PAYLOAD instead of buffering

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1408,3 +1408,10 @@ ff0f7f4,BenchmarkPadString-8,1.93,0.00,0.00
 0469af7,BenchmarkIndexSearch-8,1.71,0.00,0.00
 0469af7,BenchmarkLoadGlobalConfig-8,715.20,160.00,1.00
 0469af7,BenchmarkPadString-8,1.91,0.00,0.00
+fa2a91d,BenchmarkCheckMetricsAndSwap-8,8.38,0.00,0.00
+fa2a91d,BenchmarkCrushOptimized-8,315.20,0.00,0.00
+fa2a91d,BenchmarkCrushOriginal-8,597.80,164.00,3.00
+fa2a91d,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+fa2a91d,BenchmarkIndexSearch-8,1.79,0.00,0.00
+fa2a91d,BenchmarkLoadGlobalConfig-8,723.30,160.00,1.00
+fa2a91d,BenchmarkPadString-8,2.11,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1415,3 +1415,10 @@ fa2a91d,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
 fa2a91d,BenchmarkIndexSearch-8,1.79,0.00,0.00
 fa2a91d,BenchmarkLoadGlobalConfig-8,723.30,160.00,1.00
 fa2a91d,BenchmarkPadString-8,2.11,0.00,0.00
+be3840d,BenchmarkCheckMetricsAndSwap-8,9.16,0.00,0.00
+be3840d,BenchmarkCrushOptimized-8,375.40,0.00,0.00
+be3840d,BenchmarkCrushOriginal-8,519.00,164.00,3.00
+be3840d,BenchmarkIndexDirectTracking-8,0.65,0.00,0.00
+be3840d,BenchmarkIndexSearch-8,2.21,0.00,0.00
+be3840d,BenchmarkLoadGlobalConfig-8,850.60,160.00,1.00
+be3840d,BenchmarkPadString-8,2.32,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        391.6n ± ∞ ¹    597.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       291.3n ± ∞ ¹    315.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     715.2n ± ∞ ¹    723.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.912n ± ∞ ¹    2.106n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.997n ± ∞ ¹    8.379n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.713n ± ∞ ¹    1.789n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3531n ± ∞ ¹   0.3513n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                18.20n          20.48n        +12.56%
+CrushOriginal-8                        597.8n ± ∞ ¹    519.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       315.2n ± ∞ ¹    375.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     723.3n ± ∞ ¹    850.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.106n ± ∞ ¹    2.321n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.379n ± ∞ ¹    9.160n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.789n ± ∞ ¹    2.215n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3513n ± ∞ ¹   0.6519n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.48n          24.36n        +18.93%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 315.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 597.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.79 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 723.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.11 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.16 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 375.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 519.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.21 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 850.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.32 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d]
-    line "CheckMetricsAndSwap" [7,8,8,8,8,7,7,7,7,8]
-    line "CrushOptimized" [318,313,340,319,323,299,302,326,291,315]
-    line "CrushOriginal" [413,433,443,443,406,407,396,384,392,598]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,1,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [787,780,798,812,748,723,751,670,715,723]
+    x-axis [2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d]
+    line "CheckMetricsAndSwap" [8,8,8,8,7,7,7,7,8,9]
+    line "CrushOptimized" [313,340,319,323,299,302,326,291,315,375]
+    line "CrushOriginal" [433,443,443,406,407,396,384,392,598,519]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
+    line "IndexSearch" [2,1,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [780,798,812,748,723,751,670,715,723,851]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d]
+    x-axis [2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d]
+    x-axis [2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        384.0n ± ∞ ¹    391.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       326.5n ± ∞ ¹    291.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     670.2n ± ∞ ¹    715.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.928n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.092n ± ∞ ¹    6.997n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.541n ± ∞ ¹    1.713n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3387n ± ∞ ¹   0.3531n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                17.95n          18.20n        +1.38%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        391.6n ± ∞ ¹    597.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       291.3n ± ∞ ¹    315.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     715.2n ± ∞ ¹    723.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.912n ± ∞ ¹    2.106n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.997n ± ∞ ¹    8.379n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.713n ± ∞ ¹    1.789n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3531n ± ∞ ¹   0.3513n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                18.20n          20.48n        +12.56%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 291.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 391.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 315.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 597.80 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.71 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 715.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.79 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 723.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.11 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7]
-    line "CheckMetricsAndSwap" [8,7,8,8,8,8,7,7,7,7]
-    line "CrushOptimized" [295,318,313,340,319,323,299,302,326,291]
-    line "CrushOriginal" [408,413,433,443,443,406,407,396,384,392]
+    x-axis [7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d]
+    line "CheckMetricsAndSwap" [7,8,8,8,8,7,7,7,7,8]
+    line "CrushOptimized" [318,313,340,319,323,299,302,326,291,315]
+    line "CrushOriginal" [413,433,443,443,406,407,396,384,392,598]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,1,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [739,787,780,798,812,748,723,751,670,715]
+    line "IndexSearch" [2,2,1,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [787,780,798,812,748,723,751,670,715,723]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7]
+    x-axis [7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [9bd2937,7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7]
+    x-axis [7b6193c,2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/s3_blobstore.go
+++ b/src/storage/s3_blobstore.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -75,18 +74,23 @@ func (s *S3BlobStore) Close() error {
 }
 
 // PutBlob uploads a blob to S3 using HTTP PUT with SigV4 authentication.
-func (s *S3BlobStore) PutBlob(hash string, content io.Reader) error {
-	payload, err := io.ReadAll(content)
-	if err != nil {
-		return fmt.Errorf("s3: failed to read payload: %w", syscall.EIO)
-	}
+// The content is streamed directly to S3 using UNSIGNED-PAYLOAD to avoid
+// buffering the entire blob in memory (OOM/DoS prevention).
+func (s *S3BlobStore) PutBlob(hash string, content io.Reader) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in S3BlobStore.PutBlob: %v", r)
+			err = fmt.Errorf("panic in S3BlobStore.PutBlob: %v: %w", r, syscall.EIO)
+		}
+	}()
 
-	req, err := s.newRequest("PUT", hash, bytes.NewReader(payload))
+	boundedContent := io.LimitReader(content, common.MaxFileSize)
+
+	req, err := s.newRequest("PUT", hash, boundedContent, "UNSIGNED-PAYLOAD")
 	if err != nil {
 		return err
 	}
-	req.ContentLength = int64(len(payload))
-	req.Header.Set("x-amz-content-sha256", hexSHA256(payload))
+	req.ContentLength = -1
 
 	resp, err := s.client.Do(req)
 	if err != nil {
@@ -102,7 +106,7 @@ func (s *S3BlobStore) PutBlob(hash string, content io.Reader) error {
 
 // GetBlob downloads a blob from S3 using HTTP GET with SigV4 authentication.
 func (s *S3BlobStore) GetBlob(hash string) (io.ReadCloser, error) {
-	req, err := s.newRequest("GET", hash, nil)
+	req, err := s.newRequest("GET", hash, nil, emptyStringSHA256)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +130,7 @@ func (s *S3BlobStore) GetBlob(hash string) (io.ReadCloser, error) {
 // DeleteBlob removes a blob from S3 using HTTP DELETE with SigV4 authentication.
 // Missing blobs are silently ignored (treated as success).
 func (s *S3BlobStore) DeleteBlob(hash string) error {
-	req, err := s.newRequest("DELETE", hash, nil)
+	req, err := s.newRequest("DELETE", hash, nil, emptyStringSHA256)
 	if err != nil {
 		return err
 	}
@@ -147,7 +151,7 @@ func (s *S3BlobStore) DeleteBlob(hash string) error {
 }
 
 // newRequest builds an HTTP request for the given method and object key.
-func (s *S3BlobStore) newRequest(method, key string, body io.Reader) (req *http.Request, err error) {
+func (s *S3BlobStore) newRequest(method, key string, body io.Reader, payloadHash string) (req *http.Request, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("panic building new request: %v", r)
@@ -182,14 +186,6 @@ func (s *S3BlobStore) newRequest(method, key string, body io.Reader) (req *http.
 	now := time.Now().UTC()
 	amzDate := now.Format("20060102T150405Z")
 	dateStamp := now.Format("20060102")
-
-	payloadHash := emptyStringSHA256
-	if method == "PUT" {
-		payloadHash = req.Header.Get("x-amz-content-sha256")
-		if payloadHash == "" {
-			payloadHash = emptyStringSHA256
-		}
-	}
 
 	host := parsedURL.Host
 	if s.pathStyle {

--- a/src/storage/s3_blobstore_test.go
+++ b/src/storage/s3_blobstore_test.go
@@ -262,3 +262,49 @@ func TestNewStore_S3Backend(t *testing.T) {
 		t.Errorf("Content mismatch")
 	}
 }
+
+func TestS3BlobStore_PutLargeBlob(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	server, _ := mockS3Server(t)
+	defer server.Close()
+
+	cfg := common.ConfigurationStorage{
+		Backend:     "s3",
+		S3Endpoint:  server.URL,
+		S3Region:    "us-east-1",
+		S3Bucket:    "test-bucket",
+		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
+		S3SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // notsecret
+		S3PathStyle: true,
+	}
+
+	store, err := NewS3BlobStore(cfg)
+	if err != nil {
+		t.Fatalf("NewS3BlobStore failed: %v", err)
+	}
+	defer store.Close()
+
+	content := bytes.Repeat([]byte("x"), 10*1024*1024)
+	hash := "largeblobhash123456"
+
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("PutBlob large failed: %v", err)
+	}
+
+	reader, err := store.GetBlob(hash)
+	if err != nil {
+		t.Fatalf("GetBlob large failed: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Failed to read large blob: %v", err)
+	}
+	if len(got) != len(content) {
+		t.Errorf("Size mismatch: got %d, want %d", len(got), len(content))
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Content mismatch in large blob")
+	}
+}


### PR DESCRIPTION
Resolves #418

## Description

`S3BlobStore.PutBlob` read the entire blob into memory via `io.ReadAll(content)` to compute the SHA-256 payload hash for SigV4. No size limit → OOM kill. Any client could trigger this by uploading a file larger than available RAM.

## Fix

- **Removed `io.ReadAll`**: Content is now streamed directly as the HTTP request body
- **Use `UNSIGNED-PAYLOAD`**: Standard S3 SigV4 feature that skips payload integrity verification. Acceptable because the CAS layer already verifies content integrity via content-addressable hashing
- **Added `io.LimitReader(content, common.MaxFileSize)`**: Defense-in-depth bound (1GB limit)
- **Added `defer recover()`** with named return parameter (Rule 4/37)
- **Fixed pre-existing SigV4 bug**: `newRequest` now accepts `payloadHash` as a parameter instead of reading it from a header that hadn't been set yet. Previously the signature was always computed with `emptyStringSHA256` regardless of the actual payload
- **Removed unused `bytes` import**

## Testing

- Added `TestS3BlobStore_PutLargeBlob` — uploads a 10MB blob to verify streaming works
- All existing S3 tests pass with `go test -race`
- `go vet` clean, `gofmt` clean

## Changelog

- `fix: stream S3 PutBlob with UNSIGNED-PAYLOAD instead of buffering (#418)` — Eliminated OOM/DoS by streaming content directly to S3