### PR TITLE
fix: stream RawBlobStore.PutBlob in chunks instead of unbounded io.ReadAll (#419)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1422,3 +1422,10 @@ be3840d,BenchmarkIndexDirectTracking-8,0.65,0.00,0.00
 be3840d,BenchmarkIndexSearch-8,2.21,0.00,0.00
 be3840d,BenchmarkLoadGlobalConfig-8,850.60,160.00,1.00
 be3840d,BenchmarkPadString-8,2.32,0.00,0.00
+0c050bb,BenchmarkCheckMetricsAndSwap-8,8.28,0.00,0.00
+0c050bb,BenchmarkCrushOptimized-8,340.90,0.00,0.00
+0c050bb,BenchmarkCrushOriginal-8,434.10,164.00,3.00
+0c050bb,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+0c050bb,BenchmarkIndexSearch-8,1.58,0.00,0.00
+0c050bb,BenchmarkLoadGlobalConfig-8,736.80,160.00,1.00
+0c050bb,BenchmarkPadString-8,1.97,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        597.8n ± ∞ ¹    519.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       315.2n ± ∞ ¹    375.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     723.3n ± ∞ ¹    850.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.106n ± ∞ ¹    2.321n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.379n ± ∞ ¹    9.160n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.789n ± ∞ ¹    2.215n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3513n ± ∞ ¹   0.6519n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.48n          24.36n        +18.93%
+CrushOriginal-8                        519.0n ± ∞ ¹    434.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       375.4n ± ∞ ¹    340.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     850.6n ± ∞ ¹    736.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.321n ± ∞ ¹    1.966n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.160n ± ∞ ¹    8.280n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.215n ± ∞ ¹    1.581n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.6519n ± ∞ ¹   0.3305n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                24.36n          19.10n        -21.59%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.16 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 375.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 519.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.21 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 850.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.28 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 340.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 434.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.58 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 736.80 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.97 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d]
-    line "CheckMetricsAndSwap" [8,8,8,8,7,7,7,7,8,9]
-    line "CrushOptimized" [313,340,319,323,299,302,326,291,315,375]
-    line "CrushOriginal" [433,443,443,406,407,396,384,392,598,519]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
-    line "IndexSearch" [2,1,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [780,798,812,748,723,751,670,715,723,851]
+    x-axis [c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d,0c050bb]
+    line "CheckMetricsAndSwap" [8,8,8,7,7,7,7,8,9,8]
+    line "CrushOptimized" [340,319,323,299,302,326,291,315,375,341]
+    line "CrushOriginal" [443,443,406,407,396,384,392,598,519,434]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
+    line "IndexSearch" [1,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [798,812,748,723,751,670,715,723,851,737]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d]
+    x-axis [c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d,0c050bb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [2a3cd10,c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d]
+    x-axis [c2ccbdd,b1fc642,3913228,e441354,f1c52fe,ff0f7f4,0469af7,fa2a91d,be3840d,0c050bb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/raw_blobstore.go
+++ b/src/storage/raw_blobstore.go
@@ -109,7 +109,16 @@ func (r *RawBlobStore) Close() error {
 
 // PutBlob writes a blob to the raw device at the next available offset.
 // If the hash already exists in the allocation table, it is a no-op.
-func (r *RawBlobStore) PutBlob(hash string, content io.Reader) error {
+// Content is streamed in 64 KB chunks to avoid unbounded memory allocation.
+// The total size is capped at common.MaxFileSize (Rule 4 — Zero-Crash Pattern).
+func (r *RawBlobStore) PutBlob(hash string, content io.Reader) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("CRITICAL: Panic recovered in RawBlobStore.PutBlob: %v", rec)
+			err = fmt.Errorf("raw: write panic: %v: %w", rec, syscall.EIO)
+		}
+	}()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -125,23 +134,38 @@ func (r *RawBlobStore) PutBlob(hash string, content io.Reader) error {
 		return nil
 	}
 
-	data, err := io.ReadAll(content)
-	if err != nil {
-		return fmt.Errorf("raw: failed to read content: %w", syscall.EIO)
+	limited := io.LimitReader(content, common.MaxFileSize+1)
+	offset := r.nextOffset
+	buf := make([]byte, 64*1024)
+	var totalWritten int64
+
+	for {
+		n, readErr := limited.Read(buf)
+		if n > 0 {
+			written, writeErr := r.device.WriteAt(buf[:n], offset+totalWritten)
+			if writeErr != nil {
+				return fmt.Errorf("raw: failed to write to device: %w", syscall.EIO)
+			}
+			if written != n {
+				return fmt.Errorf("raw: short write: %w", syscall.EIO)
+			}
+			totalWritten += int64(written)
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return fmt.Errorf("raw: failed to read content: %w", syscall.EIO)
+		}
 	}
 
-	offset := r.nextOffset
-	n, err := r.device.WriteAt(data, offset)
-	if err != nil {
-		return fmt.Errorf("raw: failed to write to device: %w", syscall.EIO)
-	}
-	if int64(n) != int64(len(data)) {
-		return fmt.Errorf("raw: short write: %w", syscall.EIO)
+	if totalWritten > common.MaxFileSize {
+		return fmt.Errorf("raw: blob exceeds MaxFileSize (%d bytes): %w", common.MaxFileSize, syscall.EFBIG)
 	}
 
 	var alloc [16]byte
 	binary.BigEndian.PutUint64(alloc[0:8], uint64(offset))
-	binary.BigEndian.PutUint64(alloc[8:16], uint64(len(data)))
+	binary.BigEndian.PutUint64(alloc[8:16], uint64(totalWritten))
 	err = r.allocDB.Update(func(tx *bbolt.Tx) error {
 		return tx.Bucket(bucketRawAlloc).Put([]byte(hash), alloc[:])
 	})
@@ -149,7 +173,7 @@ func (r *RawBlobStore) PutBlob(hash string, content io.Reader) error {
 		return fmt.Errorf("raw: failed to record allocation: %w", syscall.EIO)
 	}
 
-	r.nextOffset = offset + int64(len(data))
+	r.nextOffset = offset + totalWritten
 	return nil
 }
 

--- a/src/storage/raw_blobstore_test.go
+++ b/src/storage/raw_blobstore_test.go
@@ -192,6 +192,44 @@ func TestRawBlobStore_MissingDevicePath(t *testing.T) {
 	}
 }
 
+func TestRawBlobStore_PutLargeBlob(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tempDir := t.TempDir()
+	devicePath := filepath.Join(tempDir, "fake-device")
+	dataDir := filepath.Join(tempDir, "data")
+
+	cfg := common.ConfigurationStorage{Backend: "raw", RawDevicePath: devicePath}
+	daemon := &common.Daemon{Data: dataDir}
+
+	store, err := NewRawBlobStore(cfg, daemon)
+	if err != nil {
+		t.Fatalf("NewRawBlobStore failed: %v", err)
+	}
+	defer store.Close()
+
+	size := 10 * 1024 * 1024
+	content := bytes.Repeat([]byte("A"), size)
+	hash := "largeblobhash"
+
+	if err := store.PutBlob(hash, bytes.NewReader(content)); err != nil {
+		t.Fatalf("PutBlob large failed: %v", err)
+	}
+
+	reader, err := store.GetBlob(hash)
+	if err != nil {
+		t.Fatalf("GetBlob large failed: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Failed to read large blob: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Large blob content mismatch: got %d bytes, want %d bytes", len(got), len(content))
+	}
+}
+
 func TestNewStore_RawBackend(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	tempDir := t.TempDir()


### PR DESCRIPTION
Resolves #419

## Bug Description

`RawBlobStore.PutBlob` (src/storage/raw_blobstore.go:128) read the entire blob into memory via `io.ReadAll(content)` before writing to the raw device. Raw device blobs can be very large, causing OOM kill of the momo daemon.

## Fix

1. **Removed `io.ReadAll`**: Replaced with a streaming loop using a fixed 64 KB buffer and `device.WriteAt` at progressive offsets. Memory usage is now O(64KB) regardless of blob size.
2. **Added `io.LimitReader(content, common.MaxFileSize+1)`**: Caps total bytes read at MaxFileSize (1GB) + 1 to detect oversize blobs. Returns `syscall.EFBIG` if exceeded (Rule 4 — Zero-Crash Pattern, Rule 32 — Defensive Allocation Bounds).
3. **Added panic recovery** (Rule 4/37): Named return parameter `err` + `defer recover()` with `log.Printf` + `syscall.EIO` assignment.
4. **Track `totalWritten`**: Used for allocation table entry and `nextOffset` update instead of `len(data)`.

## Test

Added `TestRawBlobStore_PutLargeBlob`: writes a 10 MB blob (155x larger than the 64KB chunk size) and verifies correct round-trip via GetBlob. All existing tests pass with `-race`.

## Changelog

- `ba5ab19`: Stream PutBlob in 64KB chunks with MaxFileSize cap and panic recovery