### PR TITLE
fix(p2p): make ping IDs globally unique across nodes (#424)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1478,3 +1478,10 @@ a991604,BenchmarkPadString-8,1.95,0.00,0.00
 04c719a,BenchmarkIndexSearch-8,1.56,0.00,0.00
 04c719a,BenchmarkLoadGlobalConfig-8,705.80,160.00,1.00
 04c719a,BenchmarkPadString-8,2.21,0.00,0.00
+639a088,BenchmarkCheckMetricsAndSwap-8,8.87,0.00,0.00
+639a088,BenchmarkCrushOptimized-8,371.10,0.00,0.00
+639a088,BenchmarkCrushOriginal-8,447.70,164.00,3.00
+639a088,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+639a088,BenchmarkIndexSearch-8,1.91,0.00,0.00
+639a088,BenchmarkLoadGlobalConfig-8,836.20,160.00,1.00
+639a088,BenchmarkPadString-8,2.02,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        395.5n ± ∞ ¹    388.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       338.8n ± ∞ ¹    322.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     716.5n ± ∞ ¹    705.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.964n ± ∞ ¹    2.211n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.789n ± ∞ ¹   11.340n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.723n ± ∞ ¹    1.559n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3250n ± ∞ ¹   0.3376n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.41n          19.74n        +7.22%
+CrushOriginal-8                        388.8n ± ∞ ¹    447.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       322.4n ± ∞ ¹    371.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     705.8n ± ∞ ¹    836.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.211n ± ∞ ¹    2.022n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 11.340n ± ∞ ¹    8.867n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.559n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3376n ± ∞ ¹   0.3417n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.74n          20.70n        +4.86%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 322.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 388.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 371.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 447.70 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 705.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.21 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 836.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.02 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [fa2a91d,be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a]
-    line "CheckMetricsAndSwap" [8,9,8,12,7,8,8,7,8,11]
-    line "CrushOptimized" [315,375,341,526,394,356,363,293,312,322]
-    line "CrushOriginal" [598,519,434,644,431,413,693,408,398,389]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
+    x-axis [be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088]
+    line "CheckMetricsAndSwap" [9,8,12,7,8,8,7,8,11,9]
+    line "CrushOptimized" [375,341,526,394,356,363,293,312,322,371]
+    line "CrushOriginal" [519,434,644,431,413,693,408,398,389,448]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [723,851,737,1240,752,758,805,719,811,706]
-    line "PadString" [2,2,2,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [851,737,1240,752,758,805,719,811,706,836]
+    line "PadString" [2,2,3,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [fa2a91d,be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a]
+    x-axis [be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [fa2a91d,be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a]
+    x-axis [be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -245,7 +245,7 @@ func (g *Gossiper) sendPing() {
 		return
 	}
 	target := peers[0]
-	pingID = atomic.AddUint64(&g.nextPingID, 1)
+	pingID = (uint64(g.cfg.LocalID) << 32) | (atomic.AddUint64(&g.nextPingID, 1) & 0xFFFFFFFF)
 	now := time.Now().UnixNano()
 
 	payload := &PingPayload{

--- a/src/p2p/gossip_test.go
+++ b/src/p2p/gossip_test.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -182,5 +183,45 @@ func TestGossiper_SuspicionTimeout(t *testing.T) {
 	}
 	if peer.State() != PeerStateSuspect && peer.State() != PeerStateOffline {
 		t.Errorf("expected peer 2 to be suspect or offline, got state %d", peer.State())
+	}
+}
+
+func TestGossiper_PingIDUniquenessAcrossNodes(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	defer tr1.Close()
+	defer tr2.Close()
+
+	cfg := GossipConfig{
+		HeartbeatInterval: time.Hour,
+		SuspicionTimeout:  time.Hour,
+		Fanout:            3,
+		PingTimeout:       time.Hour,
+		IndirectPingCount: 3,
+		RTTAlpha:          0.25,
+	}
+
+	cfg1 := cfg
+	cfg1.LocalID = 1
+	cfg2 := cfg
+	cfg2.LocalID = 2
+
+	g1 := NewGossiper(cfg1, tr1)
+	g2 := NewGossiper(cfg2, tr2)
+	defer g1.Close()
+	defer g2.Close()
+
+	for i := 0; i < 1000; i++ {
+		id1 := (uint64(g1.cfg.LocalID) << 32) | (atomic.AddUint64(&g1.nextPingID, 1) & 0xFFFFFFFF)
+		id2 := (uint64(g2.cfg.LocalID) << 32) | (atomic.AddUint64(&g2.nextPingID, 1) & 0xFFFFFFFF)
+		if id1 == id2 {
+			t.Fatalf("ping ID collision between node 1 and node 2: %d (iteration %d)", id1, i)
+		}
+		if id1>>32 != 1 {
+			t.Fatalf("node 1 ping ID %d has wrong node ID in upper bits: %d", id1, id1>>32)
+		}
+		if id2>>32 != 2 {
+			t.Fatalf("node 2 ping ID %d has wrong node ID in upper bits: %d", id2, id2>>32)
+		}
 	}
 }


### PR DESCRIPTION
## Fix

Incorporate the node ID into the upper 32 bits of ping IDs to prevent collisions when indirect pings are forwarded between nodes.

### Problem

`nextPingID` is a per-node counter starting at 0, so every node's first ping has `pingID=1`. When node A's ping times out and it asks node B to do an indirect ping with `pingID=1`, node B's `handleIndirectPing` overwrites its own pending ping with the same ID in `pendingPings`.

This causes:
- Node B's own `sendPing` goroutine waits on an orphaned `ackCh` → false timeout → healthy peer marked SUSPECT
- When an ack arrives for node B's own ping, `handleAck` signals the wrong pending ping → spurious ack

### Solution

```go
pingID = (uint64(g.cfg.LocalID) << 32) | (atomic.AddUint64(&g.nextPingID, 1) & 0xFFFFFFFF)
```

Each node's ping IDs are in a unique range (upper 32 bits = node ID), so indirect pings forwarded to other nodes never collide with those nodes' own pending pings.

### Test

Added `TestGossiper_PingIDUniquenessAcrossNodes` — generates 1000 ping IDs from two gossipers with different node IDs and verifies:
1. No ping ID collision between nodes
2. Each ping ID carries the correct node ID in the upper 32 bits

Closes #424