### PR TITLE
fix(common): protect absoluteDeadline with atomic.Pointer (#425)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1485,3 +1485,10 @@ a991604,BenchmarkPadString-8,1.95,0.00,0.00
 639a088,BenchmarkIndexSearch-8,1.91,0.00,0.00
 639a088,BenchmarkLoadGlobalConfig-8,836.20,160.00,1.00
 639a088,BenchmarkPadString-8,2.02,0.00,0.00
+12d5214,BenchmarkCheckMetricsAndSwap-8,8.54,0.00,0.00
+12d5214,BenchmarkCrushOptimized-8,342.60,0.00,0.00
+12d5214,BenchmarkCrushOriginal-8,465.20,164.00,3.00
+12d5214,BenchmarkIndexDirectTracking-8,0.42,0.00,0.00
+12d5214,BenchmarkIndexSearch-8,1.64,0.00,0.00
+12d5214,BenchmarkLoadGlobalConfig-8,826.90,160.00,1.00
+12d5214,BenchmarkPadString-8,2.29,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        388.8n ± ∞ ¹    447.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       322.4n ± ∞ ¹    371.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     705.8n ± ∞ ¹    836.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.211n ± ∞ ¹    2.022n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 11.340n ± ∞ ¹    8.867n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.559n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3376n ± ∞ ¹   0.3417n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.74n          20.70n        +4.86%
+CrushOriginal-8                        447.7n ± ∞ ¹    465.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       371.1n ± ∞ ¹    342.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     836.2n ± ∞ ¹    826.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.022n ± ∞ ¹    2.295n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.867n ± ∞ ¹    8.541n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.912n ± ∞ ¹    1.640n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3417n ± ∞ ¹   0.4214n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.70n          20.97n        +1.33%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 371.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 447.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 836.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.54 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 342.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 465.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 826.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088]
-    line "CheckMetricsAndSwap" [9,8,12,7,8,8,7,8,11,9]
-    line "CrushOptimized" [375,341,526,394,356,363,293,312,322,371]
-    line "CrushOriginal" [519,434,644,431,413,693,408,398,389,448]
-    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    x-axis [0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214]
+    line "CheckMetricsAndSwap" [8,12,7,8,8,7,8,11,9,9]
+    line "CrushOptimized" [341,526,394,356,363,293,312,322,371,343]
+    line "CrushOriginal" [434,644,431,413,693,408,398,389,448,465]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [851,737,1240,752,758,805,719,811,706,836]
-    line "PadString" [2,2,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [737,1240,752,758,805,719,811,706,836,827]
+    line "PadString" [2,3,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088]
+    x-axis [0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [be3840d,0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088]
+    x-axis [0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/net.go
+++ b/src/common/net.go
@@ -20,7 +20,7 @@ import (
 type IdleTimeoutConn struct {
 	net.Conn
 	timeout          time.Duration
-	absoluteDeadline time.Time
+	absoluteDeadline atomic.Pointer[time.Time]
 	readCalls        atomic.Uint32
 	writeCalls       atomic.Uint32
 	broken           atomic.Bool
@@ -44,7 +44,7 @@ func (c *IdleTimeoutConn) SetAbsoluteDeadline(t time.Time) {
 		}
 	}()
 
-	c.absoluteDeadline = t
+	c.absoluteDeadline.Store(&t)
 
 	// 🛡️ Sentinel: Immediately apply the new deadline to the underlying connection.
 	// Since applyDeadlines amortizes updates (skipping 63 of 64 calls), failing to
@@ -52,8 +52,8 @@ func (c *IdleTimeoutConn) SetAbsoluteDeadline(t time.Time) {
 	// handshake deadline, causing valid large file transfers to drop prematurely (DoS).
 	now := time.Now()
 	deadline := now.Add(c.timeout)
-	if !c.absoluteDeadline.IsZero() && c.absoluteDeadline.Before(deadline) {
-		deadline = c.absoluteDeadline
+	if !t.IsZero() && t.Before(deadline) {
+		deadline = t
 	}
 	c.Conn.SetDeadline(deadline)
 }
@@ -87,8 +87,8 @@ func (c *IdleTimeoutConn) applyDeadlines(isRead bool) {
 
 	now := time.Now()
 	deadline := now.Add(c.timeout)
-	if !c.absoluteDeadline.IsZero() && c.absoluteDeadline.Before(deadline) {
-		deadline = c.absoluteDeadline
+	if dp := c.absoluteDeadline.Load(); dp != nil && !dp.IsZero() && dp.Before(deadline) {
+		deadline = *dp
 	}
 
 	if isRead {

--- a/src/common/net_test.go
+++ b/src/common/net_test.go
@@ -15,6 +15,7 @@ type mockConn struct {
 	net.Conn
 	readDeadlineSet  bool
 	writeDeadlineSet bool
+	deadlineSet      bool
 	readError        error
 }
 
@@ -25,6 +26,15 @@ func (m *mockConn) SetReadDeadline(t time.Time) error {
 
 func (m *mockConn) SetWriteDeadline(t time.Time) error {
 	m.writeDeadlineSet = true
+	return nil
+}
+
+func (m *mockConn) SetDeadline(t time.Time) error {
+	m.deadlineSet = true
+	return nil
+}
+
+func (m *mockConn) Close() error {
 	return nil
 }
 
@@ -191,4 +201,46 @@ func TestIdleTimeoutConn_BrokenFlagAfterPanic(t *testing.T) {
 	if !errors.Is(err, syscall.EIO) {
 		t.Errorf("Expected err to wrap %v, got %v", syscall.EIO, err)
 	}
+}
+
+func TestIdleTimeoutConn_AbsoluteDeadlineConcurrentAccess(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mc := &mockConn{}
+	idleConn := NewIdleTimeoutConn(mc, 30*time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	stop := make(chan struct{})
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				idleConn.SetAbsoluteDeadline(time.Now().Add(time.Hour))
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 64)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				idleConn.Read(buf)
+				idleConn.Write(buf)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
## Fix

Protect the `absoluteDeadline` field in `IdleTimeoutConn` with `atomic.Pointer[time.Time]` to eliminate a data race.

### Problem

`absoluteDeadline` (`time.Time`, a multi-word struct) was written by `SetAbsoluteDeadline` (line 47) and read by `applyDeadlines` (line 90) from concurrent goroutines with no mutex or atomic synchronization. A torn read could produce a nonsensical `time.Time`, causing incorrect deadline computation — either dropping live connections or extending deadlines for dead ones.

### Solution

Replace the plain `time.Time` field with `atomic.Pointer[time.Time]`:
- **Write:** `c.absoluteDeadline.Store(&t)`
- **Read:** `c.absoluteDeadline.Load()`

Lock-free, no contention, and correct under the Go memory model.

### Test

Added `TestIdleTimeoutConn_AbsoluteDeadlineConcurrentAccess` — runs `SetAbsoluteDeadline` and `Read`/`Write` concurrently for 50ms under `-race` to verify no data race.

Closes #425