### PR TITLE
fix(metrics): validate interval before NewTicker to prevent panic (#426)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1492,3 +1492,10 @@ a991604,BenchmarkPadString-8,1.95,0.00,0.00
 12d5214,BenchmarkIndexSearch-8,1.64,0.00,0.00
 12d5214,BenchmarkLoadGlobalConfig-8,826.90,160.00,1.00
 12d5214,BenchmarkPadString-8,2.29,0.00,0.00
+91cf463,BenchmarkCheckMetricsAndSwap-8,7.10,0.00,0.00
+91cf463,BenchmarkCrushOptimized-8,335.60,0.00,0.00
+91cf463,BenchmarkCrushOriginal-8,400.70,164.00,3.00
+91cf463,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+91cf463,BenchmarkIndexSearch-8,1.68,0.00,0.00
+91cf463,BenchmarkLoadGlobalConfig-8,737.70,160.00,1.00
+91cf463,BenchmarkPadString-8,1.89,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        447.7n ± ∞ ¹    465.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       371.1n ± ∞ ¹    342.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     836.2n ± ∞ ¹    826.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.022n ± ∞ ¹    2.295n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.867n ± ∞ ¹    8.541n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.912n ± ∞ ¹    1.640n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3417n ± ∞ ¹   0.4214n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.70n          20.97n        +1.33%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        465.2n ± ∞ ¹    400.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       342.6n ± ∞ ¹    335.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     826.9n ± ∞ ¹    737.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.295n ± ∞ ¹    1.893n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.541n ± ∞ ¹    7.096n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.640n ± ∞ ¹    1.680n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4214n ± ∞ ¹   0.3172n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.97n          18.39n        -12.34%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.54 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 342.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 465.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 826.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 335.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 400.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.68 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 737.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214]
-    line "CheckMetricsAndSwap" [8,12,7,8,8,7,8,11,9,9]
-    line "CrushOptimized" [341,526,394,356,363,293,312,322,371,343]
-    line "CrushOriginal" [434,644,431,413,693,408,398,389,448,465]
+    x-axis [7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463]
+    line "CheckMetricsAndSwap" [12,7,8,8,7,8,11,9,9,7]
+    line "CrushOptimized" [526,394,356,363,293,312,322,371,343,336]
+    line "CrushOriginal" [644,431,413,693,408,398,389,448,465,401]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [737,1240,752,758,805,719,811,706,836,827]
-    line "PadString" [2,3,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [1240,752,758,805,719,811,706,836,827,738]
+    line "PadString" [3,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214]
+    x-axis [7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0c050bb,7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214]
+    x-axis [7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -99,6 +99,11 @@ func GetMetrics(ctx context.Context, cfg common.Configuration, serverId int) {
 
 	log.Printf("Daemon GetMetrics started...")
 
+	if cfg.Metrics.Interval <= 0 {
+		log.Printf("ERROR: metrics interval must be positive, got %d — metrics loop not started", cfg.Metrics.Interval)
+		return
+	}
+
 	// ⚡ Bolt: Hoist constant AuthToken padding and conversion out of the loop.
 	paddedAuthToken := []byte(common.PadString(cfg.Global.AuthToken, common.AuthTokenLength))
 

--- a/src/metrics/metrics_extra_test.go
+++ b/src/metrics/metrics_extra_test.go
@@ -46,3 +46,27 @@ func TestCheckMetricsAndSwap_EdgeCases(t *testing.T) {
 		t.Errorf("Expected (-1, false) for currentIndex == -1")
 	}
 }
+
+func TestGetMetrics_NonPositiveIntervalNoPanic(t *testing.T) {
+	for _, interval := range []int{0, -1, -100} {
+		cfg := common.Configuration{
+			Global: common.ConfigurationGlobal{
+				PolymorphicSystem: true,
+				ReplicationOrder:  []int{1, 2, 3, 4},
+				AuthToken:         "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
+			},
+			Metrics: common.ConfigurationMetrics{
+				Interval:     interval,
+				MinThreshold: 0.2,
+				MaxThreshold: 0.8,
+			},
+			Daemons: []*common.Daemon{
+				{Host: "127.0.0.1:45697", ChangeReplication: "127.0.0.1:45696"},
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		GetMetrics(ctx, cfg, 0)
+		cancel()
+	}
+}


### PR DESCRIPTION
## Fix

Validate `cfg.Metrics.Interval` is positive before calling `time.NewTicker` to prevent a panic.

### Problem

`time.NewTicker` panics if the duration is `<= 0`. `cfg.Metrics.Interval` is parsed from config with no validation that it is positive. A config with `interval = 0` or `interval = -1` causes a panic, which is recovered by `runMetricsLoop` but surfaces as a confusing error rather than a clear validation message.

### Solution

Add an early validation check in `GetMetrics`:

```go
if cfg.Metrics.Interval <= 0 {
    log.Printf("ERROR: metrics interval must be positive, got %d — metrics loop not started", cfg.Metrics.Interval)
    return
}
```

### Test

Added `TestGetMetrics_NonPositiveIntervalNoPanic` — verifies `GetMetrics` does not panic for interval values of 0, -1, and -100.

Closes #426