### PR TITLE
fix(server): wait for all goroutines before returning from runServer (#455)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1499,3 +1499,10 @@ a991604,BenchmarkPadString-8,1.95,0.00,0.00
 91cf463,BenchmarkIndexSearch-8,1.68,0.00,0.00
 91cf463,BenchmarkLoadGlobalConfig-8,737.70,160.00,1.00
 91cf463,BenchmarkPadString-8,1.89,0.00,0.00
+cab6e2d,BenchmarkCheckMetricsAndSwap-8,7.18,0.00,0.00
+cab6e2d,BenchmarkCrushOptimized-8,326.20,0.00,0.00
+cab6e2d,BenchmarkCrushOriginal-8,406.00,164.00,3.00
+cab6e2d,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+cab6e2d,BenchmarkIndexSearch-8,1.96,0.00,0.00
+cab6e2d,BenchmarkLoadGlobalConfig-8,751.30,160.00,1.00
+cab6e2d,BenchmarkPadString-8,1.93,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        465.2n ± ∞ ¹    400.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       342.6n ± ∞ ¹    335.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     826.9n ± ∞ ¹    737.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.295n ± ∞ ¹    1.893n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.541n ± ∞ ¹    7.096n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.640n ± ∞ ¹    1.680n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4214n ± ∞ ¹   0.3172n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.97n          18.39n        -12.34%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        400.7n ± ∞ ¹    406.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       335.6n ± ∞ ¹    326.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     737.7n ± ∞ ¹    751.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.893n ± ∞ ¹    1.932n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.096n ± ∞ ¹    7.180n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.680n ± ∞ ¹    1.957n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3172n ± ∞ ¹   0.3370n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.39n          19.05n        +3.61%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 335.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 400.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.68 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 737.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.18 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 326.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 406.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 751.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463]
-    line "CheckMetricsAndSwap" [12,7,8,8,7,8,11,9,9,7]
-    line "CrushOptimized" [526,394,356,363,293,312,322,371,343,336]
-    line "CrushOriginal" [644,431,413,693,408,398,389,448,465,401]
+    x-axis [dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d]
+    line "CheckMetricsAndSwap" [7,8,8,7,8,11,9,9,7,7]
+    line "CrushOptimized" [394,356,363,293,312,322,371,343,336,326]
+    line "CrushOriginal" [431,413,693,408,398,389,448,465,401,406]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [1240,752,758,805,719,811,706,836,827,738]
-    line "PadString" [3,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [752,758,805,719,811,706,836,827,738,751]
+    line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463]
+    x-axis [dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7b04923,dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463]
+    x-axis [dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/momo.go
+++ b/src/momo.go
@@ -189,30 +189,38 @@ func runServer(ctx context.Context, cfg common.Configuration, serverId int) (err
 	}()
 
 	errChan := make(chan error, 3)
+	var wg sync.WaitGroup
+	wg.Add(3)
 
 	go func() {
+		defer wg.Done()
 		if e := runMetricsLoop(ctx, cfg, serverId); e != nil {
 			errChan <- e
 		}
 	}()
 
 	go func() {
+		defer wg.Done()
 		errChan <- runReplicationServer(ctx, cfg, serverId, timestamp)
 	}()
 
 	go func() {
+		defer wg.Done()
 		errChan <- runMainDaemon(ctx, cfg, serverId)
 	}()
 
-	// Wait for any component to return an error or for the program to be interrupted
-	// In a real application, we might want to catch SIGINT/SIGTERM here.
-	select {
-	case e := <-errChan:
-		if e != nil {
-			cancel() // Shut down other components
-			return e
+	go func() {
+		wg.Wait()
+		close(errChan)
+	}()
+
+	var firstErr error
+	for e := range errChan {
+		if e != nil && firstErr == nil {
+			firstErr = e
+			cancel()
 		}
 	}
 
-	return nil
+	return firstErr
 }


### PR DESCRIPTION
## Fix

Wait for all three goroutines (metrics, replication server, main daemon) to complete before returning from `runServer`.

### Problem

`runServer` used a `select` that returned on the first value from `errChan`. `runReplicationServer` and `runMainDaemon` unconditionally send to `errChan`, so if either returned `nil` (normal exit), `runServer` returned immediately — shutting down the entire server without waiting for the remaining goroutines.

### Solution

Replace the `select` with a `sync.WaitGroup` + `errChan` drain loop:
1. All three goroutines decrement the WaitGroup on exit
2. A separate goroutine waits on the WaitGroup and closes `errChan`
3. The main loop drains `errChan`, capturing the first non-nil error and calling `cancel()` to shut down other components
4. Returns the first error (or nil) only after all goroutines have completed

Closes #455