### PR TITLE
fix(p2p): fix quorum formula for clusters with < 3 nodes (#454)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1506,3 +1506,10 @@ cab6e2d,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 cab6e2d,BenchmarkIndexSearch-8,1.96,0.00,0.00
 cab6e2d,BenchmarkLoadGlobalConfig-8,751.30,160.00,1.00
 cab6e2d,BenchmarkPadString-8,1.93,0.00,0.00
+dfca564,BenchmarkCheckMetricsAndSwap-8,6.78,0.00,0.00
+dfca564,BenchmarkCrushOptimized-8,348.80,0.00,0.00
+dfca564,BenchmarkCrushOriginal-8,406.20,164.00,3.00
+dfca564,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+dfca564,BenchmarkIndexSearch-8,1.86,0.00,0.00
+dfca564,BenchmarkLoadGlobalConfig-8,735.70,160.00,1.00
+dfca564,BenchmarkPadString-8,1.92,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        400.7n ± ∞ ¹    406.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       335.6n ± ∞ ¹    326.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     737.7n ± ∞ ¹    751.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.893n ± ∞ ¹    1.932n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.096n ± ∞ ¹    7.180n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.680n ± ∞ ¹    1.957n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3172n ± ∞ ¹   0.3370n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.39n          19.05n        +3.61%
+CrushOriginal-8                        406.0n ± ∞ ¹    406.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       326.2n ± ∞ ¹    348.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     751.3n ± ∞ ¹    735.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.932n ± ∞ ¹    1.921n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.180n ± ∞ ¹    6.784n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.957n ± ∞ ¹    1.865n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3370n ± ∞ ¹   0.3356n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.05n          18.86n        -0.97%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.18 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 326.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.78 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 348.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 406.20 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 751.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.86 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 735.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.92 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d]
-    line "CheckMetricsAndSwap" [7,8,8,7,8,11,9,9,7,7]
-    line "CrushOptimized" [394,356,363,293,312,322,371,343,336,326]
-    line "CrushOriginal" [431,413,693,408,398,389,448,465,401,406]
+    x-axis [43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564]
+    line "CheckMetricsAndSwap" [8,8,7,8,11,9,9,7,7,7]
+    line "CrushOptimized" [356,363,293,312,322,371,343,336,326,349]
+    line "CrushOriginal" [413,693,408,398,389,448,465,401,406,406]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [752,758,805,719,811,706,836,827,738,751]
+    line "LoadGlobalConfig" [758,805,719,811,706,836,827,738,751,736]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d]
+    x-axis [43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [dd6ec2d,43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d]
+    x-axis [43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/lease.go
+++ b/src/p2p/lease.go
@@ -210,7 +210,9 @@ func (lm *LeaseManager) Acquire(key string, duration time.Duration) (*Lease, err
 	}
 
 	quorum := (peerCount+1)/2 + 1
-	if quorum < 1 {
+	if peerCount == 0 {
+		quorum = 0
+	} else if peerCount == 1 {
 		quorum = 1
 	}
 

--- a/src/p2p/lease_test.go
+++ b/src/p2p/lease_test.go
@@ -86,9 +86,15 @@ func TestLeaseManager_NoPeers(t *testing.T) {
 	lm.Start()
 	defer lm.Stop()
 
-	_, err := lm.Acquire("test-key", 5*time.Second)
-	if err == nil {
-		t.Error("expected error with no peers")
+	lease, err := lm.Acquire("test-key", 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected self-grant for single-node cluster, got error: %v", err)
+	}
+	if lease == nil {
+		t.Fatal("expected non-nil lease for single-node cluster")
+	}
+	if lease.Key != "test-key" {
+		t.Errorf("key mismatch: got %q, want %q", lease.Key, "test-key")
 	}
 }
 
@@ -117,13 +123,22 @@ func TestLeaseManager_Expiry(t *testing.T) {
 
 func TestLeaseManager_QuorumTimeout(t *testing.T) {
 	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
 	defer tr1.Close()
+	defer tr2.Close()
 
 	ln1, _ := net.Listen("tcp", "127.0.0.1:0")
 	addr1 := ln1.Addr().String()
 	ln1.Close()
+	ln2, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr2 := ln2.Addr().String()
+	ln2.Close()
 
 	tr1.Listen(addr1)
+	tr2.Listen(addr2)
+
+	tr1.Dial(2, addr2)
+	time.Sleep(100 * time.Millisecond)
 
 	lm1 := NewLeaseManager(1, tr1)
 	lm1.Start()
@@ -138,6 +153,62 @@ func TestLeaseManager_QuorumTimeout(t *testing.T) {
 
 	_, err := lm1.Acquire("test-key", 1*time.Second)
 	if err == nil {
-		t.Error("expected timeout error with no peers for quorum")
+		t.Error("expected timeout error when remote peer does not grant lease")
+	}
+}
+
+func TestLeaseManager_TwoNodeCluster(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	defer tr1.Close()
+	defer tr2.Close()
+
+	ln1, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr1 := ln1.Addr().String()
+	ln1.Close()
+	ln2, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr2 := ln2.Addr().String()
+	ln2.Close()
+
+	tr1.Listen(addr1)
+	tr2.Listen(addr2)
+
+	tr1.Dial(2, addr2)
+	tr2.Dial(1, addr1)
+	time.Sleep(100 * time.Millisecond)
+
+	lm1 := NewLeaseManager(1, tr1)
+	lm2 := NewLeaseManager(2, tr2)
+
+	g1 := NewGossiper(DefaultGossipConfig(1), tr1)
+	g2 := NewGossiper(DefaultGossipConfig(2), tr2)
+	g1.SetLeaseManager(lm1)
+	g2.SetLeaseManager(lm2)
+	defer g1.Close()
+	defer g2.Close()
+
+	lm1.Start()
+	lm2.Start()
+	defer lm1.Stop()
+	defer lm2.Stop()
+
+	g1.Run()
+	g2.Run()
+
+	time.Sleep(200 * time.Millisecond)
+
+	lease, err := lm1.Acquire("test-key", 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected lease acquisition in 2-node cluster, got error: %v", err)
+	}
+	if lease == nil {
+		t.Fatal("expected non-nil lease")
+	}
+	if lease.QuorumSize < 1 {
+		t.Errorf("expected quorum >= 1, got %d", lease.QuorumSize)
+	}
+
+	if err := lm1.Release(lease); err != nil {
+		t.Fatalf("release failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Fix

Fix the quorum formula in `LeaseManager.Acquire` to support clusters with fewer than 3 nodes.

### Problem

The quorum formula `quorum := (peerCount+1)/2 + 1` computes the majority of all nodes (including self). Since self never grants itself a lease, the required remote grants exceed available peers for small clusters:
- **N=1** (0 remote peers): quorum=1, need 1 grant from 0 peers → always fails
- **N=2** (1 remote peer): quorum=2, need 2 grants from 1 peer → always fails

### Solution

```go
quorum := (peerCount+1)/2 + 1
if peerCount == 0 {
    quorum = 0  // single-node: self-grant
} else if peerCount == 1 {
    quorum = 1  // two-node: need the 1 remote peer
}
```

### Tests

- Updated `TestLeaseManager_NoPeers` to expect self-grant success for single-node cluster
- Updated `TestLeaseManager_QuorumTimeout` to test with an unresponsive remote peer (instead of 0 peers)
- Added `TestLeaseManager_TwoNodeCluster` verifying lease acquisition in a 2-node cluster

Closes #454