### PR TITLE
fix(p2p): protect gossip callback fields with RWMutex (#453)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1513,3 +1513,10 @@ dfca564,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 dfca564,BenchmarkIndexSearch-8,1.86,0.00,0.00
 dfca564,BenchmarkLoadGlobalConfig-8,735.70,160.00,1.00
 dfca564,BenchmarkPadString-8,1.92,0.00,0.00
+c5342af,BenchmarkCheckMetricsAndSwap-8,8.47,0.00,0.00
+c5342af,BenchmarkCrushOptimized-8,324.00,0.00,0.00
+c5342af,BenchmarkCrushOriginal-8,426.50,164.00,3.00
+c5342af,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+c5342af,BenchmarkIndexSearch-8,1.57,0.00,0.00
+c5342af,BenchmarkLoadGlobalConfig-8,775.00,160.00,1.00
+c5342af,BenchmarkPadString-8,1.96,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        406.0n ± ∞ ¹    406.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       326.2n ± ∞ ¹    348.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     751.3n ± ∞ ¹    735.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.932n ± ∞ ¹    1.921n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.180n ± ∞ ¹    6.784n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.957n ± ∞ ¹    1.865n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3370n ± ∞ ¹   0.3356n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.05n          18.86n        -0.97%
+CrushOriginal-8                        406.2n ± ∞ ¹    426.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       348.8n ± ∞ ¹    324.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     735.7n ± ∞ ¹    775.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.921n ± ∞ ¹    1.961n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.784n ± ∞ ¹    8.470n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.865n ± ∞ ¹    1.575n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3356n ± ∞ ¹   0.3753n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.86n          19.45n        +3.08%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.78 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 348.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.86 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 735.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.92 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 324.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 426.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.57 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 775.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564]
-    line "CheckMetricsAndSwap" [8,8,7,8,11,9,9,7,7,7]
-    line "CrushOptimized" [356,363,293,312,322,371,343,336,326,349]
-    line "CrushOriginal" [413,693,408,398,389,448,465,401,406,406]
+    x-axis [0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af]
+    line "CheckMetricsAndSwap" [8,7,8,11,9,9,7,7,7,8]
+    line "CrushOptimized" [363,293,312,322,371,343,336,326,349,324]
+    line "CrushOriginal" [693,408,398,389,448,465,401,406,406,426]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [758,805,719,811,706,836,827,738,751,736]
+    line "LoadGlobalConfig" [805,719,811,706,836,827,738,751,736,775]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564]
+    x-axis [0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [43f07f3,0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564]
+    x-axis [0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -91,9 +91,9 @@ type Gossiper struct {
 	mu        sync.Mutex
 	wg        sync.WaitGroup
 
-	onJoin  func(peer *Peer)
-	onLeave func(peerID int32)
-
+	cbMu          sync.RWMutex
+	onJoin        func(peer *Peer)
+	onLeave       func(peerID int32)
 	scatterGather *ScatterGather
 	leaseManager  *LeaseManager
 
@@ -116,24 +116,32 @@ func NewGossiper(cfg GossipConfig, transport Transport) *Gossiper {
 
 // OnJoin sets a callback invoked when a new peer joins the cluster.
 func (g *Gossiper) OnJoin(fn func(peer *Peer)) {
+	g.cbMu.Lock()
 	g.onJoin = fn
+	g.cbMu.Unlock()
 }
 
 // OnLeave sets a callback invoked when a peer leaves the cluster.
 func (g *Gossiper) OnLeave(fn func(peerID int32)) {
+	g.cbMu.Lock()
 	g.onLeave = fn
+	g.cbMu.Unlock()
 }
 
 // SetScatterGather attaches a ScatterGather instance whose query RPCs will be
 // routed by the gossiper's consumer loop.
 func (g *Gossiper) SetScatterGather(sg *ScatterGather) {
+	g.cbMu.Lock()
 	g.scatterGather = sg
+	g.cbMu.Unlock()
 }
 
 // SetLeaseManager attaches a LeaseManager instance whose lease RPCs will be
 // routed by the gossiper's consumer loop.
 func (g *Gossiper) SetLeaseManager(lm *LeaseManager) {
+	g.cbMu.Lock()
 	g.leaseManager = lm
+	g.cbMu.Unlock()
 }
 
 // Start launches the heartbeat, ping, and suspicion loops.
@@ -541,8 +549,11 @@ func (g *Gossiper) checkSuspicion() {
 			if elapsed > 2*timeout {
 				p.SetState(PeerStateOffline)
 				log.Printf("Gossip: peer %d marked OFFLINE (last seen %v ago, timeout=%v)", p.ID, elapsed, timeout)
-				if g.onLeave != nil {
-					g.onLeave(p.ID)
+				g.cbMu.RLock()
+				onLeave := g.onLeave
+				g.cbMu.RUnlock()
+				if onLeave != nil {
+					onLeave(p.ID)
 				}
 			}
 		}
@@ -588,12 +599,18 @@ func (g *Gossiper) HandleRPC(rpc *RPC) {
 	case MsgIndirectPing:
 		g.handleIndirectPing(rpc)
 	case MsgQuery, MsgQueryResponse:
-		if g.scatterGather != nil {
-			g.scatterGather.HandleRPC(rpc)
+		g.cbMu.RLock()
+		sg := g.scatterGather
+		g.cbMu.RUnlock()
+		if sg != nil {
+			sg.HandleRPC(rpc)
 		}
 	case MsgLeaseRequest, MsgLeaseGrant, MsgLeaseRelease:
-		if g.leaseManager != nil {
-			g.leaseManager.HandleLeaseRPC(rpc)
+		g.cbMu.RLock()
+		lm := g.leaseManager
+		g.cbMu.RUnlock()
+		if lm != nil {
+			lm.HandleLeaseRPC(rpc)
 		}
 	}
 }
@@ -620,8 +637,11 @@ func (g *Gossiper) handleHeartbeat(rpc *RPC) {
 			peer := NewPeer(pi.ID, pi.Addr)
 			g.transport.Peers().Add(peer)
 			log.Printf("Gossip: discovered new peer %d at %s via heartbeat from %d", pi.ID, pi.Addr, rpc.From)
-			if g.onJoin != nil {
-				g.onJoin(peer)
+			g.cbMu.RLock()
+			onJoin := g.onJoin
+			g.cbMu.RUnlock()
+			if onJoin != nil {
+				onJoin(peer)
 			}
 		}
 	}
@@ -657,8 +677,11 @@ func (g *Gossiper) handleMembership(rpc *RPC) {
 			peer := NewPeer(pi.ID, pi.Addr)
 			g.transport.Peers().Add(peer)
 			log.Printf("Gossip: new peer %d joined via membership update from %d", pi.ID, rpc.From)
-			if g.onJoin != nil {
-				g.onJoin(peer)
+			g.cbMu.RLock()
+			onJoin := g.onJoin
+			g.cbMu.RUnlock()
+			if onJoin != nil {
+				onJoin(peer)
 			}
 		}
 	}


### PR DESCRIPTION
## Fix

Protect gossip callback fields (`onJoin`, `onLeave`, `scatterGather`, `leaseManager`) with a `sync.RWMutex` to eliminate a data race.

### Problem

`OnJoin`, `OnLeave`, `SetScatterGather`, and `SetLeaseManager` wrote struct fields with no synchronization. These fields are read concurrently by goroutines launched in `Start()`/`Run()`. If any setter is called after `Start()`, it's a data race.

### Solution

Add a `sync.RWMutex` (`cbMu`) to protect all four callback fields:
- **Setters** use `Lock()` (write lock)
- **Readers** use `RLock()` (read lock) and copy the pointer/function to a local variable before calling it

This allows multiple concurrent readers in the consumer loop with no blocking, while ensuring safe writes during setup.

Closes #453