### PR TITLE
fix(client): hash file once to prevent TOCTOU race (#452)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1520,3 +1520,10 @@ c5342af,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
 c5342af,BenchmarkIndexSearch-8,1.57,0.00,0.00
 c5342af,BenchmarkLoadGlobalConfig-8,775.00,160.00,1.00
 c5342af,BenchmarkPadString-8,1.96,0.00,0.00
+0fe9fb7,BenchmarkCheckMetricsAndSwap-8,6.94,0.00,0.00
+0fe9fb7,BenchmarkCrushOptimized-8,335.30,0.00,0.00
+0fe9fb7,BenchmarkCrushOriginal-8,413.30,164.00,3.00
+0fe9fb7,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+0fe9fb7,BenchmarkIndexSearch-8,1.55,0.00,0.00
+0fe9fb7,BenchmarkLoadGlobalConfig-8,757.60,160.00,1.00
+0fe9fb7,BenchmarkPadString-8,1.99,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        406.2n ± ∞ ¹    426.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       348.8n ± ∞ ¹    324.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     735.7n ± ∞ ¹    775.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.921n ± ∞ ¹    1.961n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.784n ± ∞ ¹    8.470n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.865n ± ∞ ¹    1.575n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3356n ± ∞ ¹   0.3753n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.86n          19.45n        +3.08%
+CrushOriginal-8                        426.5n ± ∞ ¹    413.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       324.0n ± ∞ ¹    335.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     775.0n ± ∞ ¹    757.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.961n ± ∞ ¹    1.986n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.470n ± ∞ ¹    6.943n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.575n ± ∞ ¹    1.547n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3753n ± ∞ ¹   0.3497n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.45n          18.64n        -4.12%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 324.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 426.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.57 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 775.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 335.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 413.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 757.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af]
-    line "CheckMetricsAndSwap" [8,7,8,11,9,9,7,7,7,8]
-    line "CrushOptimized" [363,293,312,322,371,343,336,326,349,324]
-    line "CrushOriginal" [693,408,398,389,448,465,401,406,406,426]
+    x-axis [709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7]
+    line "CheckMetricsAndSwap" [7,8,11,9,9,7,7,7,8,7]
+    line "CrushOptimized" [293,312,322,371,343,336,326,349,324,335]
+    line "CrushOriginal" [408,398,389,448,465,401,406,406,426,413]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [805,719,811,706,836,827,738,751,736,775]
+    line "LoadGlobalConfig" [719,811,706,836,827,738,751,736,775,758]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af]
+    x-axis [709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0bedbaa,709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af]
+    x-axis [709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -53,14 +53,17 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		return
 	}
 
+	// Compute file hash once and reuse for both CRUSH placement and metadata.
+	// This prevents a TOCTOU race where the file is modified between two
+	// independent hash calls, causing placement and metadata to diverge.
+	fileHash, err := common.HashFile(filePath)
+	if err != nil {
+		log.Printf("Failed to hash file %s: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
+		return
+	}
+
 	if replicationMode == common.ReplicationPrimarySplay {
 		// ⚡ Bolt: Use CRUSH to find the specific replicas for PrimarySplay.
-		var fileHash string
-		fileHash, err = common.HashFile(filePath)
-		if err != nil {
-			log.Printf("Failed to hash file %s for CRUSH placement: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
-			return
-		}
 		nodes := make([]*common.Node, len(daemons))
 		for i, d := range daemons {
 			nodes[i] = &common.Node{ID: i, Weight: 1, Addr: d.Host}
@@ -100,17 +103,10 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		}
 	}()
 
-	// Optimization: Pre-compute file metadata (hash, size, name) before concurrent transmission.
-	// This avoids redundant disk reads and hashing for each connection in splay replication.
+	// Optimization: Pre-compute file metadata (size, name) before concurrent transmission.
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
 		log.Printf("Failed to get file info for %s: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
-		return
-	}
-
-	fileHash, err := common.HashFile(filePath)
-	if err != nil {
-		log.Printf("Failed to hash file %s: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
 		return
 	}
 


### PR DESCRIPTION
## Fix

Compute the file hash once and reuse it for both CRUSH placement and file metadata, preventing a TOCTOU (time-of-check-time-of-use) race.

### Problem

The file was hashed independently at two points in `Connect`:
1. **Line 59** — for CRUSH placement (inside `ReplicationPrimarySplay` block)
2. **Line 111** — for file metadata (always executed)

If the file was modified between these two calls, the placement nodes and metadata hash would diverge. The blob would be stored on wrong nodes and/or fail server-side integrity verification.

### Solution

Move the hash computation to after the handshake but before the `ReplicationPrimarySplay` check. Use the single hash for both CRUSH placement and file metadata.

Closes #452