### PR TITLE
fix(common): copy bytes in TrimNullBytesString to prevent unsafe aliasing (#450)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1527,3 +1527,10 @@ c5342af,BenchmarkPadString-8,1.96,0.00,0.00
 0fe9fb7,BenchmarkIndexSearch-8,1.55,0.00,0.00
 0fe9fb7,BenchmarkLoadGlobalConfig-8,757.60,160.00,1.00
 0fe9fb7,BenchmarkPadString-8,1.99,0.00,0.00
+cacc02f,BenchmarkCheckMetricsAndSwap-8,9.18,0.00,0.00
+cacc02f,BenchmarkCrushOptimized-8,351.70,0.00,0.00
+cacc02f,BenchmarkCrushOriginal-8,499.50,164.00,3.00
+cacc02f,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+cacc02f,BenchmarkIndexSearch-8,1.53,0.00,0.00
+cacc02f,BenchmarkLoadGlobalConfig-8,749.10,160.00,1.00
+cacc02f,BenchmarkPadString-8,2.19,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        426.5n ± ∞ ¹    413.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       324.0n ± ∞ ¹    335.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     775.0n ± ∞ ¹    757.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.961n ± ∞ ¹    1.986n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.470n ± ∞ ¹    6.943n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.575n ± ∞ ¹    1.547n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3753n ± ∞ ¹   0.3497n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.45n          18.64n        -4.12%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        413.3n ± ∞ ¹    499.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       335.3n ± ∞ ¹    351.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     757.6n ± ∞ ¹    749.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.986n ± ∞ ¹    2.191n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.943n ± ∞ ¹    9.179n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.547n ± ∞ ¹    1.530n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3497n ± ∞ ¹   0.3773n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                18.64n          20.51n        +10.02%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.94 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 335.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 413.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 757.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.18 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 351.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 499.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 749.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.19 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7]
-    line "CheckMetricsAndSwap" [7,8,11,9,9,7,7,7,8,7]
-    line "CrushOptimized" [293,312,322,371,343,336,326,349,324,335]
-    line "CrushOriginal" [408,398,389,448,465,401,406,406,426,413]
+    x-axis [a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f]
+    line "CheckMetricsAndSwap" [8,11,9,9,7,7,7,8,7,9]
+    line "CrushOptimized" [312,322,371,343,336,326,349,324,335,352]
+    line "CrushOriginal" [398,389,448,465,401,406,406,426,413,500]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [719,811,706,836,827,738,751,736,775,758]
+    line "LoadGlobalConfig" [811,706,836,827,738,751,736,775,758,749]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7]
+    x-axis [a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [709643d,a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7]
+    x-axis [a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/string.go
+++ b/src/common/string.go
@@ -87,16 +87,12 @@ func NormalizeVirtualPath(p string) (string, error) {
 	return strings.Join(validSegments, "/"), nil
 }
 
-// TrimNullBytesString finds the first null byte and returns a string up to that byte
-// using unsafe.String to eliminate string allocation overhead.
+// TrimNullBytesString finds the first null byte and returns a string up to that byte.
 func TrimNullBytesString(b []byte) string {
 	if idx := bytes.IndexByte(b, 0); idx != -1 {
-		return unsafe.String(unsafe.SliceData(b), idx)
+		return string(b[:idx])
 	}
-	if len(b) == 0 {
-		return ""
-	}
-	return unsafe.String(unsafe.SliceData(b), len(b))
+	return string(b)
 }
 
 // TrimNullBytesFromString finds the first null byte and returns a substring up to that byte

--- a/src/common/string_test.go
+++ b/src/common/string_test.go
@@ -158,3 +158,15 @@ func TestNormalizeVirtualPath(t *testing.T) {
 		})
 	}
 }
+
+func TestTrimNullBytesString_BufferReuse(t *testing.T) {
+	buf := []byte("hello\x00world")
+	result := TrimNullBytesString(buf)
+	if result != "hello" {
+		t.Fatalf("expected 'hello', got %q", result)
+	}
+	buf[0] = 'X'
+	if result != "hello" {
+		t.Fatalf("result changed after buffer reuse: got %q, expected 'hello'", result)
+	}
+}


### PR DESCRIPTION
## Fix

Replace `unsafe.String` with `string(b[:idx])` in `TrimNullBytesString` to prevent unsafe memory aliasing.

### Problem

`TrimNullBytesString` used `unsafe.String(unsafe.SliceData(b), idx)` to create a string that shares memory with the caller's byte slice. If the input buffer was stack-allocated or reused (e.g. a network read buffer), the returned string could become a dangling pointer when the buffer is reused or goes out of scope. This occurs at `momo_tcp.go:407` where the result is stored in `metadata.Name`.

### Solution

Replace `unsafe.String` with `string(b[:idx])`, which always allocates a new string with its own backing array. The performance difference is negligible for the typical use case (small metadata strings).

### Test

Added `TestTrimNullBytesString_BufferReuse` — verifies that modifying the input buffer after calling `TrimNullBytesString` does not affect the returned string.

Closes #450