### PR TITLE
fix(common): use 64-bit node ID in CRUSH placement (#449)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1534,3 +1534,10 @@ cacc02f,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
 cacc02f,BenchmarkIndexSearch-8,1.53,0.00,0.00
 cacc02f,BenchmarkLoadGlobalConfig-8,749.10,160.00,1.00
 cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
+9f4d9bb,BenchmarkCheckMetricsAndSwap-8,8.21,0.00,0.00
+9f4d9bb,BenchmarkCrushOptimized-8,326.90,0.00,0.00
+9f4d9bb,BenchmarkCrushOriginal-8,441.70,164.00,3.00
+9f4d9bb,BenchmarkIndexDirectTracking-8,0.40,0.00,0.00
+9f4d9bb,BenchmarkIndexSearch-8,1.61,0.00,0.00
+9f4d9bb,BenchmarkLoadGlobalConfig-8,766.10,160.00,1.00
+9f4d9bb,BenchmarkPadString-8,2.15,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        413.3n ± ∞ ¹    499.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       335.3n ± ∞ ¹    351.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     757.6n ± ∞ ¹    749.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.986n ± ∞ ¹    2.191n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.943n ± ∞ ¹    9.179n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.547n ± ∞ ¹    1.530n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3497n ± ∞ ¹   0.3773n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                18.64n          20.51n        +10.02%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        499.5n ± ∞ ¹    441.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       351.7n ± ∞ ¹    326.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     749.1n ± ∞ ¹    766.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.191n ± ∞ ¹    2.152n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.179n ± ∞ ¹    8.208n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.530n ± ∞ ¹    1.606n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3773n ± ∞ ¹   0.4005n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.51n          19.95n        -2.75%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.18 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 351.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 499.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 749.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.19 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.21 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 326.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 441.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 766.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.15 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f]
-    line "CheckMetricsAndSwap" [8,11,9,9,7,7,7,8,7,9]
-    line "CrushOptimized" [312,322,371,343,336,326,349,324,335,352]
-    line "CrushOriginal" [398,389,448,465,401,406,406,426,413,500]
+    x-axis [04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb]
+    line "CheckMetricsAndSwap" [11,9,9,7,7,7,8,7,9,8]
+    line "CrushOptimized" [322,371,343,336,326,349,324,335,352,327]
+    line "CrushOriginal" [389,448,465,401,406,406,426,413,500,442]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [811,706,836,827,738,751,736,775,758,749]
+    line "LoadGlobalConfig" [706,836,827,738,751,736,775,758,749,766]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f]
+    x-axis [04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [a991604,04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f]
+    x-axis [04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -65,8 +65,8 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 		h.Write([]byte(objectHash))
 
 		// ⚡ Bolt: Eliminate reflection overhead and allocations by using stack-allocated buffer
-		var idBuf [4]byte
-		binary.LittleEndian.PutUint32(idBuf[:], uint32(node.ID))
+		var idBuf [8]byte
+		binary.LittleEndian.PutUint64(idBuf[:], uint64(node.ID))
 		h.Write(idBuf[:])
 
 		// ⚡ Bolt: Eliminate heap allocation of hash.Sum by using stack-allocated slice

--- a/src/common/crush_test.go
+++ b/src/common/crush_test.go
@@ -130,3 +130,24 @@ func TestClusterMap_Placement_Defensive(t *testing.T) {
 		t.Errorf("Expected error to wrap syscall.EIO, got %v", err)
 	}
 }
+
+func TestClusterMap_LargeNodeIDs(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	nodes := []*Node{
+		{ID: 1, Weight: 1, Addr: "node-a"},
+		{ID: 1 + (1 << 32), Weight: 1, Addr: "node-b"},
+	}
+	m := &ClusterMap{Nodes: nodes}
+
+	p1, err := m.Placement("test-hash", 2)
+	if err != nil {
+		t.Fatalf("Placement failed: %v", err)
+	}
+	if len(p1) != 2 {
+		t.Fatalf("Expected 2 nodes, got %d", len(p1))
+	}
+	if p1[0].ID == p1[1].ID {
+		t.Fatalf("Node IDs collided: both are %d", p1[0].ID)
+	}
+}


### PR DESCRIPTION
## Fix

Use `uint64` encoding for node IDs in CRUSH placement to prevent integer truncation.

### Problem

`node.ID` (type `int`, 64-bit) was truncated to `uint32` before hashing:
```go
binary.LittleEndian.PutUint32(idBuf[:], uint32(node.ID))
```

Node IDs outside `[0, 2^32-1]` or negative IDs silently collided, producing identical hashes and corrupting placement decisions.

### Solution

Use an 8-byte buffer with `uint64` encoding:
```go
binary.LittleEndian.PutUint64(idBuf[:], uint64(node.ID))
```

### Test

Added `TestClusterMap_LargeNodeIDs` — verifies no collision for node IDs `1` and `1 + 2^32` which would have collided under `uint32` truncation.

Closes #449