### PR TITLE
fix(transport): close accepted conn on NewCommunicator error (#448)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1541,3 +1541,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 9f4d9bb,BenchmarkIndexSearch-8,1.61,0.00,0.00
 9f4d9bb,BenchmarkLoadGlobalConfig-8,766.10,160.00,1.00
 9f4d9bb,BenchmarkPadString-8,2.15,0.00,0.00
+52462e0,BenchmarkCheckMetricsAndSwap-8,9.38,0.00,0.00
+52462e0,BenchmarkCrushOptimized-8,376.60,0.00,0.00
+52462e0,BenchmarkCrushOriginal-8,444.00,164.00,3.00
+52462e0,BenchmarkIndexDirectTracking-8,0.39,0.00,0.00
+52462e0,BenchmarkIndexSearch-8,1.65,0.00,0.00
+52462e0,BenchmarkLoadGlobalConfig-8,793.00,160.00,1.00
+52462e0,BenchmarkPadString-8,2.26,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        499.5n ± ∞ ¹    441.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       351.7n ± ∞ ¹    326.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     749.1n ± ∞ ¹    766.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.191n ± ∞ ¹    2.152n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.179n ± ∞ ¹    8.208n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.530n ± ∞ ¹    1.606n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3773n ± ∞ ¹   0.4005n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.51n          19.95n        -2.75%
+CrushOriginal-8                        441.7n ± ∞ ¹    444.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       326.9n ± ∞ ¹    376.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     766.1n ± ∞ ¹    793.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.152n ± ∞ ¹    2.260n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.208n ± ∞ ¹    9.377n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.606n ± ∞ ¹    1.654n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4005n ± ∞ ¹   0.3852n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.95n          20.98n        +5.18%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.21 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 326.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 441.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 766.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 376.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 444.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 793.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.26 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb]
-    line "CheckMetricsAndSwap" [11,9,9,7,7,7,8,7,9,8]
-    line "CrushOptimized" [322,371,343,336,326,349,324,335,352,327]
-    line "CrushOriginal" [389,448,465,401,406,406,426,413,500,442]
+    x-axis [639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0]
+    line "CheckMetricsAndSwap" [9,9,7,7,7,8,7,9,8,9]
+    line "CrushOptimized" [371,343,336,326,349,324,335,352,327,377]
+    line "CrushOriginal" [448,465,401,406,406,426,413,500,442,444]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [706,836,827,738,751,736,775,758,749,766]
+    line "LoadGlobalConfig" [836,827,738,751,736,775,758,749,766,793]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb]
+    x-axis [639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [04c719a,639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb]
+    x-axis [639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/communicator.go
+++ b/src/transport/communicator.go
@@ -117,7 +117,12 @@ func (l *TCPListener) Accept() (Communicator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return l.factory.NewCommunicator(conn)
+	comm, err := l.factory.NewCommunicator(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return comm, nil
 }
 
 // QUICListener wraps a quic.Listener to implement the MomoListener interface.


### PR DESCRIPTION
## Fix

Close the accepted `conn` when `factory.NewCommunicator(conn)` returns an error in `TCPListener.Accept`.

### Problem

If `factory.NewCommunicator(conn)` returned an error, the accepted `conn` was never closed, leaking the file descriptor.

### Solution

```go
comm, err := l.factory.NewCommunicator(conn)
if err != nil {
    conn.Close()
    return nil, err
}
return comm, nil
```

Closes #448