### PR TITLE
fix: cap write deadline mb and check PropagateDelete errors (#446, #444)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1548,3 +1548,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 52462e0,BenchmarkIndexSearch-8,1.65,0.00,0.00
 52462e0,BenchmarkLoadGlobalConfig-8,793.00,160.00,1.00
 52462e0,BenchmarkPadString-8,2.26,0.00,0.00
+215f189,BenchmarkCheckMetricsAndSwap-8,7.29,0.00,0.00
+215f189,BenchmarkCrushOptimized-8,384.20,0.00,0.00
+215f189,BenchmarkCrushOriginal-8,428.30,164.00,3.00
+215f189,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+215f189,BenchmarkIndexSearch-8,1.64,0.00,0.00
+215f189,BenchmarkLoadGlobalConfig-8,755.10,160.00,1.00
+215f189,BenchmarkPadString-8,1.97,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        441.7n ± ∞ ¹    444.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       326.9n ± ∞ ¹    376.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     766.1n ± ∞ ¹    793.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.152n ± ∞ ¹    2.260n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.208n ± ∞ ¹    9.377n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.606n ± ∞ ¹    1.654n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4005n ± ∞ ¹   0.3852n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.95n          20.98n        +5.18%
+CrushOriginal-8                        444.0n ± ∞ ¹    428.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       376.6n ± ∞ ¹    384.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     793.0n ± ∞ ¹    755.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.260n ± ∞ ¹    1.966n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.377n ± ∞ ¹    7.289n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.654n ± ∞ ¹    1.640n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3852n ± ∞ ¹   0.3529n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.98n          19.39n        -7.59%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 376.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 444.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 793.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.26 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 384.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 428.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 755.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.97 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0]
-    line "CheckMetricsAndSwap" [9,9,7,7,7,8,7,9,8,9]
-    line "CrushOptimized" [371,343,336,326,349,324,335,352,327,377]
-    line "CrushOriginal" [448,465,401,406,406,426,413,500,442,444]
+    x-axis [12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189]
+    line "CheckMetricsAndSwap" [9,7,7,7,8,7,9,8,9,7]
+    line "CrushOptimized" [343,336,326,349,324,335,352,327,377,384]
+    line "CrushOriginal" [465,401,406,406,426,413,500,442,444,428]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [836,827,738,751,736,775,758,749,766,793]
+    line "LoadGlobalConfig" [827,738,751,736,775,758,749,766,793,755]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0]
+    x-axis [12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [639a088,12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0]
+    x-axis [12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/p2p_adapters.go
+++ b/src/server/p2p_adapters.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"syscall"
 	"time"
 
 	"github.com/alsotoes/momo/src/common"
@@ -89,6 +90,18 @@ func (d *ScatterGatherDeleter) PropagateDelete(key string, timeout time.Duration
 	if d.sg == nil {
 		return nil
 	}
-	d.sg.Query(p2p.QueryDelete, []byte(key), timeout)
+	results, count := d.sg.Query(p2p.QueryDelete, []byte(key), timeout)
+	if count == 0 {
+		return fmt.Errorf("propagate delete: no peers responded (errno=%d)", syscall.EHOSTUNREACH)
+	}
+	successes := 0
+	for _, resp := range results {
+		if resp.Error == "" {
+			successes++
+		}
+	}
+	if successes == 0 {
+		return fmt.Errorf("propagate delete: all %d peer responses were errors (errno=%d)", count, syscall.EIO)
+	}
 	return nil
 }

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"math/big"
 	"net"
 	"os"
@@ -311,6 +312,10 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		copyTimeout := 5 * time.Second
 		mb := meta.Size / (1024 * 1024)
 		if mb > 0 {
+			maxMB := int64(math.MaxInt64 / int64(time.Second))
+			if mb > maxMB {
+				mb = maxMB
+			}
 			copyTimeout += time.Duration(mb) * time.Second
 		}
 		m.Stream.SetWriteDeadline(time.Now().Add(copyTimeout))

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net"
 	"os"
 	"strconv"
@@ -302,6 +303,10 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		copyTimeout := 5 * time.Second
 		mb := meta.Size / (1024 * 1024)
 		if mb > 0 {
+			maxMB := int64(math.MaxInt64 / int64(time.Second))
+			if mb > maxMB {
+				mb = maxMB
+			}
 			copyTimeout += time.Duration(mb) * time.Second
 		}
 		m.SetWriteDeadline(time.Now().Add(copyTimeout))

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -347,6 +348,10 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		copyTimeout := 5 * time.Second
 		mb := meta.Size / (1024 * 1024)
 		if mb > 0 {
+			maxMB := int64(math.MaxInt64 / int64(time.Second))
+			if mb > maxMB {
+				mb = maxMB
+			}
 			copyTimeout += time.Duration(mb) * time.Second
 		}
 		m.conn.SetWriteDeadline(time.Now().Add(copyTimeout))


### PR DESCRIPTION
## Fixes

### #446: Integer overflow in progressive write deadline

`time.Duration(mb) * time.Second` overflows `int64` for very large `meta.Size`, producing a negative `copyTimeout`. This sets a past deadline, causing immediate timeout failure on legitimate large file transfers.

**Fix:** Cap `mb` at `math.MaxInt64 / int64(time.Second)` in all three transport implementations (`momo_tcp.go`, `momo_quic.go`, `s3_communicator.go`).

### #444: PropagateDelete silently swallows all errors

`PropagateDelete` discarded all return values from `sg.Query()`. If delete failed on all peers, no error was returned to the caller — the client believed the delete propagated.

**Fix:** Check response count and per-response `Error` field. Return an error if no peers responded or all responses were errors.

Closes #446, Closes #444