### PR TITLE
fix: bounds check, metadata count error, metrics server shutdown (#443, #442, #441)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1555,3 +1555,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 215f189,BenchmarkIndexSearch-8,1.64,0.00,0.00
 215f189,BenchmarkLoadGlobalConfig-8,755.10,160.00,1.00
 215f189,BenchmarkPadString-8,1.97,0.00,0.00
+1353d73,BenchmarkCheckMetricsAndSwap-8,6.74,0.00,0.00
+1353d73,BenchmarkCrushOptimized-8,312.90,0.00,0.00
+1353d73,BenchmarkCrushOriginal-8,472.90,164.00,3.00
+1353d73,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+1353d73,BenchmarkIndexSearch-8,1.47,0.00,0.00
+1353d73,BenchmarkLoadGlobalConfig-8,747.30,160.00,1.00
+1353d73,BenchmarkPadString-8,2.29,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        444.0n ± ∞ ¹    428.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       376.6n ± ∞ ¹    384.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     793.0n ± ∞ ¹    755.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.260n ± ∞ ¹    1.966n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.377n ± ∞ ¹    7.289n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.654n ± ∞ ¹    1.640n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3852n ± ∞ ¹   0.3529n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.98n          19.39n        -7.59%
+CrushOriginal-8                        428.3n ± ∞ ¹    472.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       384.2n ± ∞ ¹    312.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     755.1n ± ∞ ¹    747.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.966n ± ∞ ¹    2.285n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.289n ± ∞ ¹    6.743n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.640n ± ∞ ¹    1.473n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3529n ± ∞ ¹   0.3466n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.39n          18.93n        -2.39%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.29 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 384.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 428.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 312.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 472.90 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 755.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.97 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 747.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189]
-    line "CheckMetricsAndSwap" [9,7,7,7,8,7,9,8,9,7]
-    line "CrushOptimized" [343,336,326,349,324,335,352,327,377,384]
-    line "CrushOriginal" [465,401,406,406,426,413,500,442,444,428]
+    x-axis [91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73]
+    line "CheckMetricsAndSwap" [7,7,7,8,7,9,8,9,7,7]
+    line "CrushOptimized" [336,326,349,324,335,352,327,377,384,313]
+    line "CrushOriginal" [401,406,406,426,413,500,442,444,428,473]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [827,738,751,736,775,758,749,766,793,755]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,2,1]
+    line "LoadGlobalConfig" [738,751,736,775,758,749,766,793,755,747]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189]
+    x-axis [91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [12d5214,91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189]
+    x-axis [91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/metrics_exporter.go
+++ b/src/server/metrics_exporter.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -118,7 +119,8 @@ func (m *MetricsCollector) handler(w http.ResponseWriter, r *http.Request) {
 
 // StartMetricsServer starts an HTTP server exposing Prometheus metrics on the given port.
 // It runs in a background goroutine and returns immediately.
-func StartMetricsServer(port int, collector *MetricsCollector) {
+// The server is shut down when the provided context is canceled.
+func StartMetricsServer(ctx context.Context, port int, collector *MetricsCollector) {
 	if port <= 0 {
 		return
 	}
@@ -137,6 +139,8 @@ func StartMetricsServer(port int, collector *MetricsCollector) {
 		return
 	}
 
+	srv := &http.Server{Handler: mux}
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -144,8 +148,15 @@ func StartMetricsServer(port int, collector *MetricsCollector) {
 			}
 		}()
 		log.Printf("Prometheus metrics server listening on :%d/metrics", port)
-		if err := http.Serve(ln, mux); err != nil && err != http.ErrServerClosed {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 			log.Printf("Metrics server error: %v", err)
 		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(shutdownCtx)
 	}()
 }

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -176,7 +176,7 @@ func DecodeFileMetadataList(data []byte) (result []common.FileMetadata, err erro
 	off := 4
 	maxCount := (len(data) - 4) / 20
 	if count > maxCount {
-		count = maxCount
+		return nil, fmt.Errorf("file metadata list count %d exceeds max %d for data length %d: %w", count, maxCount, len(data), syscall.EBADMSG)
 	}
 	files := make([]common.FileMetadata, 0, count)
 	for i := 0; i < count; i++ {

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -64,6 +64,9 @@ func SetReplicationState(newMode int, timestamp int64) common.ReplicationData {
 // it propagates the change to the other servers in the cluster.
 func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, serverId int, timestamp int64) error {
 	daemons := cfg.Daemons
+	if serverId < 0 || serverId >= len(daemons) {
+		return fmt.Errorf("server ID %d is out of range [0, %d)", serverId, len(daemons))
+	}
 	factory := transport.NewProtocolFactory(cfg)
 	server, err := factory.Listen(daemons[serverId].ChangeReplication)
 	if err != nil {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -75,7 +75,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 
 	// Start Prometheus metrics endpoint if configured
 	metricsCollector := NewMetricsCollector()
-	StartMetricsServer(cfg.Metrics.PrometheusPort, metricsCollector)
+	StartMetricsServer(ctx, cfg.Metrics.PrometheusPort, metricsCollector)
 
 	// 🛡️ Zero-Crash: Log a warning if the cluster cannot meet the desired durability goal.
 	if cfg.Global.ReplicationFactor > len(daemons) {


### PR DESCRIPTION
## Fixes

### #443: Missing serverId bounds validation in ChangeReplicationModeServer

`ChangeReplicationModeServer` accessed `daemons[serverId]` without checking bounds, panicking on invalid `serverId`. Added bounds check consistent with `Daemon`.

### #442: DecodeFileMetadataList silently truncates count

When `count > maxCount`, the count was silently reduced rather than returning an error. A malicious peer could claim a large count with partial data; the decoder returned a partial list without indicating data was lost. Now returns an error.

### #441: Metrics server listener/goroutine never closed

`StartMetricsServer` created a `net.Listener` and spawned a goroutine running `http.Serve` with no shutdown path. On daemon exit, both leaked. Added `context.Context` parameter and `http.Server.Shutdown(ctx)` on context cancellation.

Closes #443, Closes #442, Closes #441