### PR TITLE
fix: dedup error propagation, hash path traversal, ApplyTombstone errors (#440, #438, #437)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1562,3 +1562,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 1353d73,BenchmarkIndexSearch-8,1.47,0.00,0.00
 1353d73,BenchmarkLoadGlobalConfig-8,747.30,160.00,1.00
 1353d73,BenchmarkPadString-8,2.29,0.00,0.00
+4246b52,BenchmarkCheckMetricsAndSwap-8,9.16,0.00,0.00
+4246b52,BenchmarkCrushOptimized-8,364.30,0.00,0.00
+4246b52,BenchmarkCrushOriginal-8,439.10,164.00,3.00
+4246b52,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+4246b52,BenchmarkIndexSearch-8,1.75,0.00,0.00
+4246b52,BenchmarkLoadGlobalConfig-8,777.20,160.00,1.00
+4246b52,BenchmarkPadString-8,2.47,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        428.3n ± ∞ ¹    472.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       384.2n ± ∞ ¹    312.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     755.1n ± ∞ ¹    747.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.966n ± ∞ ¹    2.285n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.289n ± ∞ ¹    6.743n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.640n ± ∞ ¹    1.473n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3529n ± ∞ ¹   0.3466n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.39n          18.93n        -2.39%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        472.9n ± ∞ ¹    439.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       312.9n ± ∞ ¹    364.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     747.3n ± ∞ ¹    777.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.285n ± ∞ ¹    2.470n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.743n ± ∞ ¹    9.164n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.473n ± ∞ ¹    1.748n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3466n ± ∞ ¹   0.3538n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                18.93n          20.90n        +10.41%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 312.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 472.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.16 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 364.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 439.10 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 747.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 777.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.47 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73]
-    line "CheckMetricsAndSwap" [7,7,7,8,7,9,8,9,7,7]
-    line "CrushOptimized" [336,326,349,324,335,352,327,377,384,313]
-    line "CrushOriginal" [401,406,406,426,413,500,442,444,428,473]
+    x-axis [cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52]
+    line "CheckMetricsAndSwap" [7,7,8,7,9,8,9,7,7,9]
+    line "CrushOptimized" [326,349,324,335,352,327,377,384,313,364]
+    line "CrushOriginal" [406,406,426,413,500,442,444,428,473,439]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,1]
-    line "LoadGlobalConfig" [738,751,736,775,758,749,766,793,755,747]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,1,2]
+    line "LoadGlobalConfig" [751,736,775,758,749,766,793,755,747,777]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73]
+    x-axis [cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [91cf463,cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73]
+    x-axis [cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -355,20 +355,21 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 			// Handle the file based on the replication mode
 			switch replicationMode {
 			case common.ReplicationNone, common.ReplicationPrimarySplay:
-				if exists {
-					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
-					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
-						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
-						metricsCollector.IncErrors()
-					}
-				} else {
-					if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
-						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
-						metricsCollector.IncErrors()
-						return
-					}
+			if exists {
+				// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
+				if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+					log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
+					metricsCollector.IncErrors()
+					return
 				}
-			case common.ReplicationChain:
+			} else {
+				if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
+					log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
+					metricsCollector.IncErrors()
+					return
+				}
+			}
+		case common.ReplicationChain:
 				// In Chain mode, we find our position in the placement list and forward to the next node.
 				myPos := -1
 				for i, n := range placement {
@@ -383,7 +384,9 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
 					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
+						wg.Done()
 						metricsCollector.IncErrors()
+						return
 					}
 				} else {
 					if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
@@ -432,7 +435,11 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 						// ⚡ Bolt: Deduplication hit. Just update metadata mapping.
 						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
+							for i := 0; i < len(placement)-1; i++ {
+								wg.Done()
+							}
 							metricsCollector.IncErrors()
+							return
 						}
 					} else {
 						if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
@@ -469,13 +476,14 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 					}
 					wg.Wait()
 				} else {
-					// We are a secondary in a splay, just receive the file if needed.
-					if exists {
-						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
-							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
-							metricsCollector.IncErrors()
-						}
-					} else {
+				// We are a secondary in a splay, just receive the file if needed.
+				if exists {
+					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
+						metricsCollector.IncErrors()
+						return
+					}
+				} else {
 						if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
 							log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 							metricsCollector.IncErrors()

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -213,8 +213,12 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) (err error) {
 				}
 			}
 		}
-		ns.Delete([]byte(name))
-		paths.Delete([]byte(name))
+		if err := ns.Delete([]byte(name)); err != nil {
+			return fmt.Errorf("namespace delete error: %w", err)
+		}
+		if err := paths.Delete([]byte(name)); err != nil {
+			return fmt.Errorf("paths delete error: %w", err)
+		}
 		return nil
 	})
 }

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -150,6 +150,10 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 		}
 	}()
 
+	if common.HasPathTraversalChars(hash) {
+		return fmt.Errorf("hash contains path traversal characters: %w", syscall.EINVAL)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -285,6 +289,10 @@ func (s *CASStore) Has(hash string) (exists bool, err error) {
 			err = fmt.Errorf("internal storage panic: %w", syscall.EIO)
 		}
 	}()
+
+	if common.HasPathTraversalChars(hash) {
+		return false, fmt.Errorf("hash contains path traversal characters: %w", syscall.EINVAL)
+	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
## Fixes

### #440: store.Put failure on dedup hit silently swallowed

When `store.Put` failed on a dedup hit, the error was logged but execution continued. `success = true` was set and ACK was sent to client. The client believed the upload succeeded, but the name-to-hash mapping didn't exist. Subsequent GET by name returns ENOENT.

. Now returns an error to the client in all four replication modes.

### #438: Path traversal via unsanitized hash in Store interface

The `hash` parameter was never validated within the storage package. Added `HasPathTraversalChars(hash)` validation in `Put` and `Has` methods for defense-in-depth.

### #437: Unchecked Delete errors in ApplyTombstone

`ns.Delete` and `paths.Delete` return values were discarded. Now propagates errors from both Delete calls.

Closes #440, Closes #438, Closes #437