### PR TITLE
fix: QUIC conn leak, CASStore double-close and race (#445, #428, #427)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1569,3 +1569,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 4246b52,BenchmarkIndexSearch-8,1.75,0.00,0.00
 4246b52,BenchmarkLoadGlobalConfig-8,777.20,160.00,1.00
 4246b52,BenchmarkPadString-8,2.47,0.00,0.00
+66ac855,BenchmarkCheckMetricsAndSwap-8,8.20,0.00,0.00
+66ac855,BenchmarkCrushOptimized-8,303.60,0.00,0.00
+66ac855,BenchmarkCrushOriginal-8,401.70,164.00,3.00
+66ac855,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+66ac855,BenchmarkIndexSearch-8,1.49,0.00,0.00
+66ac855,BenchmarkLoadGlobalConfig-8,711.30,160.00,1.00
+66ac855,BenchmarkPadString-8,2.04,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        472.9n ± ∞ ¹    439.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       312.9n ± ∞ ¹    364.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     747.3n ± ∞ ¹    777.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.285n ± ∞ ¹    2.470n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.743n ± ∞ ¹    9.164n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.473n ± ∞ ¹    1.748n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3466n ± ∞ ¹   0.3538n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                18.93n          20.90n        +10.41%
+CrushOriginal-8                        439.1n ± ∞ ¹    401.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       364.3n ± ∞ ¹    303.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     777.2n ± ∞ ¹    711.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.470n ± ∞ ¹    2.041n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.164n ± ∞ ¹    8.201n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.748n ± ∞ ¹    1.494n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3538n ± ∞ ¹   0.3759n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.90n          18.75n        -10.26%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.16 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 364.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 439.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 777.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 303.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 401.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 711.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.04 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52]
-    line "CheckMetricsAndSwap" [7,7,8,7,9,8,9,7,7,9]
-    line "CrushOptimized" [326,349,324,335,352,327,377,384,313,364]
-    line "CrushOriginal" [406,406,426,413,500,442,444,428,473,439]
+    x-axis [dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855]
+    line "CheckMetricsAndSwap" [7,8,7,9,8,9,7,7,9,8]
+    line "CrushOptimized" [349,324,335,352,327,377,384,313,364,304]
+    line "CrushOriginal" [406,426,413,500,442,444,428,473,439,402]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,1,2]
-    line "LoadGlobalConfig" [751,736,775,758,749,766,793,755,747,777]
+    line "IndexSearch" [2,2,2,2,2,2,2,1,2,1]
+    line "LoadGlobalConfig" [736,775,758,749,766,793,755,747,777,711]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52]
+    x-axis [dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cab6e2d,dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52]
+    x-axis [dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -70,12 +70,13 @@ type Store interface {
 // It composes a pluggable BlobStore (for raw blob bytes) with a fixed
 // bbolt metadata layer (for refcounts, tombstones, namespace mappings).
 type CASStore struct {
-	mu     sync.RWMutex
-	db     *bbolt.DB
-	base   string
-	blobs  BlobStore
-	gcDone chan struct{}
-	gcWG   sync.WaitGroup
+	mu       sync.RWMutex
+	db       *bbolt.DB
+	base     string
+	blobs    BlobStore
+	gcDone   chan struct{}
+	gcWG     sync.WaitGroup
+	closeOnce sync.Once
 }
 
 // NewCASStore initializes a CAS store with a LocalBlobStore backend.
@@ -129,14 +130,19 @@ func newCASStore(dataDir string, blobs BlobStore) (*CASStore, error) {
 }
 
 func (s *CASStore) Close() error {
-	if s.gcDone != nil {
-		close(s.gcDone)
-		s.gcWG.Wait()
-	}
-	if s.blobs != nil {
-		s.blobs.Close()
-	}
-	return s.db.Close()
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		if s.gcDone != nil {
+			close(s.gcDone)
+			s.gcWG.Wait()
+		}
+		if s.blobs != nil {
+			s.blobs.Close()
+		}
+		s.db.Close()
+		s.mu.Unlock()
+	})
+	return nil
 }
 
 // Put saves an object to the store.

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -506,7 +506,12 @@ func (m *MomoQUICCommunicator) Close() (err error) {
 			err = fmt.Errorf("panic in Close: %v: %w", r, syscall.EIO)
 		}
 	}()
-	return m.Stream.Close()
+	streamErr := m.Stream.Close()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		m.conn.CloseWithError(0, "")
+	}()
+	return streamErr
 }
 
 // GenerateSelfSignedCert generates a self-signed TLS certificate for testing and internal use.


### PR DESCRIPTION
## Fixes

### #445: QUIC connection leak — Close() only closes stream, never quic.Conn

`MomoQUICCommunicator.Close()` only closed the QUIC stream, never the `quic.Conn`, leaking the UDP socket and associated resources on every connection close.

**Fix:** Close the stream first, then close the connection in a goroutine after a short delay (100ms) to allow pending reads to complete.

### #428: Double-close panic on gcDone channel in CASStore

`close(s.gcDone)` panicked if `Close()` was called twice. No `sync.Once` guard.

**Fix:** Added `sync.Once` to guard the close.

### #427: Close() races with concurrent operations in CASStore

`Close()` never acquired `s.mu`. A concurrent `Put`/`Get`/`Delete` could be using `s.db` or `s.blobs` when `Close` closed them, causing panics or undefined behavior.

**Fix:** Acquire `s.mu.Lock()` before closing resources.

Closes #445, Closes #428, Closes #427