### PR TITLE
fix: raw blobstore integer overflow and unchecked View (#434, #433, #432)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1576,3 +1576,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 66ac855,BenchmarkIndexSearch-8,1.49,0.00,0.00
 66ac855,BenchmarkLoadGlobalConfig-8,711.30,160.00,1.00
 66ac855,BenchmarkPadString-8,2.04,0.00,0.00
+5a741d8,BenchmarkCheckMetricsAndSwap-8,7.29,0.00,0.00
+5a741d8,BenchmarkCrushOptimized-8,310.30,0.00,0.00
+5a741d8,BenchmarkCrushOriginal-8,439.10,164.00,3.00
+5a741d8,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+5a741d8,BenchmarkIndexSearch-8,1.53,0.00,0.00
+5a741d8,BenchmarkLoadGlobalConfig-8,710.90,160.00,1.00
+5a741d8,BenchmarkPadString-8,2.01,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1583,3 +1583,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 5a741d8,BenchmarkIndexSearch-8,1.53,0.00,0.00
 5a741d8,BenchmarkLoadGlobalConfig-8,710.90,160.00,1.00
 5a741d8,BenchmarkPadString-8,2.01,0.00,0.00
+6a5515e,BenchmarkCheckMetricsAndSwap-8,8.28,0.00,0.00
+6a5515e,BenchmarkCrushOptimized-8,440.40,0.00,0.00
+6a5515e,BenchmarkCrushOriginal-8,446.60,164.00,3.00
+6a5515e,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+6a5515e,BenchmarkIndexSearch-8,1.52,0.00,0.00
+6a5515e,BenchmarkLoadGlobalConfig-8,823.20,160.00,1.00
+6a5515e,BenchmarkPadString-8,2.40,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        439.1n ± ∞ ¹    401.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       364.3n ± ∞ ¹    303.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     777.2n ± ∞ ¹    711.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.470n ± ∞ ¹    2.041n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.164n ± ∞ ¹    8.201n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.748n ± ∞ ¹    1.494n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3538n ± ∞ ¹   0.3759n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.90n          18.75n        -10.26%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        401.7n ± ∞ ¹    439.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       303.6n ± ∞ ¹    310.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     711.3n ± ∞ ¹    710.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.041n ± ∞ ¹    2.011n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.201n ± ∞ ¹    7.293n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.494n ± ∞ ¹    1.526n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3759n ± ∞ ¹   0.3180n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.75n          18.31n        -2.37%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 303.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 401.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.49 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 711.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.04 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 310.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 439.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 710.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.01 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855]
-    line "CheckMetricsAndSwap" [7,8,7,9,8,9,7,7,9,8]
-    line "CrushOptimized" [349,324,335,352,327,377,384,313,364,304]
-    line "CrushOriginal" [406,426,413,500,442,444,428,473,439,402]
+    x-axis [c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8]
+    line "CheckMetricsAndSwap" [8,7,9,8,9,7,7,9,8,7]
+    line "CrushOptimized" [324,335,352,327,377,384,313,364,304,310]
+    line "CrushOriginal" [426,413,500,442,444,428,473,439,402,439]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,1,2,1]
-    line "LoadGlobalConfig" [736,775,758,749,766,793,755,747,777,711]
+    line "IndexSearch" [2,2,2,2,2,2,1,2,1,2]
+    line "LoadGlobalConfig" [775,758,749,766,793,755,747,777,711,711]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855]
+    x-axis [c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [dfca564,c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855]
+    x-axis [c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        401.7n ± ∞ ¹    439.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       303.6n ± ∞ ¹    310.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     711.3n ± ∞ ¹    710.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.041n ± ∞ ¹    2.011n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.201n ± ∞ ¹    7.293n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.494n ± ∞ ¹    1.526n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3759n ± ∞ ¹   0.3180n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.75n          18.31n        -2.37%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        439.1n ± ∞ ¹    446.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       310.3n ± ∞ ¹    440.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     710.9n ± ∞ ¹    823.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.011n ± ∞ ¹    2.395n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.293n ± ∞ ¹    8.281n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.526n ± ∞ ¹    1.524n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3180n ± ∞ ¹   0.3528n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                18.31n          20.87n        +14.01%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.29 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 310.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 439.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 710.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.01 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.28 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 440.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 446.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 823.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.40 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8]
-    line "CheckMetricsAndSwap" [8,7,9,8,9,7,7,9,8,7]
-    line "CrushOptimized" [324,335,352,327,377,384,313,364,304,310]
-    line "CrushOriginal" [426,413,500,442,444,428,473,439,402,439]
+    x-axis [0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e]
+    line "CheckMetricsAndSwap" [7,9,8,9,7,7,9,8,7,8]
+    line "CrushOptimized" [335,352,327,377,384,313,364,304,310,440]
+    line "CrushOriginal" [413,500,442,444,428,473,439,402,439,447]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,1,2,1,2]
-    line "LoadGlobalConfig" [775,758,749,766,793,755,747,777,711,711]
+    line "IndexSearch" [2,2,2,2,2,1,2,1,2,2]
+    line "LoadGlobalConfig" [758,749,766,793,755,747,777,711,711,823]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8]
+    x-axis [0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c5342af,0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8]
+    x-axis [0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/raw_blobstore.go
+++ b/src/storage/raw_blobstore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -78,13 +79,15 @@ func NewRawBlobStore(cfg common.ConfigurationStorage, daemon *common.Daemon) (rb
 		}
 		c := b.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
-			if len(v) == 16 {
-				offset := int64(binary.BigEndian.Uint64(v[0:8]))
-				length := int64(binary.BigEndian.Uint64(v[8:16]))
+		if len(v) == 16 {
+			offset := int64(binary.BigEndian.Uint64(v[0:8]))
+			length := int64(binary.BigEndian.Uint64(v[8:16]))
+			if offset > 0 && length > 0 && offset <= math.MaxInt64-length {
 				end := offset + length
 				if end > nextOffset {
 					nextOffset = end
 				}
+			}
 			}
 		}
 		return nil
@@ -123,13 +126,16 @@ func (r *RawBlobStore) PutBlob(hash string, content io.Reader) (err error) {
 	defer r.mu.Unlock()
 
 	var exists bool
-	r.allocDB.View(func(tx *bbolt.Tx) error {
+	err = r.allocDB.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(bucketRawAlloc)
 		if b != nil {
 			exists = b.Get([]byte(hash)) != nil
 		}
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("raw: failed to check existence: %w", err)
+	}
 	if exists {
 		return nil
 	}
@@ -173,6 +179,9 @@ func (r *RawBlobStore) PutBlob(hash string, content io.Reader) (err error) {
 		return fmt.Errorf("raw: failed to record allocation: %w", syscall.EIO)
 	}
 
+	if offset > math.MaxInt64-totalWritten {
+		return fmt.Errorf("raw: offset overflow: %d + %d exceeds MaxInt64: %w", offset, totalWritten, syscall.EIO)
+	}
 	r.nextOffset = offset + totalWritten
 	return nil
 }

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -131,11 +131,11 @@ func newCASStore(dataDir string, blobs BlobStore) (*CASStore, error) {
 
 func (s *CASStore) Close() error {
 	s.closeOnce.Do(func() {
-		s.mu.Lock()
 		if s.gcDone != nil {
 			close(s.gcDone)
 			s.gcWG.Wait()
 		}
+		s.mu.Lock()
 		if s.blobs != nil {
 			s.blobs.Close()
 		}


### PR DESCRIPTION
## Fixes

### #434: Integer overflow in nextOffset update

`r.nextOffset = offset + totalWritten` could overflow to negative if `offset` was near `MaxInt64`. All subsequent `WriteAt` calls would use a negative offset and fail, permanently bricking the raw backend.

**Fix:** Added overflow check before updating `nextOffset`.

### #433: Integer overflow in allocation table scan

`end := offset + length` could overflow from corrupted DB data, causing `nextOffset` to not update correctly and subsequent writes to overlap existing data.

**Fix:** Added overflow guard: `if offset <= math.MaxInt64-length`.

### #432: Unchecked allocDB.View in RawBlobStore

`allocDB.View` return value was unchecked in `PutBlob`. If `View` failed, `exists` stayed `false` and a duplicate blob was written at a new offset, permanently leaking space.

**Fix:** Check and propagate the error.

Closes #434, Closes #433, Closes #432