### PR TITLE
fix: unchecked errors in CASStore Put/Get/Delete (#431, #430, #429)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1590,3 +1590,10 @@ cacc02f,BenchmarkPadString-8,2.19,0.00,0.00
 6a5515e,BenchmarkIndexSearch-8,1.52,0.00,0.00
 6a5515e,BenchmarkLoadGlobalConfig-8,823.20,160.00,1.00
 6a5515e,BenchmarkPadString-8,2.40,0.00,0.00
+cbe2a54,BenchmarkCheckMetricsAndSwap-8,7.39,0.00,0.00
+cbe2a54,BenchmarkCrushOptimized-8,290.40,0.00,0.00
+cbe2a54,BenchmarkCrushOriginal-8,407.60,164.00,3.00
+cbe2a54,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+cbe2a54,BenchmarkIndexSearch-8,1.58,0.00,0.00
+cbe2a54,BenchmarkLoadGlobalConfig-8,707.80,160.00,1.00
+cbe2a54,BenchmarkPadString-8,1.93,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        439.1n ± ∞ ¹    446.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       310.3n ± ∞ ¹    440.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     710.9n ± ∞ ¹    823.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.011n ± ∞ ¹    2.395n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.293n ± ∞ ¹    8.281n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.526n ± ∞ ¹    1.524n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3180n ± ∞ ¹   0.3528n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                18.31n          20.87n        +14.01%
+CrushOriginal-8                        446.6n ± ∞ ¹    407.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       440.4n ± ∞ ¹    290.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     823.2n ± ∞ ¹    707.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.395n ± ∞ ¹    1.926n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.281n ± ∞ ¹    7.389n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.524n ± ∞ ¹    1.584n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3528n ± ∞ ¹   0.3827n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.87n          18.43n        -11.70%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.28 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 440.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 446.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 823.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 290.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 407.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.58 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 707.80 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e]
-    line "CheckMetricsAndSwap" [7,9,8,9,7,7,9,8,7,8]
-    line "CrushOptimized" [335,352,327,377,384,313,364,304,310,440]
-    line "CrushOriginal" [413,500,442,444,428,473,439,402,439,447]
+    x-axis [cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54]
+    line "CheckMetricsAndSwap" [9,8,9,7,7,9,8,7,8,7]
+    line "CrushOptimized" [352,327,377,384,313,364,304,310,440,290]
+    line "CrushOriginal" [500,442,444,428,473,439,402,439,447,408]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,1,2,1,2,2]
-    line "LoadGlobalConfig" [758,749,766,793,755,747,777,711,711,823]
+    line "IndexSearch" [2,2,2,2,1,2,1,2,2,2]
+    line "LoadGlobalConfig" [749,766,793,755,747,777,711,711,823,708]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e]
+    x-axis [cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0fe9fb7,cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e]
+    x-axis [cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -164,7 +164,10 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 	defer s.mu.Unlock()
 
 	// 1. Check if we already have the blob
-	exists, _ := s.hasInternal(hash)
+	exists, err := s.hasInternal(hash)
+	if err != nil {
+		return fmt.Errorf("failed to check blob existence: %w", err)
+	}
 	if !exists && content != nil {
 		if err := s.blobs.PutBlob(hash, content); err != nil {
 			return err
@@ -192,7 +195,9 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 		}
 
 		// Remove any existing tombstone for this name (resurrection).
-		tx.Bucket(bucketTombstones).Delete([]byte(name))
+		if err := tx.Bucket(bucketTombstones).Delete([]byte(name)); err != nil {
+			return fmt.Errorf("tombstone delete error: %w", err)
+		}
 
 		// Store RemotePath
 		if remotePath != "" {
@@ -275,13 +280,16 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 	}
 
 	var remotePath string
-	_ = s.db.View(func(tx *bbolt.Tx) error {
+	err = s.db.View(func(tx *bbolt.Tx) error {
 		p := tx.Bucket(bucketPaths).Get([]byte(name))
 		if p != nil {
 			remotePath = string(p)
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, common.FileMetadata{}, fmt.Errorf("failed to read remotePath: %w", err)
+	}
 
 	return f, common.FileMetadata{Name: name, Hash: hash, Size: size, RemotePath: remotePath}, nil
 }
@@ -359,8 +367,12 @@ func (s *CASStore) Delete(name string) (err error) {
 		}
 
 		// Remove namespace and paths entries.
-		ns.Delete([]byte(name))
-		paths.Delete([]byte(name))
+		if err := ns.Delete([]byte(name)); err != nil {
+			return fmt.Errorf("namespace delete error: %w", err)
+		}
+		if err := paths.Delete([]byte(name)); err != nil {
+			return fmt.Errorf("paths delete error: %w", err)
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
## Fixes

### #431: Unchecked bbolt.Bucket.Delete errors

`Delete` errors were unchecked in `Put` (tombstone removal on resurrection) and `Delete` (namespace/paths removal). If these failed, tombstones were not removed or namespace/paths entries persisted, creating metadata inconsistency.

### #430: Unchecked db.View for remotePath

`db.View` for reading `remotePath` discarded the error, silently defaulting to empty string. The returned `FileMetadata` had a missing `RemotePath` with no error indication.

### #429: Unchecked hasInternal error causes duplicate blob writes

`hasInternal` error was discarded in `Put`. If `View` failed, `exists` defaulted to `false` and the blob was written unnecessarily. For `RawBlobStore`, this meant a duplicate allocation at a new offset, wasting device space permanently.

Closes #431, Closes #430, Closes #429