### PR TITLE
fix(ci): sync PR labels/assignee from issues before review

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1597,3 +1597,10 @@ cbe2a54,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
 cbe2a54,BenchmarkIndexSearch-8,1.58,0.00,0.00
 cbe2a54,BenchmarkLoadGlobalConfig-8,707.80,160.00,1.00
 cbe2a54,BenchmarkPadString-8,1.93,0.00,0.00
+83d81be,BenchmarkCheckMetricsAndSwap-8,9.00,0.00,0.00
+83d81be,BenchmarkCrushOptimized-8,330.50,0.00,0.00
+83d81be,BenchmarkCrushOriginal-8,443.60,164.00,3.00
+83d81be,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+83d81be,BenchmarkIndexSearch-8,1.74,0.00,0.00
+83d81be,BenchmarkLoadGlobalConfig-8,794.70,160.00,1.00
+83d81be,BenchmarkPadString-8,2.39,0.00,0.00

--- a/.github/scripts/ai_reviewer.py
+++ b/.github/scripts/ai_reviewer.py
@@ -90,6 +90,60 @@ def add_jules_label(pr_number):
     except Exception as e:
         print(f"Failed to add jules label: {e}", file=sys.stderr)
 
+def sync_pr_labels_and_assignee(pr_number, pr_title, pr_body):
+    """Sync labels from linked issues to the PR and assign alsotoes.
+
+    This runs BEFORE any review work, ensuring every PR has correct
+    labels and an assignee from the moment it's opened.
+
+    1. Parse 'Closes #NNN' / 'Fixes #NNN' / 'Resolves #NNN' from PR body.
+    2. Fetch labels from each linked issue.
+    3. Add those labels to the PR (deduplicated by gh).
+    4. Assign alsotoes to the PR.
+    5. Add 'bug' label if the PR title starts with 'fix('.
+    """
+    if not pr_number:
+        return
+
+    labels_to_add = set()
+
+    # Parse issue references from PR body
+    issue_pattern = re.compile(r'\b(?:Closes|Fixes|Resolves)\s+#(\d+)', re.IGNORECASE)
+    issue_nums = issue_pattern.findall(pr_body or "")
+
+    for issue_num in issue_nums:
+        try:
+            cmd = ["gh", "issue", "view", issue_num, "--json", "labels"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            data = json.loads(result.stdout)
+            for label in data.get("labels", []):
+                labels_to_add.add(label["name"])
+        except Exception as e:
+            print(f"Failed to fetch labels for issue #{issue_num}: {e}", file=sys.stderr)
+
+    # Add 'bug' label for fix() PRs even without issue links
+    if pr_title and pr_title.lower().startswith("fix("):
+        labels_to_add.add("bug")
+    elif pr_title and pr_title.lower().startswith("feat("):
+        labels_to_add.add("enhancement")
+
+    # Apply labels
+    if labels_to_add:
+        try:
+            cmd = ["gh", "pr", "edit", pr_number, "--add-label", ",".join(sorted(labels_to_add))]
+            subprocess.run(cmd, capture_output=True, text=True, check=True)
+            print(f"Synced labels to PR #{pr_number}: {sorted(labels_to_add)}")
+        except Exception as e:
+            print(f"Failed to sync labels: {e}", file=sys.stderr)
+
+    # Assign alsotoes to every PR
+    try:
+        subprocess.run(["gh", "pr", "edit", pr_number, "--add-assignee", "alsotoes"],
+                       capture_output=True, text=True, check=True)
+        print(f"Assigned alsotoes to PR #{pr_number}")
+    except Exception as e:
+        print(f"Failed to assign alsotoes: {e}", file=sys.stderr)
+
 def create_missing_issue(pr_number, pr_title, pr_body):
     try:
         print(f"Rule 11 Violation detected. Autonomously creating tracking issue for PR #{pr_number}...")
@@ -147,6 +201,12 @@ def main():
     pr_body = os.environ.get("PR_BODY", "")
     pr_title = os.environ.get("PR_TITLE", "")
     pr_number = os.environ.get("PR_NUMBER", "")
+
+    # ⚡ First: Sync labels from linked issues and assign alsotoes.
+    # This ensures every PR has correct labels and an assignee before
+    # any review work begins.
+    sync_pr_labels_and_assignee(pr_number, pr_title, pr_body)
+
     # Rule 68: Detect Jules PRs by author, body, or first comment
     is_jules_pr = "jules" in pr_author.lower() or "jules" in pr_body.lower() or check_jules_first_comment(pr_number)
     
@@ -166,17 +226,15 @@ def main():
 
     # ⚡ Bolt: Automated PR Management
     if pr_number:
-        # 1. Labeling for Jules PRs (Rule 68)
+        # Labeling for Jules PRs (Rule 68)
         if is_jules_pr:
             add_jules_label(pr_number)
             if "sentinel" in pr_title.lower():
-                subprocess.run(["gh", "pr", "edit", pr_number, "--add-label", "bug"])
+                subprocess.run(["gh", "pr", "edit", pr_number, "--add-label", "bug"],
+                               capture_output=True, text=True)
             elif "bolt" in pr_title.lower():
-                subprocess.run(["gh", "pr", "edit", pr_number, "--add-label", "enhancement"])
-        
-        # 2. Assignment for alsotoes PRs
-        if pr_author.lower() == "alsotoes":
-            subprocess.run(["gh", "pr", "edit", pr_number, "--add-assignee", "alsotoes"])
+                subprocess.run(["gh", "pr", "edit", pr_number, "--add-label", "enhancement"],
+                               capture_output=True, text=True)
 
     jules_commits = get_jules_commit_count()
     max_jules_pushes = 3

--- a/.github/workflows/gemini_reviewer.yml
+++ b/.github/workflows/gemini_reviewer.yml
@@ -3,11 +3,6 @@ name: Gemini AI Reviewer
 on:
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - 'src/**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
   workflow_dispatch:
     inputs:
       pr_number:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        446.6n ± ∞ ¹    407.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       440.4n ± ∞ ¹    290.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     823.2n ± ∞ ¹    707.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.395n ± ∞ ¹    1.926n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.281n ± ∞ ¹    7.389n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.524n ± ∞ ¹    1.584n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3528n ± ∞ ¹   0.3827n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.87n          18.43n        -11.70%
+CrushOriginal-8                        407.6n ± ∞ ¹    443.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       290.4n ± ∞ ¹    330.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     707.8n ± ∞ ¹    794.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.926n ± ∞ ¹    2.392n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.389n ± ∞ ¹    9.000n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.584n ± ∞ ¹    1.741n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3827n ± ∞ ¹   0.3741n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                18.43n          20.71n        +12.36%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 290.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 407.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.58 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 707.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 330.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 443.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 794.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.39 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54]
-    line "CheckMetricsAndSwap" [9,8,9,7,7,9,8,7,8,7]
-    line "CrushOptimized" [352,327,377,384,313,364,304,310,440,290]
-    line "CrushOriginal" [500,442,444,428,473,439,402,439,447,408]
+    x-axis [9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be]
+    line "CheckMetricsAndSwap" [8,9,7,7,9,8,7,8,7,9]
+    line "CrushOptimized" [327,377,384,313,364,304,310,440,290,330]
+    line "CrushOriginal" [442,444,428,473,439,402,439,447,408,444]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,1,2,1,2,2,2]
-    line "LoadGlobalConfig" [749,766,793,755,747,777,711,711,823,708]
+    line "IndexSearch" [2,2,2,1,2,1,2,2,2,2]
+    line "LoadGlobalConfig" [766,793,755,747,777,711,711,823,708,795]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54]
+    x-axis [9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cacc02f,9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54]
+    x-axis [9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]


### PR DESCRIPTION
## Fix

The AI reviewer script was only labeling Jules PRs and only assigning `alsotoes` when the PR author was already `alsotoes`. All other PRs had no labels and no assignee.

### Changes

**`.github/scripts/ai_reviewer.py`:**
- Added `sync_pr_labels_and_assignee()` which runs **first** in `main()`, before any review work:
  1. Parses `Closes #NNN` / `Fixes #NNN` / `Resolves #NNN` from PR body
  2. Fetches labels from each linked issue via `gh issue view`
  3. Adds those labels to the PR
  4. Assigns `alsotoes` to **every** PR
  5. Adds `bug` or `enhancement` label based on PR title prefix
- Removed redundant assignment code that only ran for `alsotoes`-authored PRs

**`.github/workflows/gemini_reviewer.yml`:**
- Removed `paths:` filter so the workflow runs on **every** PR, ensuring labels and assignee are set immediately regardless of what files changed