### PR TITLE
fix: move blob deletion outside bbolt transaction in GC sweep (#435)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1604,3 +1604,10 @@ cbe2a54,BenchmarkPadString-8,1.93,0.00,0.00
 83d81be,BenchmarkIndexSearch-8,1.74,0.00,0.00
 83d81be,BenchmarkLoadGlobalConfig-8,794.70,160.00,1.00
 83d81be,BenchmarkPadString-8,2.39,0.00,0.00
+221ec34,BenchmarkCheckMetricsAndSwap-8,7.59,0.00,0.00
+221ec34,BenchmarkCrushOptimized-8,388.90,0.00,0.00
+221ec34,BenchmarkCrushOriginal-8,602.30,164.00,3.00
+221ec34,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+221ec34,BenchmarkIndexSearch-8,1.49,0.00,0.00
+221ec34,BenchmarkLoadGlobalConfig-8,886.00,160.00,1.00
+221ec34,BenchmarkPadString-8,2.06,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        407.6n ± ∞ ¹    443.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       290.4n ± ∞ ¹    330.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     707.8n ± ∞ ¹    794.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.926n ± ∞ ¹    2.392n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.389n ± ∞ ¹    9.000n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.584n ± ∞ ¹    1.741n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3827n ± ∞ ¹   0.3741n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                18.43n          20.71n        +12.36%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        443.6n ± ∞ ¹    602.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       330.5n ± ∞ ¹    388.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     794.7n ± ∞ ¹    886.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.392n ± ∞ ¹    2.060n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.000n ± ∞ ¹    7.595n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.741n ± ∞ ¹    1.485n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3741n ± ∞ ¹   0.3257n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.71n          20.59n        -0.56%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 330.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 443.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 794.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.59 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 388.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 602.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 886.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be]
-    line "CheckMetricsAndSwap" [8,9,7,7,9,8,7,8,7,9]
-    line "CrushOptimized" [327,377,384,313,364,304,310,440,290,330]
-    line "CrushOriginal" [442,444,428,473,439,402,439,447,408,444]
+    x-axis [52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34]
+    line "CheckMetricsAndSwap" [9,7,7,9,8,7,8,7,9,8]
+    line "CrushOptimized" [377,384,313,364,304,310,440,290,330,389]
+    line "CrushOriginal" [444,428,473,439,402,439,447,408,444,602]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,1,2,1,2,2,2,2]
-    line "LoadGlobalConfig" [766,793,755,747,777,711,711,823,708,795]
+    line "IndexSearch" [2,2,1,2,1,2,2,2,2,1]
+    line "LoadGlobalConfig" [793,755,747,777,711,711,823,708,795,886]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be]
+    x-axis [52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [9f4d9bb,52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be]
+    x-axis [52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -70,6 +70,8 @@ func (s *CASStore) runGC(cfg GCConfig) (err error) {
 }
 
 // sweepOrphanedBlobs removes blob files and objects entries with RefCount=0.
+// Blob deletions (which may involve network I/O for S3 backends) are performed
+// OUTSIDE the bbolt write transaction to avoid blocking all db operations.
 func (s *CASStore) sweepOrphanedBlobs() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -86,24 +88,28 @@ func (s *CASStore) sweepOrphanedBlobs() error {
 			meta := decodeObjectMeta(v)
 			if meta.RefCount <= 0 {
 				hash := string(k)
-				if err := s.blobs.DeleteBlob(hash); err != nil {
-					log.Printf("CAS GC: failed to remove blob %s: %v", hash, err)
-					continue
-				}
 				orphanedHashes = append(orphanedHashes, hash)
+				if err := obj.Delete([]byte(hash)); err != nil {
+					log.Printf("CAS GC: failed to delete metadata for blob %s: %v", hash, err)
+				}
 			}
-		}
-
-		for _, hash := range orphanedHashes {
-			obj.Delete([]byte(hash))
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	for _, hash := range orphanedHashes {
+		if err := s.blobs.DeleteBlob(hash); err != nil {
+			log.Printf("CAS GC: failed to remove blob %s: %v", hash, err)
+		}
+	}
 
 	if len(orphanedHashes) > 0 {
 		log.Printf("CAS GC: removed %d orphaned blob(s)", len(orphanedHashes))
 	}
-	return err
+	return nil
 }
 
 // sweepExpiredTombstones removes tombstones older than the retention period.


### PR DESCRIPTION
Resolves #435

## Problem

`sweepOrphanedBlobs` in `src/storage/gc.go` called `s.blobs.DeleteBlob` inside a `db.Update` transaction. For the S3 backend, each `DeleteBlob` is an HTTP request with a 30s timeout. With N orphaned blobs, the bbolt write transaction was held for up to 30×N seconds, blocking all database operations (reads and writes) for the entire duration.

## Fix

Restructured `sweepOrphanedBlobs` to perform blob deletions **outside** the bbolt write transaction:

1. **Inside `db.Update`**: Scan for orphaned blobs (RefCount ≤ 0), collect their hashes, and delete their bbolt metadata entries. This is fast — only local bbolt cursor operations.
2. **After transaction commit**: Call `s.blobs.DeleteBlob` for each collected hash. Network I/O (S3 HTTP requests) happens outside the transaction.

The `s.mu` lock is still held during blob deletion to prevent a concurrent `Put` from referencing a blob whose metadata was already deleted but whose physical data hasn't been removed yet.

## Changelog

- `src/storage/gc.go`: `sweepOrphanedBlobs` — blob deletion moved outside bbolt transaction; bbolt entry deletion now checks errors.