### PR TITLE
fix: clone cursor keys in GC tombstone sweep to prevent use-after-invalidation (#436)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1611,3 +1611,10 @@ cbe2a54,BenchmarkPadString-8,1.93,0.00,0.00
 221ec34,BenchmarkIndexSearch-8,1.49,0.00,0.00
 221ec34,BenchmarkLoadGlobalConfig-8,886.00,160.00,1.00
 221ec34,BenchmarkPadString-8,2.06,0.00,0.00
+e7ad95e,BenchmarkCheckMetricsAndSwap-8,8.09,0.00,0.00
+e7ad95e,BenchmarkCrushOptimized-8,328.20,0.00,0.00
+e7ad95e,BenchmarkCrushOriginal-8,429.20,164.00,3.00
+e7ad95e,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+e7ad95e,BenchmarkIndexSearch-8,1.60,0.00,0.00
+e7ad95e,BenchmarkLoadGlobalConfig-8,768.70,160.00,1.00
+e7ad95e,BenchmarkPadString-8,1.98,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        443.6n ± ∞ ¹    602.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       330.5n ± ∞ ¹    388.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     794.7n ± ∞ ¹    886.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.392n ± ∞ ¹    2.060n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.000n ± ∞ ¹    7.595n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.741n ± ∞ ¹    1.485n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3741n ± ∞ ¹   0.3257n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.71n          20.59n        -0.56%
+CrushOriginal-8                        602.3n ± ∞ ¹    429.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       388.9n ± ∞ ¹    328.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     886.0n ± ∞ ¹    768.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.060n ± ∞ ¹    1.978n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.595n ± ∞ ¹    8.090n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.485n ± ∞ ¹    1.601n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3257n ± ∞ ¹   0.3691n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.59n          19.37n        -5.93%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.59 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 388.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 602.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.49 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 886.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.09 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 328.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 429.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 768.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34]
-    line "CheckMetricsAndSwap" [9,7,7,9,8,7,8,7,9,8]
-    line "CrushOptimized" [377,384,313,364,304,310,440,290,330,389]
-    line "CrushOriginal" [444,428,473,439,402,439,447,408,444,602]
+    x-axis [215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e]
+    line "CheckMetricsAndSwap" [7,7,9,8,7,8,7,9,8,8]
+    line "CrushOptimized" [384,313,364,304,310,440,290,330,389,328]
+    line "CrushOriginal" [428,473,439,402,439,447,408,444,602,429]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,1,2,1,2,2,2,2,1]
-    line "LoadGlobalConfig" [793,755,747,777,711,711,823,708,795,886]
+    line "IndexSearch" [2,1,2,1,2,2,2,2,1,2]
+    line "LoadGlobalConfig" [755,747,777,711,711,823,708,795,886,769]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34]
+    x-axis [215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [52462e0,215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34]
+    x-axis [215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"log"
@@ -125,12 +126,12 @@ func (s *CASStore) sweepExpiredTombstones(retention time.Duration) error {
 		c := ts.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			if len(v) < 8 {
-				expiredNames = append(expiredNames, k)
+				expiredNames = append(expiredNames, bytes.Clone(k))
 				continue
 			}
 			deletedAt := int64(binary.BigEndian.Uint64(v[:8]))
 			if deletedAt < cutoff {
-				expiredNames = append(expiredNames, k)
+				expiredNames = append(expiredNames, bytes.Clone(k))
 			}
 		}
 


### PR DESCRIPTION
Resolves #436

## Problem

`sweepExpiredTombstones` in `src/storage/gc.go` stored cursor key slices (`k`) directly in `expiredNames` without copying. Per bbolt's API contract, cursor keys are only valid until the next cursor call. The later `ts.Delete(name)` loop used these potentially invalidated slices, which could delete wrong keys or garbage data.

## Fix

Use `bytes.Clone(k)` when appending cursor keys to `expiredNames`, ensuring each stored key is an independent copy that remains valid after subsequent cursor operations.

## Changelog

- `src/storage/gc.go`: Added `bytes` import; cursor keys cloned with `bytes.Clone(k)` in `sweepExpiredTombstones`.