### PR TITLE
fix: select on ctx.Done() when acquiring semaphore to allow graceful shutdown (#439)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1618,3 +1618,10 @@ e7ad95e,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
 e7ad95e,BenchmarkIndexSearch-8,1.60,0.00,0.00
 e7ad95e,BenchmarkLoadGlobalConfig-8,768.70,160.00,1.00
 e7ad95e,BenchmarkPadString-8,1.98,0.00,0.00
+7e31dfb,BenchmarkCheckMetricsAndSwap-8,6.94,0.00,0.00
+7e31dfb,BenchmarkCrushOptimized-8,293.80,0.00,0.00
+7e31dfb,BenchmarkCrushOriginal-8,376.70,164.00,3.00
+7e31dfb,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+7e31dfb,BenchmarkIndexSearch-8,1.50,0.00,0.00
+7e31dfb,BenchmarkLoadGlobalConfig-8,663.60,160.00,1.00
+7e31dfb,BenchmarkPadString-8,1.89,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        602.3n ± ∞ ¹    429.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       388.9n ± ∞ ¹    328.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     886.0n ± ∞ ¹    768.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.060n ± ∞ ¹    1.978n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.595n ± ∞ ¹    8.090n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.485n ± ∞ ¹    1.601n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3257n ± ∞ ¹   0.3691n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.59n          19.37n        -5.93%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        429.2n ± ∞ ¹    376.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       328.2n ± ∞ ¹    293.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     768.7n ± ∞ ¹    663.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.978n ± ∞ ¹    1.891n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.090n ± ∞ ¹    6.944n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.601n ± ∞ ¹    1.503n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3691n ± ∞ ¹   0.3208n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                19.37n          17.31n        -10.66%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.09 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 328.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 429.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 768.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 293.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 376.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 663.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e]
-    line "CheckMetricsAndSwap" [7,7,9,8,7,8,7,9,8,8]
-    line "CrushOptimized" [384,313,364,304,310,440,290,330,389,328]
-    line "CrushOriginal" [428,473,439,402,439,447,408,444,602,429]
+    x-axis [1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb]
+    line "CheckMetricsAndSwap" [7,9,8,7,8,7,9,8,8,7]
+    line "CrushOptimized" [313,364,304,310,440,290,330,389,328,294]
+    line "CrushOriginal" [473,439,402,439,447,408,444,602,429,377]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,1,2,1,2,2,2,2,1,2]
-    line "LoadGlobalConfig" [755,747,777,711,711,823,708,795,886,769]
+    line "IndexSearch" [1,2,1,2,2,2,2,1,2,2]
+    line "LoadGlobalConfig" [747,777,711,711,823,708,795,886,769,664]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e]
+    x-axis [1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [215f189,1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e]
+    x-axis [1353d73,4246b52,66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -119,7 +119,11 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 		}
 
 		// Acquire semaphore slot before spinning up a new goroutine
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return nil
+		}
 		go func(comm transport.Communicator) {
 			defer func() { <-sem }()
 			// 🛡️ Zero-Crash Hardening: Recover from any unexpected panics in the connection handler
@@ -355,21 +359,21 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 			// Handle the file based on the replication mode
 			switch replicationMode {
 			case common.ReplicationNone, common.ReplicationPrimarySplay:
-			if exists {
-				// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
-				if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
-					log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
-					metricsCollector.IncErrors()
-					return
+				if exists {
+					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
+					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
+						metricsCollector.IncErrors()
+						return
+					}
+				} else {
+					if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
+						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
+						metricsCollector.IncErrors()
+						return
+					}
 				}
-			} else {
-				if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
-					log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
-					metricsCollector.IncErrors()
-					return
-				}
-			}
-		case common.ReplicationChain:
+			case common.ReplicationChain:
 				// In Chain mode, we find our position in the placement list and forward to the next node.
 				myPos := -1
 				for i, n := range placement {
@@ -455,13 +459,13 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 						targetId := placement[i].ID
 						go func(id int) {
 							// ⚡ Bolt: connectToPeerStream (client.ConnectStream) handles wg.Done() internally via defer.
-						defer func() {
-							if r := recover(); r != nil {
-								log.Printf("CRITICAL: Panic recovered in Splay forwarder to node %d: %v", id, r)
-								wg.Done()
-								metricsCollector.IncErrors()
-							}
-						}()
+							defer func() {
+								if r := recover(); r != nil {
+									log.Printf("CRITICAL: Panic recovered in Splay forwarder to node %d: %v", id, r)
+									wg.Done()
+									metricsCollector.IncErrors()
+								}
+							}()
 							reader, _, err := store.Get(fileName)
 							if err != nil {
 								log.Printf("AUDIT: Failed to get blob for splay forwarding: %v", common.SanitizeLog(err.Error()))
@@ -476,14 +480,14 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 					}
 					wg.Wait()
 				} else {
-				// We are a secondary in a splay, just receive the file if needed.
-				if exists {
-					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
-						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
-						metricsCollector.IncErrors()
-						return
-					}
-				} else {
+					// We are a secondary in a splay, just receive the file if needed.
+					if exists {
+						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
+							metricsCollector.IncErrors()
+							return
+						}
+					} else {
 						if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
 							log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 							metricsCollector.IncErrors()


### PR DESCRIPTION
Resolves #439

## Problem

`src/server/server.go:122` — `sem <- struct{}{}` was a blocking send with no `ctx.Done()` select. If all 1000 semaphore slots were occupied by slow clients, the accept loop could not check for shutdown. The server would hang until all goroutines drained, preventing graceful shutdown.

## Fix

Replaced the blocking send with a `select` on `ctx.Done()`:

```go
select {
case sem <- struct{}{}:
case <-ctx.Done():
    return nil
}
```

This allows the accept loop to exit immediately when the context is cancelled, even if all semaphore slots are full.

## Changelog

- `src/server/server.go`: Semaphore acquisition now uses `select` with `ctx.Done()` for graceful shutdown.