### PR TITLE
fix: check SendACK error in server handshake (#456)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1639,3 +1639,10 @@ b14b291,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
 b14b291,BenchmarkIndexSearch-8,2.88,0.00,0.00
 b14b291,BenchmarkLoadGlobalConfig-8,718.80,160.00,1.00
 b14b291,BenchmarkPadString-8,2.07,0.00,0.00
+90bdb21,BenchmarkCheckMetricsAndSwap-8,7.39,0.00,0.00
+90bdb21,BenchmarkCrushOptimized-8,321.80,0.00,0.00
+90bdb21,BenchmarkCrushOriginal-8,403.30,164.00,3.00
+90bdb21,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+90bdb21,BenchmarkIndexSearch-8,2.84,0.00,0.00
+90bdb21,BenchmarkLoadGlobalConfig-8,756.90,160.00,1.00
+90bdb21,BenchmarkPadString-8,1.91,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        389.4n ± ∞ ¹    381.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       289.6n ± ∞ ¹    298.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     727.4n ± ∞ ¹    718.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.041n ± ∞ ¹    2.066n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.965n ± ∞ ¹    7.012n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.726n ± ∞ ¹    2.875n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3433n ± ∞ ¹   0.3578n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.55n          19.86n        +1.59%
+CrushOriginal-8                        381.0n ± ∞ ¹    403.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       298.6n ± ∞ ¹    321.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     718.8n ± ∞ ¹    756.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.066n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.012n ± ∞ ¹    7.391n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.875n ± ∞ ¹    2.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3578n ± ∞ ¹   0.3294n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.86n          20.04n        +0.93%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.01 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 298.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 381.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.88 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 718.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.07 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 321.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 403.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 756.90 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291]
-    line "CheckMetricsAndSwap" [8,7,8,7,9,8,8,7,7,7]
-    line "CrushOptimized" [304,310,440,290,330,389,328,294,290,299]
-    line "CrushOriginal" [402,439,447,408,444,602,429,377,389,381]
+    x-axis [5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21]
+    line "CheckMetricsAndSwap" [7,8,7,9,8,8,7,7,7,7]
+    line "CrushOptimized" [310,440,290,330,389,328,294,290,299,322]
+    line "CrushOriginal" [439,447,408,444,602,429,377,389,381,403]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [1,2,2,2,2,1,2,2,3,3]
-    line "LoadGlobalConfig" [711,711,823,708,795,886,769,664,727,719]
+    line "IndexSearch" [2,2,2,2,1,2,2,3,3,3]
+    line "LoadGlobalConfig" [711,823,708,795,886,769,664,727,719,757]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291]
+    x-axis [5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [66ac855,5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291]
+    x-axis [5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -180,7 +180,9 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 			defer func() {
 				if success {
 					log.Printf("AUDIT: Server ACK to Client %s => ACK%d", remoteAddr, serverId)
-					comm.SendACK(serverId)
+					if err := comm.SendACK(serverId); err != nil {
+						log.Printf("ERROR: Failed to send ACK to client %s: %v", remoteAddr, err)
+					}
 				}
 				comm.Close()
 			}()


### PR DESCRIPTION
Resolves #456

## Problem

`src/server/server.go:183` — `comm.SendACK(serverId)` return value was ignored. If the ACK fails to send, the client hangs waiting for a response with no server-side visibility into the failure.

## Fix

Check the error returned by `comm.SendACK()` and log it if non-nil:

```go
if err := comm.SendACK(serverId); err != nil {
    log.Printf("ERROR: Failed to send ACK to client %s: %v", remoteAddr, err)
}
```

This is in a `defer` block during connection teardown, so we can only log — the connection is already closing. But logging gives operators visibility into ACK delivery failures that were previously silent.

## Changelog

- `src/server/server.go`: Check `SendACK` error and log on failure