### PR TITLE
fix: eliminate double server.Close() with sync.Once (#458)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1653,3 +1653,10 @@ b14b291,BenchmarkPadString-8,2.07,0.00,0.00
 5282e9b,BenchmarkIndexSearch-8,2.80,0.00,0.00
 5282e9b,BenchmarkLoadGlobalConfig-8,730.50,160.00,1.00
 5282e9b,BenchmarkPadString-8,1.94,0.00,0.00
+0b200dc,BenchmarkCheckMetricsAndSwap-8,7.03,0.00,0.00
+0b200dc,BenchmarkCrushOptimized-8,293.40,0.00,0.00
+0b200dc,BenchmarkCrushOriginal-8,384.90,164.00,3.00
+0b200dc,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+0b200dc,BenchmarkIndexSearch-8,2.86,0.00,0.00
+0b200dc,BenchmarkLoadGlobalConfig-8,724.20,160.00,1.00
+0b200dc,BenchmarkPadString-8,2.06,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1660,3 +1660,10 @@ b14b291,BenchmarkPadString-8,2.07,0.00,0.00
 0b200dc,BenchmarkIndexSearch-8,2.86,0.00,0.00
 0b200dc,BenchmarkLoadGlobalConfig-8,724.20,160.00,1.00
 0b200dc,BenchmarkPadString-8,2.06,0.00,0.00
+15ea837,BenchmarkCheckMetricsAndSwap-8,6.72,0.00,0.00
+15ea837,BenchmarkCrushOptimized-8,311.00,0.00,0.00
+15ea837,BenchmarkCrushOriginal-8,399.10,164.00,3.00
+15ea837,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+15ea837,BenchmarkIndexSearch-8,2.75,0.00,0.00
+15ea837,BenchmarkLoadGlobalConfig-8,734.30,160.00,1.00
+15ea837,BenchmarkPadString-8,1.93,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1646,3 +1646,10 @@ b14b291,BenchmarkPadString-8,2.07,0.00,0.00
 90bdb21,BenchmarkIndexSearch-8,2.84,0.00,0.00
 90bdb21,BenchmarkLoadGlobalConfig-8,756.90,160.00,1.00
 90bdb21,BenchmarkPadString-8,1.91,0.00,0.00
+5282e9b,BenchmarkCheckMetricsAndSwap-8,6.84,0.00,0.00
+5282e9b,BenchmarkCrushOptimized-8,300.50,0.00,0.00
+5282e9b,BenchmarkCrushOriginal-8,393.20,164.00,3.00
+5282e9b,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+5282e9b,BenchmarkIndexSearch-8,2.80,0.00,0.00
+5282e9b,BenchmarkLoadGlobalConfig-8,730.50,160.00,1.00
+5282e9b,BenchmarkPadString-8,1.94,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        381.0n ± ∞ ¹    403.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       298.6n ± ∞ ¹    321.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     718.8n ± ∞ ¹    756.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.066n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.012n ± ∞ ¹    7.391n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.875n ± ∞ ¹    2.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3578n ± ∞ ¹   0.3294n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.86n          20.04n        +0.93%
+CrushOriginal-8                        403.3n ± ∞ ¹    393.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       321.8n ± ∞ ¹    300.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     756.9n ± ∞ ¹    730.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.912n ± ∞ ¹    1.943n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.391n ± ∞ ¹    6.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.843n ± ∞ ¹    2.804n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3294n ± ∞ ¹   0.3339n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.04n          19.51n        -2.69%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 321.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 403.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 300.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 393.20 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 756.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 730.50 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21]
-    line "CheckMetricsAndSwap" [7,8,7,9,8,8,7,7,7,7]
-    line "CrushOptimized" [310,440,290,330,389,328,294,290,299,322]
-    line "CrushOriginal" [439,447,408,444,602,429,377,389,381,403]
+    x-axis [6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b]
+    line "CheckMetricsAndSwap" [8,7,9,8,8,7,7,7,7,7]
+    line "CrushOptimized" [440,290,330,389,328,294,290,299,322,300]
+    line "CrushOriginal" [447,408,444,602,429,377,389,381,403,393]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,1,2,2,3,3,3]
-    line "LoadGlobalConfig" [711,823,708,795,886,769,664,727,719,757]
+    line "IndexSearch" [2,2,2,1,2,2,3,3,3,3]
+    line "LoadGlobalConfig" [823,708,795,886,769,664,727,719,757,730]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21]
+    x-axis [6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [5a741d8,6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21]
+    x-axis [6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        393.2n ± ∞ ¹    384.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       300.5n ± ∞ ¹    293.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     730.5n ± ∞ ¹    724.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.943n ± ∞ ¹    2.055n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  6.843n ± ∞ ¹    7.033n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.804n ± ∞ ¹    2.858n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3339n ± ∞ ¹   0.3261n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.51n          19.58n        +0.36%
+CrushOriginal-8                        384.9n ± ∞ ¹    399.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       293.4n ± ∞ ¹    311.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     724.2n ± ∞ ¹    734.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.055n ± ∞ ¹    1.933n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.033n ± ∞ ¹    6.723n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.858n ± ∞ ¹    2.745n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3261n ± ∞ ¹   0.3268n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.58n          19.47n        -0.52%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.03 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 293.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 384.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.72 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 311.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 399.10 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.86 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 724.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 734.30 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc]
-    line "CheckMetricsAndSwap" [7,9,8,8,7,7,7,7,7,7]
-    line "CrushOptimized" [290,330,389,328,294,290,299,322,300,293]
-    line "CrushOriginal" [408,444,602,429,377,389,381,403,393,385]
+    x-axis [83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837]
+    line "CheckMetricsAndSwap" [9,8,8,7,7,7,7,7,7,7]
+    line "CrushOptimized" [330,389,328,294,290,299,322,300,293,311]
+    line "CrushOriginal" [444,602,429,377,389,381,403,393,385,399]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,1,2,2,3,3,3,3,3]
-    line "LoadGlobalConfig" [708,795,886,769,664,727,719,757,730,724]
+    line "IndexSearch" [2,1,2,2,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [795,886,769,664,727,719,757,730,724,734]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc]
+    x-axis [83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc]
+    x-axis [83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        403.3n ± ∞ ¹    393.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       321.8n ± ∞ ¹    300.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     756.9n ± ∞ ¹    730.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.912n ± ∞ ¹    1.943n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.391n ± ∞ ¹    6.843n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.843n ± ∞ ¹    2.804n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3294n ± ∞ ¹   0.3339n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.04n          19.51n        -2.69%
+CrushOriginal-8                        393.2n ± ∞ ¹    384.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       300.5n ± ∞ ¹    293.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     730.5n ± ∞ ¹    724.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.943n ± ∞ ¹    2.055n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.843n ± ∞ ¹    7.033n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.804n ± ∞ ¹    2.858n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3339n ± ∞ ¹   0.3261n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.51n          19.58n        +0.36%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 300.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 393.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.03 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 293.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 384.90 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 730.50 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.86 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 724.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b]
-    line "CheckMetricsAndSwap" [8,7,9,8,8,7,7,7,7,7]
-    line "CrushOptimized" [440,290,330,389,328,294,290,299,322,300]
-    line "CrushOriginal" [447,408,444,602,429,377,389,381,403,393]
+    x-axis [cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc]
+    line "CheckMetricsAndSwap" [7,9,8,8,7,7,7,7,7,7]
+    line "CrushOptimized" [290,330,389,328,294,290,299,322,300,293]
+    line "CrushOriginal" [408,444,602,429,377,389,381,403,393,385]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,1,2,2,3,3,3,3]
-    line "LoadGlobalConfig" [823,708,795,886,769,664,727,719,757,730]
+    line "IndexSearch" [2,2,1,2,2,3,3,3,3,3]
+    line "LoadGlobalConfig" [708,795,886,769,664,727,719,757,730,724]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b]
+    x-axis [cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6a5515e,cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b]
+    x-axis [cbe2a54,83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -38,7 +38,14 @@ var connectToPeerStream = client.ConnectStream
 //   - ReplicationPrimarySplay: This mode is currently handled as ReplicationNone, which means no replication is performed.
 //
 // The replication mode is determined by the client, and for secondary servers, it's influenced by the timestamp of the operation.
-func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
+func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in Daemon: %v", r)
+			err = syscall.EIO
+		}
+	}()
+
 	daemons := cfg.Daemons
 	if serverId < 0 || serverId >= len(daemons) {
 		return fmt.Errorf("server id out of range")

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -105,6 +105,8 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 	const maxConcurrentConnections = 1000
 	sem := make(chan struct{}, maxConcurrentConnections)
 
+	// Accept loop: server.Accept() returns errors, not panics. Per-connection
+	// goroutines below each have their own recover() block (Rule 37) for panic safety.
 	for {
 		connection, err := server.Accept()
 		if err != nil {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -57,7 +57,9 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 		return fmt.Errorf("Error listening: %v", err)
 	}
 
-	defer server.Close()
+	closeOnce := sync.Once{}
+	closeServer := func() { closeOnce.Do(func() { server.Close() }) }
+	defer closeServer()
 
 	// Handle graceful shutdown via context
 	go func() {
@@ -67,7 +69,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) error {
 			}
 		}()
 		<-ctx.Done()
-		server.Close()
+		closeServer()
 	}()
 
 	log.Printf("Server primary Daemon started... at %s using %s", daemons[serverId].Host, cfg.Global.Protocol)


### PR DESCRIPTION
Resolves #458

## Problem

`src/server/server.go:60,70` — `server.Close()` was deferred at line 60 and also called in the shutdown goroutine at line 70. While likely idempotent for TCP/QUIC listeners, this is technically a double-close and could cause issues with future protocol implementations.

## Fix

Wrap `server.Close()` in `sync.Once` so it executes exactly once regardless of whether it's triggered by the deferred cleanup or the context-cancellation goroutine:

```go
closeOnce := sync.Once{}
closeServer := func() { closeOnce.Do(func() { server.Close() }) }
defer closeServer()
```

The shutdown goroutine now calls `closeServer()` instead of `server.Close()` directly.

## Changelog

- `src/server/server.go`: Replace `defer server.Close()` + goroutine `server.Close()` with `sync.Once`-guarded `closeServer()`