### PR TITLE
fix: remove SanitizeLog from hash data in getMetadata (#459)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1667,3 +1667,10 @@ b14b291,BenchmarkPadString-8,2.07,0.00,0.00
 15ea837,BenchmarkIndexSearch-8,2.75,0.00,0.00
 15ea837,BenchmarkLoadGlobalConfig-8,734.30,160.00,1.00
 15ea837,BenchmarkPadString-8,1.93,0.00,0.00
+573b881,BenchmarkCheckMetricsAndSwap-8,7.52,0.00,0.00
+573b881,BenchmarkCrushOptimized-8,291.50,0.00,0.00
+573b881,BenchmarkCrushOriginal-8,388.50,164.00,3.00
+573b881,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+573b881,BenchmarkIndexSearch-8,2.76,0.00,0.00
+573b881,BenchmarkLoadGlobalConfig-8,730.70,160.00,1.00
+573b881,BenchmarkPadString-8,1.91,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        384.9n ± ∞ ¹    399.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       293.4n ± ∞ ¹    311.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     724.2n ± ∞ ¹    734.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.055n ± ∞ ¹    1.933n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.033n ± ∞ ¹    6.723n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.858n ± ∞ ¹    2.745n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3261n ± ∞ ¹   0.3268n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.58n          19.47n        -0.52%
+CrushOriginal-8                        399.1n ± ∞ ¹    388.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       311.0n ± ∞ ¹    291.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     734.3n ± ∞ ¹    730.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.933n ± ∞ ¹    1.909n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  6.723n ± ∞ ¹    7.521n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.745n ± ∞ ¹    2.762n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3268n ± ∞ ¹   0.3355n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.47n          19.57n        +0.51%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 6.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 311.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 399.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 734.30 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 291.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 388.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.76 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 730.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837]
-    line "CheckMetricsAndSwap" [9,8,8,7,7,7,7,7,7,7]
-    line "CrushOptimized" [330,389,328,294,290,299,322,300,293,311]
-    line "CrushOriginal" [444,602,429,377,389,381,403,393,385,399]
+    x-axis [221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881]
+    line "CheckMetricsAndSwap" [8,8,7,7,7,7,7,7,7,8]
+    line "CrushOptimized" [389,328,294,290,299,322,300,293,311,292]
+    line "CrushOriginal" [602,429,377,389,381,403,393,385,399,388]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,1,2,2,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [795,886,769,664,727,719,757,730,724,734]
+    line "IndexSearch" [1,2,2,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [886,769,664,727,719,757,730,724,734,731]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837]
+    x-axis [221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [83d81be,221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837]
+    x-axis [221ec34,e7ad95e,7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/file.go
+++ b/src/server/file.go
@@ -52,11 +52,11 @@ func getMetadata(r io.Reader) (metadata common.FileMetadata, err error) {
 		return string(b)
 	}
 
-	fileHash := common.SanitizeLog(trimNull(bufferFileHash))
+	fileHash := trimNull(bufferFileHash)
 
 	// 🛡️ Sentinel: Sanitize Hash immediately to prevent path traversal in all downstream consumers.
 	if fileHash == "" || common.HasPathTraversalChars(fileHash) {
-		return metadata, fmt.Errorf("invalid hash received: %s: %w", fileHash, syscall.EBADMSG)
+		return metadata, fmt.Errorf("invalid hash received: %s: %w", common.SanitizeLog(fileHash), syscall.EBADMSG)
 	}
 
 	// 🛡️ Sentinel: Sanitize and normalize fileName to prevent path traversal attacks (Rule 4).


### PR DESCRIPTION
Resolves #459

## Problem

`src/server/file.go:55` — `SanitizeLog` replaces `\n`/`\r` with `_`. Applied to the hash value, this corrupts the hash if it contains those bytes. The hash is raw data used for storage lookups, not a log message.

## Fix

Removed `SanitizeLog` from the hash extraction line. The raw hash is now used directly:

```go
fileHash := trimNull(bufferFileHash)
```

`SanitizeLog` is still applied at the only point where the hash appears in a log/error message (line 59):

```go
fmt.Errorf("invalid hash received: %s: %w", common.SanitizeLog(fileHash), syscall.EBADMSG)
```

This preserves log injection protection without corrupting the hash data itself.

## Changelog

- `src/server/file.go`: Remove `SanitizeLog` from hash extraction; apply it only in error message