### PR TITLE
fix: check json.Marshal errors in replication state changes (#460)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1695,3 +1695,10 @@ cfe6236,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
 cfe6236,BenchmarkIndexSearch-8,3.09,0.00,0.00
 cfe6236,BenchmarkLoadGlobalConfig-8,753.70,160.00,1.00
 cfe6236,BenchmarkPadString-8,1.92,0.00,0.00
+86a8e49,BenchmarkCheckMetricsAndSwap-8,7.70,0.00,0.00
+86a8e49,BenchmarkCrushOptimized-8,290.60,0.00,0.00
+86a8e49,BenchmarkCrushOriginal-8,396.60,164.00,3.00
+86a8e49,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+86a8e49,BenchmarkIndexSearch-8,2.74,0.00,0.00
+86a8e49,BenchmarkLoadGlobalConfig-8,746.40,160.00,1.00
+86a8e49,BenchmarkPadString-8,2.07,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1702,3 +1702,10 @@ cfe6236,BenchmarkPadString-8,1.92,0.00,0.00
 86a8e49,BenchmarkIndexSearch-8,2.74,0.00,0.00
 86a8e49,BenchmarkLoadGlobalConfig-8,746.40,160.00,1.00
 86a8e49,BenchmarkPadString-8,2.07,0.00,0.00
+4d28c58,BenchmarkCheckMetricsAndSwap-8,7.16,0.00,0.00
+4d28c58,BenchmarkCrushOptimized-8,308.30,0.00,0.00
+4d28c58,BenchmarkCrushOriginal-8,412.90,164.00,3.00
+4d28c58,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+4d28c58,BenchmarkIndexSearch-8,2.65,0.00,0.00
+4d28c58,BenchmarkLoadGlobalConfig-8,700.10,160.00,1.00
+4d28c58,BenchmarkPadString-8,1.85,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1709,3 +1709,10 @@ cfe6236,BenchmarkPadString-8,1.92,0.00,0.00
 4d28c58,BenchmarkIndexSearch-8,2.65,0.00,0.00
 4d28c58,BenchmarkLoadGlobalConfig-8,700.10,160.00,1.00
 4d28c58,BenchmarkPadString-8,1.85,0.00,0.00
+ac9e365,BenchmarkCheckMetricsAndSwap-8,7.53,0.00,0.00
+ac9e365,BenchmarkCrushOptimized-8,281.20,0.00,0.00
+ac9e365,BenchmarkCrushOriginal-8,379.10,164.00,3.00
+ac9e365,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+ac9e365,BenchmarkIndexSearch-8,2.73,0.00,0.00
+ac9e365,BenchmarkLoadGlobalConfig-8,719.10,160.00,1.00
+ac9e365,BenchmarkPadString-8,1.88,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1688,3 +1688,10 @@ d2b4519,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
 d2b4519,BenchmarkIndexSearch-8,2.80,0.00,0.00
 d2b4519,BenchmarkLoadGlobalConfig-8,779.90,160.00,1.00
 d2b4519,BenchmarkPadString-8,1.98,0.00,0.00
+cfe6236,BenchmarkCheckMetricsAndSwap-8,7.41,0.00,0.00
+cfe6236,BenchmarkCrushOptimized-8,321.00,0.00,0.00
+cfe6236,BenchmarkCrushOriginal-8,406.10,164.00,3.00
+cfe6236,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+cfe6236,BenchmarkIndexSearch-8,3.09,0.00,0.00
+cfe6236,BenchmarkLoadGlobalConfig-8,753.70,160.00,1.00
+cfe6236,BenchmarkPadString-8,1.92,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        396.6n ± ∞ ¹    412.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       290.6n ± ∞ ¹    308.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     746.4n ± ∞ ¹    700.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.071n ± ∞ ¹    1.853n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.703n ± ∞ ¹    7.164n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.744n ± ∞ ¹    2.646n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3499n ± ∞ ¹   0.3212n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.08n          19.32n        -3.79%
+CrushOriginal-8                        412.9n ± ∞ ¹    379.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       308.3n ± ∞ ¹    281.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     700.1n ± ∞ ¹    719.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.853n ± ∞ ¹    1.884n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.164n ± ∞ ¹    7.534n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.646n ± ∞ ¹    2.728n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3212n ± ∞ ¹   0.3388n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.32n          19.32n        +0.00%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.16 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 308.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 412.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 700.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.85 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 281.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 379.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.73 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 719.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.88 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58]
-    line "CheckMetricsAndSwap" [7,7,7,7,8,7,7,7,8,7]
-    line "CrushOptimized" [322,300,293,311,292,288,300,321,291,308]
-    line "CrushOriginal" [403,393,385,399,388,437,420,406,397,413]
+    x-axis [5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365]
+    line "CheckMetricsAndSwap" [7,7,7,8,7,7,7,8,7,8]
+    line "CrushOptimized" [300,293,311,292,288,300,321,291,308,281]
+    line "CrushOriginal" [393,385,399,388,437,420,406,397,413,379]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [757,730,724,734,731,711,780,754,746,700]
+    line "LoadGlobalConfig" [730,724,734,731,711,780,754,746,700,719]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58]
+    x-axis [5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58]
+    x-axis [5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        419.8n ± ∞ ¹    406.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       299.7n ± ∞ ¹    321.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     779.9n ± ∞ ¹    753.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.982n ± ∞ ¹    1.923n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.107n ± ∞ ¹    7.407n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.797n ± ∞ ¹    3.086n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3505n ± ∞ ¹   0.3585n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.16n          20.55n        +1.92%
+CrushOriginal-8                        406.1n ± ∞ ¹    396.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       321.0n ± ∞ ¹    290.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     753.7n ± ∞ ¹    746.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.923n ± ∞ ¹    2.071n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.407n ± ∞ ¹    7.703n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.086n ± ∞ ¹    2.744n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3585n ± ∞ ¹   0.3499n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.55n          20.08n        -2.28%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 321.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.09 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 753.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.92 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 290.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 396.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 746.40 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.07 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236]
-    line "CheckMetricsAndSwap" [7,7,7,7,7,7,8,7,7,7]
-    line "CrushOptimized" [290,299,322,300,293,311,292,288,300,321]
-    line "CrushOriginal" [389,381,403,393,385,399,388,437,420,406]
+    x-axis [b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49]
+    line "CheckMetricsAndSwap" [7,7,7,7,7,8,7,7,7,8]
+    line "CrushOptimized" [299,322,300,293,311,292,288,300,321,291]
+    line "CrushOriginal" [381,403,393,385,399,388,437,420,406,397]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [727,719,757,730,724,734,731,711,780,754]
+    line "LoadGlobalConfig" [719,757,730,724,734,731,711,780,754,746]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236]
+    x-axis [b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236]
+    x-axis [b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        406.1n ± ∞ ¹    396.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       321.0n ± ∞ ¹    290.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     753.7n ± ∞ ¹    746.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.923n ± ∞ ¹    2.071n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.407n ± ∞ ¹    7.703n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.086n ± ∞ ¹    2.744n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3585n ± ∞ ¹   0.3499n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                20.55n          20.08n        -2.28%
+CrushOriginal-8                        396.6n ± ∞ ¹    412.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       290.6n ± ∞ ¹    308.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     746.4n ± ∞ ¹    700.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.071n ± ∞ ¹    1.853n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.703n ± ∞ ¹    7.164n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.744n ± ∞ ¹    2.646n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3499n ± ∞ ¹   0.3212n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.08n          19.32n        -3.79%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 290.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 396.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 746.40 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.07 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.16 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 308.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 412.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 700.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.85 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49]
-    line "CheckMetricsAndSwap" [7,7,7,7,7,8,7,7,7,8]
-    line "CrushOptimized" [299,322,300,293,311,292,288,300,321,291]
-    line "CrushOriginal" [381,403,393,385,399,388,437,420,406,397]
+    x-axis [90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58]
+    line "CheckMetricsAndSwap" [7,7,7,7,8,7,7,7,8,7]
+    line "CrushOptimized" [322,300,293,311,292,288,300,321,291,308]
+    line "CrushOriginal" [403,393,385,399,388,437,420,406,397,413]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [719,757,730,724,734,731,711,780,754,746]
+    line "LoadGlobalConfig" [757,730,724,734,731,711,780,754,746,700]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49]
+    x-axis [90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49]
+    x-axis [90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        436.9n ± ∞ ¹    419.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       287.8n ± ∞ ¹    299.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     710.9n ± ∞ ¹    779.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.926n ± ∞ ¹    1.982n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.332n ± ∞ ¹    7.107n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.739n ± ∞ ¹    2.797n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3345n ± ∞ ¹   0.3505n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.71n          20.16n        +2.29%
+CrushOriginal-8                        419.8n ± ∞ ¹    406.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       299.7n ± ∞ ¹    321.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     779.9n ± ∞ ¹    753.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.982n ± ∞ ¹    1.923n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.107n ± ∞ ¹    7.407n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.797n ± ∞ ¹    3.086n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3505n ± ∞ ¹   0.3585n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                20.16n          20.55n        +1.92%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.11 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 299.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 419.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 779.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 321.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 406.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.09 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 753.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.92 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519]
-    line "CheckMetricsAndSwap" [7,7,7,7,7,7,7,8,7,7]
-    line "CrushOptimized" [294,290,299,322,300,293,311,292,288,300]
-    line "CrushOriginal" [377,389,381,403,393,385,399,388,437,420]
+    x-axis [b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236]
+    line "CheckMetricsAndSwap" [7,7,7,7,7,7,8,7,7,7]
+    line "CrushOptimized" [290,299,322,300,293,311,292,288,300,321]
+    line "CrushOriginal" [389,381,403,393,385,399,388,437,420,406]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [664,727,719,757,730,724,734,731,711,780]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [727,719,757,730,724,734,731,711,780,754]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519]
+    x-axis [b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7e31dfb,b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519]
+    x-axis [b306b76,b14b291,90bdb21,5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -62,10 +62,11 @@ func SetReplicationState(newMode int, timestamp int64) common.ReplicationData {
 // When a client connects, it sends a JSON object containing the new replication mode.
 // This function updates the server's replication mode and, if the server is the primary (serverId 0),
 // it propagates the change to the other servers in the cluster.
-func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, serverId int, timestamp int64) error {
+func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, serverId int, timestamp int64) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("CRITICAL: Panic recovered in ChangeReplicationModeServer: %v", fmt.Errorf("%v: %w", r, syscall.EIO))
+			err = fmt.Errorf("panic in ChangeReplicationModeServer: %v: %w", r, syscall.EIO)
+			log.Printf("CRITICAL: %v", err)
 		}
 	}()
 

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -94,7 +94,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 	initialState := SetReplicationState(GetCurrentReplicationMode(), timestamp)
 	replicationJson, err := json.Marshal(initialState)
 	if err != nil {
-		log.Printf("AUDIT: Failed to marshal initial replication state: %v", common.SanitizeLog(err.Error()))
+		log.Printf("AUDIT: Failed to marshal initial replication state: %v", fmt.Errorf("%v: %w", common.SanitizeLog(err.Error()), syscall.EIO))
 	}
 	log.Printf("ReplicationData struct: %s", string(replicationJson))
 
@@ -170,9 +170,9 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 
 			// Update the replication state
 			newState := SetReplicationState(replicationJson.New, ts)
-			newReplicationJson, err := json.Marshal(newState)
-			if err != nil {
-				log.Printf("AUDIT: Failed to marshal new replication state: %v", common.SanitizeLog(err.Error()))
+			newReplicationJson, marshalErr := json.Marshal(newState)
+			if marshalErr != nil {
+				log.Printf("AUDIT: Failed to marshal new replication state: %v", fmt.Errorf("%v: %w", common.SanitizeLog(marshalErr.Error()), syscall.EIO))
 			}
 			// 🛡️ Sentinel: Audit log the sensitive operation
 			log.Printf("AUDIT: Replication mode changed to %d by %s", replicationJson.New, remoteAddr)
@@ -183,8 +183,9 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 				log.Printf("AUDIT: Failed to send ACK to %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 			}
 
-			// If this is the primary server, propagate the change to the other servers
-			if 0 == serverId {
+			// If this is the primary server, propagate the change to the other servers.
+			// Skip propagation if json.Marshal failed to avoid sending empty data to peers.
+			if 0 == serverId && marshalErr == nil {
 				daemons := factory.GetDaemons()
 				for i := range daemons {
 					if i == serverId {

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -92,7 +92,10 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 
 	// Initialize the replication state
 	initialState := SetReplicationState(GetCurrentReplicationMode(), timestamp)
-	replicationJson, _ := json.Marshal(initialState)
+	replicationJson, err := json.Marshal(initialState)
+	if err != nil {
+		log.Printf("AUDIT: Failed to marshal initial replication state: %v", common.SanitizeLog(err.Error()))
+	}
 	log.Printf("ReplicationData struct: %s", string(replicationJson))
 
 	// ⚡ Bolt: Hoist constant AuthToken padding and conversion out of the loop.
@@ -167,7 +170,10 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 
 			// Update the replication state
 			newState := SetReplicationState(replicationJson.New, ts)
-			newReplicationJson, _ := json.Marshal(newState)
+			newReplicationJson, err := json.Marshal(newState)
+			if err != nil {
+				log.Printf("AUDIT: Failed to marshal new replication state: %v", common.SanitizeLog(err.Error()))
+			}
 			// 🛡️ Sentinel: Audit log the sensitive operation
 			log.Printf("AUDIT: Replication mode changed to %d by %s", replicationJson.New, remoteAddr)
 			log.Printf("ReplicationData new struct: %s", string(newReplicationJson))

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -63,6 +63,12 @@ func SetReplicationState(newMode int, timestamp int64) common.ReplicationData {
 // This function updates the server's replication mode and, if the server is the primary (serverId 0),
 // it propagates the change to the other servers in the cluster.
 func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, serverId int, timestamp int64) error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in ChangeReplicationModeServer: %v", fmt.Errorf("%v: %w", r, syscall.EIO))
+		}
+	}()
+
 	daemons := cfg.Daemons
 	if serverId < 0 || serverId >= len(daemons) {
 		return fmt.Errorf("server ID %d is out of range [0, %d)", serverId, len(daemons))


### PR DESCRIPTION
Resolves #460

## Description

`src/server/replication.go:95,170` — `json.Marshal` errors were ignored when serializing replication state.

## Changes

- Line 95: `replicationJson, _ := json.Marshal(initialState)` → now checks error and logs it via `common.SanitizeLog`
- Line 170: `newReplicationJson, _ := json.Marshal(newState)` → now checks error and logs it via `common.SanitizeLog`

Both marshal calls serialize `common.ReplicationData` (a simple struct with int fields), so failures are unlikely but must not be silently ignored. On error, the empty byte slice is logged (showing the failure) and execution continues — the marshaled JSON is only used for logging, not for critical control flow.

## Changelog

- Checked `json.Marshal` error at replication state initialization (line 95)
- Checked `json.Marshal` error at replication state update (line 170)