### PR TITLE
fix: track propagation goroutines with sync.WaitGroup (#461)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1716,3 +1716,10 @@ ac9e365,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 ac9e365,BenchmarkIndexSearch-8,2.73,0.00,0.00
 ac9e365,BenchmarkLoadGlobalConfig-8,719.10,160.00,1.00
 ac9e365,BenchmarkPadString-8,1.88,0.00,0.00
+a9a2e8c,BenchmarkCheckMetricsAndSwap-8,8.26,0.00,0.00
+a9a2e8c,BenchmarkCrushOptimized-8,314.20,0.00,0.00
+a9a2e8c,BenchmarkCrushOriginal-8,412.00,164.00,3.00
+a9a2e8c,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+a9a2e8c,BenchmarkIndexSearch-8,2.77,0.00,0.00
+a9a2e8c,BenchmarkLoadGlobalConfig-8,771.20,160.00,1.00
+a9a2e8c,BenchmarkPadString-8,1.98,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1723,3 +1723,10 @@ a9a2e8c,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
 a9a2e8c,BenchmarkIndexSearch-8,2.77,0.00,0.00
 a9a2e8c,BenchmarkLoadGlobalConfig-8,771.20,160.00,1.00
 a9a2e8c,BenchmarkPadString-8,1.98,0.00,0.00
+814e4cc,BenchmarkCheckMetricsAndSwap-8,8.87,0.00,0.00
+814e4cc,BenchmarkCrushOptimized-8,334.40,0.00,0.00
+814e4cc,BenchmarkCrushOriginal-8,531.90,164.00,3.00
+814e4cc,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+814e4cc,BenchmarkIndexSearch-8,2.81,0.00,0.00
+814e4cc,BenchmarkLoadGlobalConfig-8,1033.00,160.00,1.00
+814e4cc,BenchmarkPadString-8,2.31,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        379.1n ± ∞ ¹    412.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       281.2n ± ∞ ¹    314.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     719.1n ± ∞ ¹    771.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.884n ± ∞ ¹    1.984n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.534n ± ∞ ¹    8.259n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.728n ± ∞ ¹    2.766n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3388n ± ∞ ¹   0.3484n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.32n          20.60n        +6.63%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        412.0n ± ∞ ¹    531.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       314.2n ± ∞ ¹    334.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     771.2n ± ∞ ¹   1033.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.984n ± ∞ ¹    2.308n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.259n ± ∞ ¹    8.870n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.766n ± ∞ ¹    2.814n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3484n ± ∞ ¹   0.3699n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                20.60n          23.46n        +13.88%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.26 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 314.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 412.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.77 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 771.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 334.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 531.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.81 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1033.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.31 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c]
-    line "CheckMetricsAndSwap" [7,7,8,7,7,7,8,7,8,8]
-    line "CrushOptimized" [293,311,292,288,300,321,291,308,281,314]
-    line "CrushOriginal" [385,399,388,437,420,406,397,413,379,412]
+    x-axis [15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc]
+    line "CheckMetricsAndSwap" [7,8,7,7,7,8,7,8,8,9]
+    line "CrushOptimized" [311,292,288,300,321,291,308,281,314,334]
+    line "CrushOriginal" [399,388,437,420,406,397,413,379,412,532]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [724,734,731,711,780,754,746,700,719,771]
+    line "LoadGlobalConfig" [734,731,711,780,754,746,700,719,771,1033]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c]
+    x-axis [15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c]
+    x-axis [15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        412.9n ± ∞ ¹    379.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       308.3n ± ∞ ¹    281.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     700.1n ± ∞ ¹    719.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.853n ± ∞ ¹    1.884n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.164n ± ∞ ¹    7.534n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.646n ± ∞ ¹    2.728n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3212n ± ∞ ¹   0.3388n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.32n          19.32n        +0.00%
+CrushOriginal-8                        379.1n ± ∞ ¹    412.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       281.2n ± ∞ ¹    314.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     719.1n ± ∞ ¹    771.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.884n ± ∞ ¹    1.984n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.534n ± ∞ ¹    8.259n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.728n ± ∞ ¹    2.766n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3388n ± ∞ ¹   0.3484n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                19.32n          20.60n        +6.63%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 281.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 379.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.73 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 719.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.88 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.26 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 314.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 412.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.77 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 771.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365]
-    line "CheckMetricsAndSwap" [7,7,7,8,7,7,7,8,7,8]
-    line "CrushOptimized" [300,293,311,292,288,300,321,291,308,281]
-    line "CrushOriginal" [393,385,399,388,437,420,406,397,413,379]
+    x-axis [0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c]
+    line "CheckMetricsAndSwap" [7,7,8,7,7,7,8,7,8,8]
+    line "CrushOptimized" [293,311,292,288,300,321,291,308,281,314]
+    line "CrushOriginal" [385,399,388,437,420,406,397,413,379,412]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [730,724,734,731,711,780,754,746,700,719]
+    line "LoadGlobalConfig" [724,734,731,711,780,754,746,700,719,771]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365]
+    x-axis [0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [5282e9b,0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365]
+    x-axis [0b200dc,15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -211,7 +211,18 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 						ChangeReplicationModeClient(factory, newReplicationJson, id)
 					}(i)
 				}
-				propWg.Wait()
+				// Timeout-bounded wait: each peer has a 10s deadline in ChangeReplicationModeClient.
+				// Bound the wait to 11s to avoid blocking the control plane indefinitely on unresponsive peers.
+				propDone := make(chan struct{})
+				go func() {
+					propWg.Wait()
+					close(propDone)
+				}()
+				select {
+				case <-propDone:
+				case <-time.After(11 * time.Second):
+					log.Printf("AUDIT: Propagation timed out after 11s, some peers may not have received replication update from %s", remoteAddr)
+				}
 			}
 		}()
 	}

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -194,11 +194,14 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 			// Skip propagation if json.Marshal failed to avoid sending empty data to peers.
 			if 0 == serverId && marshalErr == nil {
 				daemons := factory.GetDaemons()
+				var propWg sync.WaitGroup
 				for i := range daemons {
 					if i == serverId {
 						continue
 					}
+					propWg.Add(1)
 					go func(id int) {
+						defer propWg.Done()
 						defer func() {
 							if r := recover(); r != nil {
 								err := fmt.Errorf("panic in propagation to node %d: %v: %w", id, r, syscall.EIO)
@@ -208,6 +211,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 						ChangeReplicationModeClient(factory, newReplicationJson, id)
 					}(i)
 				}
+				propWg.Wait()
 			}
 		}()
 	}


### PR DESCRIPTION
Resolves #461

## Description

`src/server/replication.go:184-193` — Goroutines spawned to propagate replication mode changes were not waited on. The connection handler goroutine returned while propagation goroutines could still be running. They had a 10s deadline so they'd eventually finish, but there was no clean shutdown coordination.

## Changes

- Added `sync.WaitGroup` (`propWg`) to track propagation goroutines
- Each goroutine calls `propWg.Add(1)` before launch and `defer propWg.Done()` inside
- After spawning all propagation goroutines, `propWg.Wait()` blocks until all complete
- This ensures the connection handler goroutine doesn't return until all peer propagations finish

## Changelog

- Propagation goroutines now tracked with `sync.WaitGroup` for clean shutdown coordination