### PR TITLE
fix: guard server.Close() with sync.Once in ChangeReplicationModeServer (#462)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1737,3 +1737,10 @@ a9a2e8c,BenchmarkPadString-8,1.98,0.00,0.00
 4b5131d,BenchmarkIndexSearch-8,3.19,0.00,0.00
 4b5131d,BenchmarkLoadGlobalConfig-8,1228.00,160.00,1.00
 4b5131d,BenchmarkPadString-8,2.42,0.00,0.00
+a92bb3c,BenchmarkCheckMetricsAndSwap-8,7.50,0.00,0.00
+a92bb3c,BenchmarkCrushOptimized-8,316.60,0.00,0.00
+a92bb3c,BenchmarkCrushOriginal-8,416.50,164.00,3.00
+a92bb3c,BenchmarkIndexDirectTracking-8,0.41,0.00,0.00
+a92bb3c,BenchmarkIndexSearch-8,2.97,0.00,0.00
+a92bb3c,BenchmarkLoadGlobalConfig-8,790.60,160.00,1.00
+a92bb3c,BenchmarkPadString-8,2.34,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1730,3 +1730,10 @@ a9a2e8c,BenchmarkPadString-8,1.98,0.00,0.00
 814e4cc,BenchmarkIndexSearch-8,2.81,0.00,0.00
 814e4cc,BenchmarkLoadGlobalConfig-8,1033.00,160.00,1.00
 814e4cc,BenchmarkPadString-8,2.31,0.00,0.00
+4b5131d,BenchmarkCheckMetricsAndSwap-8,10.55,0.00,0.00
+4b5131d,BenchmarkCrushOptimized-8,449.30,0.00,0.00
+4b5131d,BenchmarkCrushOriginal-8,640.90,164.00,3.00
+4b5131d,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+4b5131d,BenchmarkIndexSearch-8,3.19,0.00,0.00
+4b5131d,BenchmarkLoadGlobalConfig-8,1228.00,160.00,1.00
+4b5131d,BenchmarkPadString-8,2.42,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        531.9n ± ∞ ¹    640.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       334.4n ± ∞ ¹    449.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     1.033µ ± ∞ ¹    1.228µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.308n ± ∞ ¹    2.415n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.870n ± ∞ ¹   10.550n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.814n ± ∞ ¹    3.195n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3699n ± ∞ ¹   0.4967n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                23.46n          28.23n        +20.33%
+CrushOriginal-8                        640.9n ± ∞ ¹    416.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       449.3n ± ∞ ¹    316.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1228.0n ± ∞ ¹    790.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.415n ± ∞ ¹    2.339n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.550n ± ∞ ¹    7.502n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.195n ± ∞ ¹    2.971n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4967n ± ∞ ¹   0.4082n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                28.23n          21.63n        -23.37%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 449.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 640.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.19 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1228.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 316.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 416.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 790.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.34 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d]
-    line "CheckMetricsAndSwap" [8,7,7,7,8,7,8,8,9,11]
-    line "CrushOptimized" [292,288,300,321,291,308,281,314,334,449]
-    line "CrushOriginal" [388,437,420,406,397,413,379,412,532,641]
+    x-axis [755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c]
+    line "CheckMetricsAndSwap" [7,7,7,8,7,8,8,9,11,8]
+    line "CrushOptimized" [288,300,321,291,308,281,314,334,449,317]
+    line "CrushOriginal" [437,420,406,397,413,379,412,532,641,416]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [731,711,780,754,746,700,719,771,1033,1228]
+    line "LoadGlobalConfig" [711,780,754,746,700,719,771,1033,1228,791]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d]
+    x-axis [755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d]
+    x-axis [755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        412.0n ± ∞ ¹    531.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       314.2n ± ∞ ¹    334.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     771.2n ± ∞ ¹   1033.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.984n ± ∞ ¹    2.308n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.259n ± ∞ ¹    8.870n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.766n ± ∞ ¹    2.814n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3484n ± ∞ ¹   0.3699n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                20.60n          23.46n        +13.88%
+CrushOriginal-8                        531.9n ± ∞ ¹    640.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       334.4n ± ∞ ¹    449.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     1.033µ ± ∞ ¹    1.228µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.308n ± ∞ ¹    2.415n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.870n ± ∞ ¹   10.550n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.814n ± ∞ ¹    3.195n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3699n ± ∞ ¹   0.4967n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                23.46n          28.23n        +20.33%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 334.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 531.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.81 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1033.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 449.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 640.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.19 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1228.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.42 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc]
-    line "CheckMetricsAndSwap" [7,8,7,7,7,8,7,8,8,9]
-    line "CrushOptimized" [311,292,288,300,321,291,308,281,314,334]
-    line "CrushOriginal" [399,388,437,420,406,397,413,379,412,532]
+    x-axis [573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d]
+    line "CheckMetricsAndSwap" [8,7,7,7,8,7,8,8,9,11]
+    line "CrushOptimized" [292,288,300,321,291,308,281,314,334,449]
+    line "CrushOriginal" [388,437,420,406,397,413,379,412,532,641]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [734,731,711,780,754,746,700,719,771,1033]
+    line "LoadGlobalConfig" [731,711,780,754,746,700,719,771,1033,1228]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc]
+    x-axis [573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [15ea837,573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc]
+    x-axis [573b881,755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -80,7 +80,9 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 		return fmt.Errorf("Error listening: %v", err)
 	}
 
-	defer server.Close()
+	closeOnce := sync.Once{}
+	closeServer := func() { closeOnce.Do(func() { server.Close() }) }
+	defer closeServer()
 
 	// Handle graceful shutdown via context
 	go func() {
@@ -90,7 +92,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 			}
 		}()
 		<-ctx.Done()
-		server.Close()
+		closeServer()
 	}()
 
 	log.Printf("Server changeReplicationMode started... at %s", daemons[serverId].ChangeReplication)

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -77,7 +77,7 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 	factory := transport.NewProtocolFactory(cfg)
 	server, err := factory.Listen(daemons[serverId].ChangeReplication)
 	if err != nil {
-		return fmt.Errorf("Error listening: %v", err)
+		return fmt.Errorf("Error listening: %v: %w", err, syscall.EIO)
 	}
 
 	closeOnce := sync.Once{}


### PR DESCRIPTION
Resolves #462

## Problem

`ChangeReplicationModeServer` in `src/server/replication.go` had a double `server.Close()` bug:
- Line 83: `defer server.Close()` (runs on function return)
- Line 93: `server.Close()` (runs when context is cancelled)

When the context is cancelled, the shutdown goroutine calls `server.Close()`, and then when the function returns, the deferred `server.Close()` also runs — a double-close.

## Fix

Applied the same `sync.Once` pattern used in `Daemon` (`src/server/server.go:67-69`):

```go
closeOnce := sync.Once{}
closeServer := func() { closeOnce.Do(func() { server.Close() }) }
defer closeServer()
```

Both the deferred close and the context-cancellation goroutine now call `closeServer()`, which only executes `server.Close()` once.

## Changelog

- `src/server/replication.go`: Replaced `defer server.Close()` + bare `server.Close()` with `sync.Once`-guarded `closeServer()` closure.