### PR TITLE
fix: validate FallbackInterval > 0 in config loading (#481)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1744,3 +1744,10 @@ a92bb3c,BenchmarkIndexDirectTracking-8,0.41,0.00,0.00
 a92bb3c,BenchmarkIndexSearch-8,2.97,0.00,0.00
 a92bb3c,BenchmarkLoadGlobalConfig-8,790.60,160.00,1.00
 a92bb3c,BenchmarkPadString-8,2.34,0.00,0.00
+5f3b3db,BenchmarkCheckMetricsAndSwap-8,7.92,0.00,0.00
+5f3b3db,BenchmarkCrushOptimized-8,408.00,0.00,0.00
+5f3b3db,BenchmarkCrushOriginal-8,463.90,164.00,3.00
+5f3b3db,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+5f3b3db,BenchmarkIndexSearch-8,2.74,0.00,0.00
+5f3b3db,BenchmarkLoadGlobalConfig-8,1335.00,160.00,1.00
+5f3b3db,BenchmarkPadString-8,2.49,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        640.9n ± ∞ ¹    416.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       449.3n ± ∞ ¹    316.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1228.0n ± ∞ ¹    790.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.415n ± ∞ ¹    2.339n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.550n ± ∞ ¹    7.502n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.195n ± ∞ ¹    2.971n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4967n ± ∞ ¹   0.4082n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                28.23n          21.63n        -23.37%
+CrushOriginal-8                        416.5n ± ∞ ¹    463.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       316.6n ± ∞ ¹    408.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     790.6n ± ∞ ¹   1335.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.339n ± ∞ ¹    2.489n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.502n ± ∞ ¹    7.915n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.971n ± ∞ ¹    2.742n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4082n ± ∞ ¹   0.3665n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                21.63n          24.30n        +12.32%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 316.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 416.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 790.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.92 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 408.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 463.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1335.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.49 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c]
-    line "CheckMetricsAndSwap" [7,7,7,8,7,8,8,9,11,8]
-    line "CrushOptimized" [288,300,321,291,308,281,314,334,449,317]
-    line "CrushOriginal" [437,420,406,397,413,379,412,532,641,416]
+    x-axis [d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db]
+    line "CheckMetricsAndSwap" [7,7,8,7,8,8,9,11,8,8]
+    line "CrushOptimized" [300,321,291,308,281,314,334,449,317,408]
+    line "CrushOriginal" [420,406,397,413,379,412,532,641,416,464]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [711,780,754,746,700,719,771,1033,1228,791]
+    line "LoadGlobalConfig" [780,754,746,700,719,771,1033,1228,791,1335]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c]
+    x-axis [d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [755c797,d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c]
+    x-axis [d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -244,6 +244,9 @@ func loadMetricsConfig(section *ini.Section) (ConfigurationMetrics, error) {
 	if err != nil {
 		return ConfigurationMetrics{}, fmt.Errorf("failed to parse 'fallback_interval': %w", err)
 	}
+	if metricsCfg.FallbackInterval <= 0 {
+		return ConfigurationMetrics{}, fmt.Errorf("'fallback_interval' must be positive, got %d: %w", metricsCfg.FallbackInterval, syscall.EINVAL)
+	}
 
 	metricsCfg.PrometheusPort, err = section.Key("prometheus_port").Int()
 	if err != nil {

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -120,6 +120,16 @@ func TestGetConfig_Failures(t *testing.T) {
 			content:       strings.Replace(validConfig, "interval = 10", "", 1),
 			expectedError: "failed to load [metrics] section: failed to parse 'interval'",
 		},
+		{
+			name:          "Zero fallback_interval",
+			content:       strings.Replace(validConfig, "fallback_interval = 30", "fallback_interval = 0", 1),
+			expectedError: "failed to load [metrics] section: 'fallback_interval' must be positive",
+		},
+		{
+			name:          "Negative fallback_interval",
+			content:       strings.Replace(validConfig, "fallback_interval = 30", "fallback_interval = -5", 1),
+			expectedError: "failed to load [metrics] section: 'fallback_interval' must be positive",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Resolves #481

## Problem

If `cfg.Metrics.FallbackInterval <= 0`, then `fallbackDuration` in `src/metrics/metrics.go:121` becomes `<= 0`. This makes the condition `now.Sub(start) > fallbackDuration` (line 141) true on every tick, causing the replication mode to decrement to 0 immediately — a silent correctness bug.

## Fix

Added validation in `loadMetricsConfig` (`src/common/config.go`): if `FallbackInterval <= 0`, return an error wrapped with `syscall.EINVAL`:

```go
if metricsCfg.FallbackInterval <= 0 {
    return ConfigurationMetrics{}, fmt.Errorf("'fallback_interval' must be positive, got %d: %w", metricsCfg.FallbackInterval, syscall.EINVAL)
}
```

This fails fast at startup instead of silently causing incorrect replication behavior at runtime.

## Tests

Added two test cases in `src/common/config_test.go`:
- `Zero fallback_interval`: verifies error for `fallback_interval = 0`
- `Negative fallback_interval`: verifies error for `fallback_interval = -5`

## Changelog

- `src/common/config.go`: Validate `FallbackInterval > 0` in `loadMetricsConfig` with `syscall.EINVAL` error wrapping.
- `src/common/config_test.go`: Added test cases for zero and negative `fallback_interval`.