### PR TITLE
fix: batch LOW fixes #463-#467 — unchecked errors + error wrapping

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1751,3 +1751,10 @@ a92bb3c,BenchmarkPadString-8,2.34,0.00,0.00
 5f3b3db,BenchmarkIndexSearch-8,2.74,0.00,0.00
 5f3b3db,BenchmarkLoadGlobalConfig-8,1335.00,160.00,1.00
 5f3b3db,BenchmarkPadString-8,2.49,0.00,0.00
+f08ad45,BenchmarkCheckMetricsAndSwap-8,7.46,0.00,0.00
+f08ad45,BenchmarkCrushOptimized-8,363.30,0.00,0.00
+f08ad45,BenchmarkCrushOriginal-8,464.80,164.00,3.00
+f08ad45,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+f08ad45,BenchmarkIndexSearch-8,2.74,0.00,0.00
+f08ad45,BenchmarkLoadGlobalConfig-8,761.20,160.00,1.00
+f08ad45,BenchmarkPadString-8,1.92,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        416.5n ± ∞ ¹    463.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       316.6n ± ∞ ¹    408.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     790.6n ± ∞ ¹   1335.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.339n ± ∞ ¹    2.489n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.502n ± ∞ ¹    7.915n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.971n ± ∞ ¹    2.742n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4082n ± ∞ ¹   0.3665n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                21.63n          24.30n        +12.32%
+CrushOriginal-8                        463.9n ± ∞ ¹    464.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       408.0n ± ∞ ¹    363.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1335.0n ± ∞ ¹    761.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.489n ± ∞ ¹    1.923n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.915n ± ∞ ¹    7.460n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.742n ± ∞ ¹    2.743n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3665n ± ∞ ¹   0.3561n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                24.30n          21.00n        -13.58%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.92 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 408.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 463.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 363.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 464.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 2.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1335.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 761.20 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.92 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db]
-    line "CheckMetricsAndSwap" [7,7,8,7,8,8,9,11,8,8]
-    line "CrushOptimized" [300,321,291,308,281,314,334,449,317,408]
-    line "CrushOriginal" [420,406,397,413,379,412,532,641,416,464]
+    x-axis [cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45]
+    line "CheckMetricsAndSwap" [7,8,7,8,8,9,11,8,8,7]
+    line "CrushOptimized" [321,291,308,281,314,334,449,317,408,363]
+    line "CrushOriginal" [406,397,413,379,412,532,641,416,464,465]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [780,754,746,700,719,771,1033,1228,791,1335]
+    line "LoadGlobalConfig" [754,746,700,719,771,1033,1228,791,1335,761]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db]
+    x-axis [cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [d2b4519,cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db]
+    x-axis [cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/metrics_exporter.go
+++ b/src/server/metrics_exporter.go
@@ -15,16 +15,16 @@ import (
 
 // MetricsCollector tracks server-level metrics for Prometheus export.
 type MetricsCollector struct {
-	connectionsTotal   atomic.Uint64
-	uploadsTotal       atomic.Uint64
-	downloadsTotal     atomic.Uint64
-	deletesTotal       atomic.Uint64
-	replicationTotal   atomic.Uint64
-	errorsTotal        atomic.Uint64
-	activeConnections  atomic.Int64
-	bytesUploaded      atomic.Uint64
-	bytesDownloaded    atomic.Uint64
-	startTime          time.Time
+	connectionsTotal  atomic.Uint64
+	uploadsTotal      atomic.Uint64
+	downloadsTotal    atomic.Uint64
+	deletesTotal      atomic.Uint64
+	replicationTotal  atomic.Uint64
+	errorsTotal       atomic.Uint64
+	activeConnections atomic.Int64
+	bytesUploaded     atomic.Uint64
+	bytesDownloaded   atomic.Uint64
+	startTime         time.Time
 }
 
 // NewMetricsCollector creates a new MetricsCollector.
@@ -34,15 +34,15 @@ func NewMetricsCollector() *MetricsCollector {
 	}
 }
 
-func (m *MetricsCollector) IncConnections()    { m.connectionsTotal.Add(1); m.activeConnections.Add(1) }
-func (m *MetricsCollector) DecConnections()    { m.activeConnections.Add(-1) }
-func (m *MetricsCollector) IncUploads()         { m.uploadsTotal.Add(1) }
-func (m *MetricsCollector) IncDownloads()       { m.downloadsTotal.Add(1) }
-func (m *MetricsCollector) IncDeletes()         { m.deletesTotal.Add(1) }
-func (m *MetricsCollector) IncReplication()     { m.replicationTotal.Add(1) }
-func (m *MetricsCollector) IncErrors()          { m.errorsTotal.Add(1) }
-func (m *MetricsCollector) AddBytesUploaded(n uint64)    { m.bytesUploaded.Add(n) }
-func (m *MetricsCollector) AddBytesDownloaded(n uint64)  { m.bytesDownloaded.Add(n) }
+func (m *MetricsCollector) IncConnections()             { m.connectionsTotal.Add(1); m.activeConnections.Add(1) }
+func (m *MetricsCollector) DecConnections()             { m.activeConnections.Add(-1) }
+func (m *MetricsCollector) IncUploads()                 { m.uploadsTotal.Add(1) }
+func (m *MetricsCollector) IncDownloads()               { m.downloadsTotal.Add(1) }
+func (m *MetricsCollector) IncDeletes()                 { m.deletesTotal.Add(1) }
+func (m *MetricsCollector) IncReplication()             { m.replicationTotal.Add(1) }
+func (m *MetricsCollector) IncErrors()                  { m.errorsTotal.Add(1) }
+func (m *MetricsCollector) AddBytesUploaded(n uint64)   { m.bytesUploaded.Add(n) }
+func (m *MetricsCollector) AddBytesDownloaded(n uint64) { m.bytesDownloaded.Add(n) }
 
 func (m *MetricsCollector) writeMetrics(w io.Writer) {
 	var memStats runtime.MemStats
@@ -106,7 +106,11 @@ func (m *MetricsCollector) writeMetrics(w io.Writer) {
 	fmt.Fprintf(w, "# TYPE momo_gc_runs_total counter\n")
 	fmt.Fprintf(w, "momo_gc_runs_total %d\n", memStats.NumGC)
 
-	hostname, _ := os.Hostname()
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+		log.Printf("AUDIT: os.Hostname() failed: %v", err)
+	}
 	fmt.Fprintf(w, "# HELP momo_build_info Build information.\n")
 	fmt.Fprintf(w, "# TYPE momo_build_info gauge\n")
 	fmt.Fprintf(w, "momo_build_info{hostname=\"%s\"} 1\n", hostname)

--- a/src/server/p2p_adapters.go
+++ b/src/server/p2p_adapters.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"log"
 	"syscall"
 	"time"
 
@@ -34,10 +35,12 @@ func (s *ScatterGatherLister) GlobalList(timeout time.Duration) ([]common.FileMe
 	var allLists [][]common.FileMetadata
 	for _, resp := range responses {
 		if resp.Error != "" {
+			log.Printf("AUDIT: GlobalList peer error: %s", common.SanitizeLog(resp.Error))
 			continue
 		}
 		files, err := DecodeFileMetadataList(resp.Data)
 		if err != nil {
+			log.Printf("AUDIT: GlobalList decode failed from peer: %v", common.SanitizeLog(err.Error()))
 			continue
 		}
 		allLists = append(allLists, files)

--- a/src/storage/raw_blobstore.go
+++ b/src/storage/raw_blobstore.go
@@ -79,15 +79,15 @@ func NewRawBlobStore(cfg common.ConfigurationStorage, daemon *common.Daemon) (rb
 		}
 		c := b.Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
-		if len(v) == 16 {
-			offset := int64(binary.BigEndian.Uint64(v[0:8]))
-			length := int64(binary.BigEndian.Uint64(v[8:16]))
-			if offset > 0 && length > 0 && offset <= math.MaxInt64-length {
-				end := offset + length
-				if end > nextOffset {
-					nextOffset = end
+			if len(v) == 16 {
+				offset := int64(binary.BigEndian.Uint64(v[0:8]))
+				length := int64(binary.BigEndian.Uint64(v[8:16]))
+				if offset > 0 && length > 0 && offset <= math.MaxInt64-length {
+					end := offset + length
+					if end > nextOffset {
+						nextOffset = end
+					}
 				}
-			}
 			}
 		}
 		return nil
@@ -106,7 +106,9 @@ func NewRawBlobStore(cfg common.ConfigurationStorage, daemon *common.Daemon) (rb
 }
 
 func (r *RawBlobStore) Close() error {
-	r.allocDB.Close()
+	if err := r.allocDB.Close(); err != nil {
+		log.Printf("AUDIT: allocDB.Close() failed: %v", err)
+	}
 	return r.device.Close()
 }
 

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -52,7 +52,10 @@ func decodeObjectMeta(val []byte) ObjectMeta {
 		}
 	}
 	// Legacy format: ASCII integer = size only, refCount=1, not deleted
-	size, _ := strconv.ParseInt(string(val), 10, 64)
+	size, err := strconv.ParseInt(string(val), 10, 64)
+	if err != nil {
+		log.Printf("AUDIT: legacy metadata decode failed: %v", err)
+	}
 	return ObjectMeta{Size: size, RefCount: 1}
 }
 
@@ -70,12 +73,12 @@ type Store interface {
 // It composes a pluggable BlobStore (for raw blob bytes) with a fixed
 // bbolt metadata layer (for refcounts, tombstones, namespace mappings).
 type CASStore struct {
-	mu       sync.RWMutex
-	db       *bbolt.DB
-	base     string
-	blobs    BlobStore
-	gcDone   chan struct{}
-	gcWG     sync.WaitGroup
+	mu        sync.RWMutex
+	db        *bbolt.DB
+	base      string
+	blobs     BlobStore
+	gcDone    chan struct{}
+	gcWG      sync.WaitGroup
 	closeOnce sync.Once
 }
 
@@ -93,13 +96,13 @@ func NewCASStore(dataDir string) (*CASStore, error) {
 // a bbolt metadata database in dataDir.
 func newCASStore(dataDir string, blobs BlobStore) (*CASStore, error) {
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create data dir: %w", syscall.EIO)
+		return nil, fmt.Errorf("failed to create data dir: %v: %w", err, syscall.EIO)
 	}
 
 	dbPath := filepath.Join(dataDir, "momo.db")
 	db, err := bbolt.Open(dbPath, 0600, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open bbolt: %w", syscall.EIO)
+		return nil, fmt.Errorf("failed to open bbolt: %v: %w", err, syscall.EIO)
 	}
 
 	// Initialize buckets


### PR DESCRIPTION
Resolves #463, #464, #465, #466, #467

## Summary

Batch of 5 LOW-severity bug fixes across server and storage packages.

## Changes

### #463 — GlobalList silently drops peer errors (`src/server/p2p_adapters.go`)
Added `log.Printf` for peer errors and decode failures instead of silently skipping.

### #464 — os.Hostname() error ignored (`src/server/metrics_exporter.go`)
Check error from `os.Hostname()`, fallback to `"unknown"` with audit log.

### #465 — Error wrapping discards original error (`src/storage/storage.go:95,101`)
Wrapped original `err` from `os.MkdirAll`/`bbolt.Open` with `%v: %w` format alongside `syscall.EIO`.

### #466 — Unchecked ParseInt in legacy metadata (`src/storage/storage.go:55`)
Check `ParseInt` error and log it instead of silently setting size=0.

### #467 — Unchecked allocDB.Close() (`src/storage/raw_blobstore.go:108`)
Log `allocDB.Close()` error instead of silently discarding.