### PR TITLE
fix: batch LOW fixes #468-#472 — PadString guard, traversal, config race, CRUSH

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1758,3 +1758,10 @@ f08ad45,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
 f08ad45,BenchmarkIndexSearch-8,2.74,0.00,0.00
 f08ad45,BenchmarkLoadGlobalConfig-8,761.20,160.00,1.00
 f08ad45,BenchmarkPadString-8,1.92,0.00,0.00
+b32f6ea,BenchmarkCheckMetricsAndSwap-8,10.52,0.00,0.00
+b32f6ea,BenchmarkCrushOptimized-8,329.20,0.00,0.00
+b32f6ea,BenchmarkCrushOriginal-8,435.60,164.00,3.00
+b32f6ea,BenchmarkIndexDirectTracking-8,0.80,0.00,0.00
+b32f6ea,BenchmarkIndexSearch-8,3.41,0.00,0.00
+b32f6ea,BenchmarkLoadGlobalConfig-8,887.70,160.00,1.00
+b32f6ea,BenchmarkPadString-8,2.25,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1765,3 +1765,10 @@ b32f6ea,BenchmarkIndexDirectTracking-8,0.80,0.00,0.00
 b32f6ea,BenchmarkIndexSearch-8,3.41,0.00,0.00
 b32f6ea,BenchmarkLoadGlobalConfig-8,887.70,160.00,1.00
 b32f6ea,BenchmarkPadString-8,2.25,0.00,0.00
+f372029,BenchmarkCheckMetricsAndSwap-8,7.66,0.00,0.00
+f372029,BenchmarkCrushOptimized-8,301.10,0.00,0.00
+f372029,BenchmarkCrushOriginal-8,408.90,164.00,3.00
+f372029,BenchmarkIndexDirectTracking-8,0.45,0.00,0.00
+f372029,BenchmarkIndexSearch-8,2.99,0.00,0.00
+f372029,BenchmarkLoadGlobalConfig-8,824.10,160.00,1.00
+f372029,BenchmarkPadString-8,1.96,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        463.9n ± ∞ ¹    464.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       408.0n ± ∞ ¹    363.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1335.0n ± ∞ ¹    761.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.489n ± ∞ ¹    1.923n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.915n ± ∞ ¹    7.460n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.742n ± ∞ ¹    2.743n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3665n ± ∞ ¹   0.3561n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                24.30n          21.00n        -13.58%
+CrushOriginal-8                        464.8n ± ∞ ¹    435.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       363.3n ± ∞ ¹    329.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     761.2n ± ∞ ¹    887.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.923n ± ∞ ¹    2.246n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.460n ± ∞ ¹   10.520n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.743n ± ∞ ¹    3.408n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3561n ± ∞ ¹   0.7963n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                21.00n          26.06n        +24.09%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 363.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 464.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 761.20 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.92 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 329.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 435.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 887.70 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.25 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45]
-    line "CheckMetricsAndSwap" [7,8,7,8,8,9,11,8,8,7]
-    line "CrushOptimized" [321,291,308,281,314,334,449,317,408,363]
-    line "CrushOriginal" [406,397,413,379,412,532,641,416,464,465]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
+    x-axis [86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea]
+    line "CheckMetricsAndSwap" [8,7,8,8,9,11,8,8,7,11]
+    line "CrushOptimized" [291,308,281,314,334,449,317,408,363,329]
+    line "CrushOriginal" [397,413,379,412,532,641,416,464,465,436]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [754,746,700,719,771,1033,1228,791,1335,761]
+    line "LoadGlobalConfig" [746,700,719,771,1033,1228,791,1335,761,888]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45]
+    x-axis [86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cfe6236,86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45]
+    x-axis [86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        464.8n ± ∞ ¹    435.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       363.3n ± ∞ ¹    329.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     761.2n ± ∞ ¹    887.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.923n ± ∞ ¹    2.246n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.460n ± ∞ ¹   10.520n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.743n ± ∞ ¹    3.408n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3561n ± ∞ ¹   0.7963n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                21.00n          26.06n        +24.09%
+CrushOriginal-8                        435.6n ± ∞ ¹    408.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       329.2n ± ∞ ¹    301.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     887.7n ± ∞ ¹    824.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.246n ± ∞ ¹    1.958n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.520n ± ∞ ¹    7.663n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.408n ± ∞ ¹    2.993n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.7963n ± ∞ ¹   0.4542n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                26.06n          21.42n        -17.80%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 329.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 435.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 887.70 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.25 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.66 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 301.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 408.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.45 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 824.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea]
-    line "CheckMetricsAndSwap" [8,7,8,8,9,11,8,8,7,11]
-    line "CrushOptimized" [291,308,281,314,334,449,317,408,363,329]
-    line "CrushOriginal" [397,413,379,412,532,641,416,464,465,436]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
+    x-axis [4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029]
+    line "CheckMetricsAndSwap" [7,8,8,9,11,8,8,7,11,8]
+    line "CrushOptimized" [308,281,314,334,449,317,408,363,329,301]
+    line "CrushOriginal" [413,379,412,532,641,416,464,465,436,409]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [746,700,719,771,1033,1228,791,1335,761,888]
+    line "LoadGlobalConfig" [700,719,771,1033,1228,791,1335,761,888,824]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea]
+    x-axis [4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [86a8e49,4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea]
+    x-axis [4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"gopkg.in/ini.v1"
@@ -118,10 +119,28 @@ func GetConfig(path string) (Configuration, error) {
 	return config, nil
 }
 
-// GetConfigFromFile is a function variable that loads the configuration from the default path "conf/momo.conf".
-// It can be overridden in tests to load a custom configuration for testing purposes.
-var GetConfigFromFile = func() (Configuration, error) {
-	return GetConfig("conf/momo.conf")
+// getConfigFromFileMu protects getConfigFromFileFn from concurrent reads/writes (Rule 471).
+var (
+	getConfigFromFileMu sync.RWMutex
+	getConfigFromFileFn = func() (Configuration, error) {
+		return GetConfig("conf/momo.conf")
+	}
+)
+
+// GetConfigFromFile loads the configuration from the default path "conf/momo.conf".
+// It is thread-safe; tests may override the implementation via SetConfigFromFile.
+func GetConfigFromFile() (Configuration, error) {
+	getConfigFromFileMu.RLock()
+	fn := getConfigFromFileFn
+	getConfigFromFileMu.RUnlock()
+	return fn()
+}
+
+// SetConfigFromFile overrides the config loader implementation (for testing).
+func SetConfigFromFile(fn func() (Configuration, error)) {
+	getConfigFromFileMu.Lock()
+	getConfigFromFileFn = fn
+	getConfigFromFileMu.Unlock()
 }
 
 // loadGlobalConfig loads the [global] section from the configuration.

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -79,7 +79,7 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 		// ⚡ Bolt: Use Weighted Rendezvous Hashing (WRH) formula: -weight / log(score).
 		// This provides mathematically perfect load balancing for heterogeneous nodes.
 		var finalScore float64
-		if floatVal > 0 && node.Weight > 0 {
+		if floatVal > 0 && floatVal < 1.0 && node.Weight > 0 {
 			finalScore = -float64(node.Weight) / math.Log(floatVal)
 		} else {
 			finalScore = 0

--- a/src/common/string.go
+++ b/src/common/string.go
@@ -28,12 +28,16 @@ func AppendPaddedInt(dst []byte, val int64, width int) error {
 	return nil
 }
 
-// HasPathTraversalChars returns true if the string contains '.', '/' or '\'.
+// HasPathTraversalChars returns true if the string contains path separators (/ or \)
+// or the parent directory sequence (..). Single dots (file extensions) are allowed.
 // It is inlineable and operates directly on the string bytes without any heap allocation (Rule 19).
 func HasPathTraversalChars(s string) bool {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if c == '.' || c == '/' || c == '\\' {
+		if c == '/' || c == '\\' {
+			return true
+		}
+		if c == '.' && i+1 < len(s) && s[i+1] == '.' {
 			return true
 		}
 	}
@@ -42,6 +46,9 @@ func HasPathTraversalChars(s string) bool {
 
 // PadString pads or truncates a string to the given length.
 func PadString(input string, length int) string {
+	if length < 0 {
+		return input
+	}
 	if len(input) >= length {
 		return input[:length]
 	}
@@ -60,9 +67,14 @@ func NormalizeVirtualPath(p string) (string, error) {
 		return "", nil
 	}
 
-	// Strictly reject parent directory references and backslashes immediately
-	if strings.Contains(p, "..") || strings.Contains(p, "\\") {
+	// Strictly reject path traversal segments (..) and backslashes
+	if strings.Contains(p, "\\") {
 		return "", syscall.EINVAL
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return "", syscall.EINVAL
+		}
 	}
 
 	// Resolve slashes and remove redundancies efficiently

--- a/src/common/string_test.go
+++ b/src/common/string_test.go
@@ -55,11 +55,12 @@ func TestHasPathTraversalChars(t *testing.T) {
 		expected bool
 	}{
 		{"No special characters", "helloworld", false},
-		{"Contains dot", "hello.world", true},
+		{"Contains dot (extension)", "hello.world", false},
 		{"Contains slash", "hello/world", true},
 		{"Contains backslash", "hello\\world", true},
 		{"Path traversal", "../etc/passwd", true},
 		{"Just dots", "..", true},
+		{"Double dot in filename", "file..txt", true},
 		{"Empty string", "", false},
 	}
 

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -133,7 +133,6 @@ func TestS3Communicator_HashTraversalValidation(t *testing.T) {
 		"../../malicious",
 		"some/path",
 		"bad\\hash",
-		".dot",
 	}
 
 	for _, malHash := range maliciousHashes {


### PR DESCRIPTION
Resolves #468, #469, #470, #471, #472

## Changes

### #468 — PadString panics on negative length (`src/common/string.go`)
Added `if length < 0 { return input }` guard.

### #469 — NormalizeVirtualPath false-positive on '..' (`src/common/string.go`)
Replaced overly broad `strings.Contains(p, "..")` with segment-level check: only rejects `".."` as a complete path segment, not substrings like `file..txt`.

### #470 — HasPathTraversalChars rejects all dots (`src/common/string.go`)
Changed to only reject path separators (`/`, `\`) and double-dot (`..`), allowing single dots (file extensions). Updated test expectations.

### #471 — GetConfigFromFile data race (`src/common/config.go`)
Replaced package-level `var` with RWMutex-protected function variable + `GetConfigFromFile()`/`SetConfigFromFile()` accessors.

### #472 — CRUSH division by zero (`src/common/crush.go`)
Added `floatVal < 1.0` guard to prevent `math.Log(1.0) == 0.0` producing `-Inf`.