### PR TITLE
fix: transport wireName validation, protocol mismatch, unchecked Send errors, RandomPeers edge cases (#473-#478)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1772,3 +1772,10 @@ f372029,BenchmarkIndexDirectTracking-8,0.45,0.00,0.00
 f372029,BenchmarkIndexSearch-8,2.99,0.00,0.00
 f372029,BenchmarkLoadGlobalConfig-8,824.10,160.00,1.00
 f372029,BenchmarkPadString-8,1.96,0.00,0.00
+99882c9,BenchmarkCheckMetricsAndSwap-8,6.97,0.00,0.00
+99882c9,BenchmarkCrushOptimized-8,301.70,0.00,0.00
+99882c9,BenchmarkCrushOriginal-8,424.30,164.00,3.00
+99882c9,BenchmarkIndexDirectTracking-8,0.42,0.00,0.00
+99882c9,BenchmarkIndexSearch-8,3.12,0.00,0.00
+99882c9,BenchmarkLoadGlobalConfig-8,749.00,160.00,1.00
+99882c9,BenchmarkPadString-8,2.25,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        435.6n ± ∞ ¹    408.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       329.2n ± ∞ ¹    301.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     887.7n ± ∞ ¹    824.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.246n ± ∞ ¹    1.958n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.520n ± ∞ ¹    7.663n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.408n ± ∞ ¹    2.993n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.7963n ± ∞ ¹   0.4542n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                26.06n          21.42n        -17.80%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        408.9n ± ∞ ¹    424.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       301.1n ± ∞ ¹    301.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     824.1n ± ∞ ¹    749.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.958n ± ∞ ¹    2.245n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.663n ± ∞ ¹    6.972n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.993n ± ∞ ¹    3.124n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4542n ± ∞ ¹   0.4157n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                21.42n          21.24n        -0.85%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.66 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 301.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 408.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.45 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.99 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 824.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 6.97 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 301.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 424.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.12 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 749.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.25 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029]
-    line "CheckMetricsAndSwap" [7,8,8,9,11,8,8,7,11,8]
-    line "CrushOptimized" [308,281,314,334,449,317,408,363,329,301]
-    line "CrushOriginal" [413,379,412,532,641,416,464,465,436,409]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
+    x-axis [ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029,99882c9]
+    line "CheckMetricsAndSwap" [8,8,9,11,8,8,7,11,8,7]
+    line "CrushOptimized" [281,314,334,449,317,408,363,329,301,302]
+    line "CrushOriginal" [379,412,532,641,416,464,465,436,409,424]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [700,719,771,1033,1228,791,1335,761,888,824]
+    line "LoadGlobalConfig" [719,771,1033,1228,791,1335,761,888,824,749]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029]
+    x-axis [ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029,99882c9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [4d28c58,ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029]
+    x-axis [ac9e365,a9a2e8c,814e4cc,4b5131d,a92bb3c,5f3b3db,f08ad45,b32f6ea,f372029,99882c9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -495,7 +495,9 @@ func (g *Gossiper) handleIndirectPing(rpc *RPC) {
 			Type:    MsgAck,
 			Payload: ackPayload.Encode(),
 		}
-		g.transport.Send(rpc.From, ackRPC)
+		if err := g.transport.Send(rpc.From, ackRPC); err != nil {
+			log.Printf("Gossip: failed to forward indirect ping ack to peer %d: %v (errno=%d)", rpc.From, err, syscall.EHOSTUNREACH)
+		}
 		g.removePendingPing(payload.PingID)
 	case <-time.After(g.cfg.PingTimeout):
 		g.removePendingPing(payload.PingID)

--- a/src/p2p/lease.go
+++ b/src/p2p/lease.go
@@ -35,10 +35,10 @@ type LeaseManager struct {
 	pendingMu sync.Mutex
 	pending   map[uint64]chan bool
 
-	stopMu  sync.Mutex
-	closed  bool
-	done    chan struct{}
-	wg      sync.WaitGroup
+	stopMu sync.Mutex
+	closed bool
+	done   chan struct{}
+	wg     sync.WaitGroup
 }
 
 // NewLeaseManager creates a new LeaseManager.
@@ -149,7 +149,9 @@ func (lm *LeaseManager) handleLeaseRequest(rpc *RPC) {
 		lm.grantedMu.Unlock()
 		grant := &LeasePayload{LeaseID: payload.LeaseID, Key: payload.Key, Expiry: 0}
 		resp := &RPC{From: lm.localID, Type: MsgLeaseGrant, Payload: grant.Encode()}
-		lm.transport.Send(rpc.From, resp)
+		if err := lm.transport.Send(rpc.From, resp); err != nil {
+			log.Printf("LeaseManager: failed to send denial to peer %d: %v (errno=%d)", rpc.From, err, syscall.EHOSTUNREACH)
+		}
 		return
 	}
 	lm.granted[payload.Key] = payload.Expiry

--- a/src/p2p/peer_map.go
+++ b/src/p2p/peer_map.go
@@ -69,6 +69,9 @@ func (m *PeerMap) Alive() []*Peer {
 
 // RandomPeers returns up to k random alive peers, excluding the peer with excludeID.
 func (m *PeerMap) RandomPeers(k int, excludeID int32) []*Peer {
+	if k <= 0 {
+		return nil
+	}
 	alive := m.Alive()
 	if len(alive) <= 1 {
 		result := make([]*Peer, 0)

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -198,15 +198,18 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		// Send metadata packets (192 bytes each)
 		for _, file := range files {
 			// 🛡️ Sentinel: Validate length bounds
-			if len(file.Name) > 64 || len(file.Hash) > 64 {
+			if len(file.Hash) > 64 {
 				continue
 			}
-			var packet [192]byte
-			copy(packet[0:64], common.PadString(file.Hash, 64))
 			wireName := file.Name
 			if file.RemotePath != "" {
 				wireName = file.RemotePath + "/" + file.Name
 			}
+			if len(wireName) > 64 {
+				continue
+			}
+			var packet [192]byte
+			copy(packet[0:64], common.PadString(file.Hash, 64))
 			copy(packet[64:128], common.PadString(wireName, 64))
 			if err := common.AppendPaddedInt(packet[128:], file.Size, 64); err != nil {
 				return 0, 0, fmt.Errorf("failed to format file size: %v: %w", err, syscall.EINVAL)
@@ -344,7 +347,11 @@ func (m *MomoQUICCommunicator) SendReplicationMode(mode int) (err error) {
 	}()
 
 	var repModeBuf [16]byte
-	if _, err := m.Write(strconv.AppendInt(repModeBuf[:0], int64(mode), 10)); err != nil {
+	if mode < 0 || mode > 9 {
+		return fmt.Errorf("invalid replication mode %d: %w", mode, syscall.EBADMSG)
+	}
+	repModeBuf[0] = byte(mode + '0')
+	if _, err := m.Write(repModeBuf[:1]); err != nil {
 		return fmt.Errorf("failed to send replication mode: %v: %w", err, syscall.EIO)
 	}
 	return nil

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -189,15 +189,18 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		// Send metadata packets (192 bytes each)
 		for _, file := range files {
 			// 🛡️ Sentinel: Validate length bounds
-			if len(file.Name) > 64 || len(file.Hash) > 64 {
+			if len(file.Hash) > 64 {
 				continue
 			}
-			var packet [192]byte
-			copy(packet[0:64], common.PadString(file.Hash, 64))
 			wireName := file.Name
 			if file.RemotePath != "" {
 				wireName = file.RemotePath + "/" + file.Name
 			}
+			if len(wireName) > 64 {
+				continue
+			}
+			var packet [192]byte
+			copy(packet[0:64], common.PadString(file.Hash, 64))
 			copy(packet[64:128], common.PadString(wireName, 64))
 			if err := common.AppendPaddedInt(packet[128:], file.Size, 64); err != nil {
 				return 0, 0, fmt.Errorf("failed to format file size: %v: %w", err, syscall.EINVAL)
@@ -336,7 +339,11 @@ func (m *MomoTCPCommunicator) SendReplicationMode(mode int) (err error) {
 	}()
 
 	var repModeBuf [16]byte
-	if _, err := m.Write(strconv.AppendInt(repModeBuf[:0], int64(mode), 10)); err != nil {
+	if mode < 0 || mode > 9 {
+		return fmt.Errorf("invalid replication mode %d: %w", mode, syscall.EBADMSG)
+	}
+	repModeBuf[0] = byte(mode + '0')
+	if _, err := m.Write(repModeBuf[:1]); err != nil {
 		return fmt.Errorf("failed to send replication mode: %v: %w", err, syscall.EIO)
 	}
 	return nil


### PR DESCRIPTION
Closes #473
Closes #474
Closes #475
Closes #476
Closes #477
Closes #478

## Summary

Batch fix for 6 LOW-severity issues in transport and p2p packages.

### #473: LIST response name truncation
`wireName` (`RemotePath + "/" + Name`) could exceed 64 bytes but was only validated against `file.Name`. Now validates `len(wireName) > 64` after computing the full path. Fixed in both `momo_tcp.go` and `momo_quic.go`.

### #474: SendReplicationMode/HandshakeClient protocol mismatch
`SendReplicationMode` sent mode as a decimal string (`strconv.AppendInt`), but `HandshakeClient` only reads 1 byte. For modes >= 10, the client would read only the first digit. Fixed by sending mode as a single byte (`byte(mode + '0')`) with validation that mode is 0-9, matching the request direction protocol. Fixed in both `momo_tcp.go` and `momo_quic.go`.

### #475: Unchecked error in handleIndirectPing ack forward
`g.transport.Send(rpc.From, ackRPC)` return value was discarded. Now checked and logged with `syscall.EHOSTUNREACH`.

### #476: Unchecked error in lease denial response
`lm.transport.Send(rpc.From, resp)` return value was discarded. Now checked and logged with `syscall.EHOSTUNREACH`.

### #477: RandomPeers panics on negative k
`make([]*Peer, 0, k)` panics when `k < 0` (negative capacity). Added early return `if k <= 0 { return nil }`.

### #478: RandomPeers returns 1 peer when k=0
When `k=0`, the loop appended one peer before checking `len(result) >= k`. The early return `if k <= 0 { return nil }` also fixes this.

## Test Plan
- `go build ./...` — passes
- `go test ./src/transport/... ./src/p2p/...` — passes
- `go test ./...` — passes