### PR TITLE
Fix CVE-008: S3 SigV4 signature bypass — validate cryptographic signatures

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1947,3 +1947,10 @@ aef7e26,BenchmarkPadString-8,2.03,0.00,0.00
 0f28cb7,BenchmarkIndexSearch-8,1.91,0.00,0.00
 0f28cb7,BenchmarkLoadGlobalConfig-8,1066.00,160.00,1.00
 0f28cb7,BenchmarkPadString-8,2.29,0.00,0.00
+893a670,BenchmarkCheckMetricsAndSwap-8,12.08,0.00,0.00
+893a670,BenchmarkCrushOptimized-8,327.50,0.00,0.00
+893a670,BenchmarkCrushOriginal-8,427.50,164.00,3.00
+893a670,BenchmarkIndexDirectTracking-8,0.56,0.00,0.00
+893a670,BenchmarkIndexSearch-8,2.13,0.00,0.00
+893a670,BenchmarkLoadGlobalConfig-8,806.10,160.00,1.00
+893a670,BenchmarkPadString-8,2.30,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1954,3 +1954,10 @@ aef7e26,BenchmarkPadString-8,2.03,0.00,0.00
 893a670,BenchmarkIndexSearch-8,2.13,0.00,0.00
 893a670,BenchmarkLoadGlobalConfig-8,806.10,160.00,1.00
 893a670,BenchmarkPadString-8,2.30,0.00,0.00
+19fffcf,BenchmarkCheckMetricsAndSwap-8,10.33,0.00,0.00
+19fffcf,BenchmarkCrushOptimized-8,301.40,0.00,0.00
+19fffcf,BenchmarkCrushOriginal-8,439.40,164.00,3.00
+19fffcf,BenchmarkIndexDirectTracking-8,0.39,0.00,0.00
+19fffcf,BenchmarkIndexSearch-8,1.61,0.00,0.00
+19fffcf,BenchmarkLoadGlobalConfig-8,926.50,160.00,1.00
+19fffcf,BenchmarkPadString-8,2.28,0.00,0.00

--- a/.github/scripts/test-external-client.sh
+++ b/.github/scripts/test-external-client.sh
@@ -75,11 +75,42 @@ echo "external-client-test-data" > $E2E_DIR/test_external.txt
 FILE_HASH=$(sha256sum $E2E_DIR/test_external.txt | awk '{print $1}')
 FILE_SIZE=$(wc -c < $E2E_DIR/test_external.txt)
 
+# Compute real SigV4 signature for the PUT request
+TOKEN="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"  # notsecret
+AMZ_DATE="20260727T120000Z"
+DATE_STAMP="20260727"
+REGION="us-east-1"
+SIGNED_HEADERS="host;x-amz-content-sha256;x-amz-date"
+SIGNATURE=$(python3 -c "
+import hmac, hashlib, sys
+token='$TOKEN'
+amz_date='$AMZ_DATE'
+date_stamp='$DATE_STAMP'
+region='$REGION'
+payload_hash='$FILE_HASH'
+signed_headers='$SIGNED_HEADERS'
+host='127.0.0.1:4440'
+method='PUT'
+uri='/test-bucket/test_external.txt'
+canonical_request = method + '\n' + uri + '\n\n' + 'host:' + host + '\n' + 'x-amz-content-sha256:' + payload_hash + '\n' + 'x-amz-date:' + amz_date + '\n\n' + signed_headers + '\n' + payload_hash
+hashed_cr = hashlib.sha256(canonical_request.encode()).hexdigest()
+credential_scope = date_stamp + '/' + region + '/s3/aws4_request'
+string_to_sign = 'AWS4-HMAC-SHA256\n' + amz_date + '\n' + credential_scope + '\n' + hashed_cr
+def hmac_sha256(key, data):
+    return hmac.new(key, data.encode(), hashlib.sha256).digest()
+k_date = hmac_sha256(('AWS4' + token).encode(), date_stamp)
+k_region = hmac_sha256(k_date, region)
+k_service = hmac_sha256(k_region, 's3')
+k_signing = hmac_sha256(k_service, 'aws4_request')
+sig = hmac.new(k_signing, string_to_sign.encode(), hashlib.sha256).hexdigest()
+print(sig)
+")
+
 # curl PUT without X-Momo-Requested-Mode — simulates aws-cli
-AUTH_HDR="Authorization: AWS4-HMAC-SHA256 Credential=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6/20260727/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=dummy"  # notsecret
+AUTH_HDR="Authorization: AWS4-HMAC-SHA256 Credential=$TOKEN/$DATE_STAMP/$REGION/s3/aws4_request, SignedHeaders=$SIGNED_HEADERS, Signature=$SIGNATURE"  # notsecret
 curl -s -X PUT \
   -H "$AUTH_HDR" \
-  -H "X-Amz-Date: 20260727T120000Z" \
+  -H "X-Amz-Date: $AMZ_DATE" \
   -H "X-Amz-Content-Sha256: $FILE_HASH" \
   -H "Content-Type: application/octet-stream" \
   --data-binary @$E2E_DIR/test_external.txt \

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -215,7 +215,7 @@ jobs:
         ss -tlnp | grep -q 8083 && echo "S3 test server is running" \
           || { cat /tmp/momo_s3_test.log; exit 1; }
 
-    - name: Test S3 SigV4 signature bypass
+    - name: Test S3 SigV4 signature bypass (regression)
       id: sigv4
       run: |
         python3 -c "
@@ -227,11 +227,11 @@ jobs:
             r=urllib.request.urlopen(req, timeout=5)
             print(f'SIGV4_BYPASS=true')
             print(f'HTTP {r.status} - SigV4 bypass CONFIRMED with invalid signature')
-            sys.exit(0)
+            sys.exit(1)
         except Exception as e:
             print(f'SIGV4_BYPASS=false')
-            print(f'SigV4 bypass not confirmed: {e}')
-            sys.exit(1)
+            print(f'SigV4 bypass blocked (fix working): {e}')
+            sys.exit(0)
         " 2>&1 | tee /tmp/sigv4_result.txt
 
         if grep -q "SIGV4_BYPASS=true" /tmp/sigv4_result.txt; then
@@ -240,17 +240,24 @@ jobs:
           echo "SIGV4_BYPASS=false" >> $GITHUB_ENV
         fi
 
-    - name: Test S3 PUT with invalid signature
+    - name: Test S3 PUT with invalid signature (regression)
       run: |
         python3 -c "
-        import urllib.request, hashlib
+        import urllib.request, hashlib, sys
         TOKEN='${{ env.MOMO_AUTH_TOKEN }}'
         auth=f'AWS4-HMAC-SHA256 Credential={TOKEN}/20260728/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature={\"0\"*64}'
         content=b'CI pipeline SigV4 bypass test'
         req=urllib.request.Request('http://localhost:8083/ci-bucket/sigv4_test.txt', data=content, method='PUT',
             headers={'Authorization':auth,'x-amz-date':'20260728T120000Z','X-Amz-Content-Sha256':hashlib.sha256(content).hexdigest(),'Content-Length':str(len(content))})
-        r=urllib.request.urlopen(req, timeout=5)
-        print(f'PUT with invalid signature: HTTP {r.status}')
+        try:
+            r=urllib.request.urlopen(req, timeout=5)
+            print(f'PUT with invalid signature: HTTP {r.status} — BYPASS CONFIRMED')
+            sys.exit(1)
+        except urllib.error.HTTPError as e:
+            if e.code == 403:
+                print(f'PUT with invalid signature: HTTP 403 — correctly rejected (fix working)')
+                sys.exit(0)
+            raise
         "
 
     - name: Stop S3 test server

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        471.4n ± ∞ ¹    729.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       344.4n ± ∞ ¹    424.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     875.8n ± ∞ ¹   1066.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.382n ± ∞ ¹    2.291n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.841n ± ∞ ¹    8.876n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.081n ± ∞ ¹    1.913n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4077n ± ∞ ¹   0.4361n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                22.06n          24.69n        +11.95%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        729.8n ± ∞ ¹    427.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       424.1n ± ∞ ¹    327.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1066.0n ± ∞ ¹    806.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.291n ± ∞ ¹    2.302n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.876n ± ∞ ¹   12.080n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.913n ± ∞ ¹    2.128n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4361n ± ∞ ¹   0.5630n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.69n          23.33n        -5.53%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.88 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 424.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 729.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1066.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.08 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 327.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 427.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.56 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.13 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 806.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.30 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cca012e,6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7]
-    line "CheckMetricsAndSwap" [10,10,9,10,11,10,11,9,9,9]
-    line "CrushOptimized" [389,328,292,363,376,378,331,302,344,424]
-    line "CrushOriginal" [544,434,439,438,522,445,479,434,471,730]
-    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,3,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [940,1065,831,831,1196,882,941,800,876,1066]
-    line "PadString" [2,2,2,3,3,2,2,2,2,2]
+    x-axis [6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670]
+    line "CheckMetricsAndSwap" [10,9,10,11,10,11,9,9,9,12]
+    line "CrushOptimized" [328,292,363,376,378,331,302,344,424,328]
+    line "CrushOriginal" [434,439,438,522,445,479,434,471,730,428]
+    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,1]
+    line "IndexSearch" [2,2,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [1065,831,831,1196,882,941,800,876,1066,806]
+    line "PadString" [2,2,3,3,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cca012e,6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7]
+    x-axis [6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cca012e,6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7]
+    x-axis [6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        729.8n ± ∞ ¹    427.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       424.1n ± ∞ ¹    327.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1066.0n ± ∞ ¹    806.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.291n ± ∞ ¹    2.302n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.876n ± ∞ ¹   12.080n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.913n ± ∞ ¹    2.128n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4361n ± ∞ ¹   0.5630n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.69n          23.33n        -5.53%
+CrushOriginal-8                        427.5n ± ∞ ¹    439.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       327.5n ± ∞ ¹    301.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     806.1n ± ∞ ¹    926.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.302n ± ∞ ¹    2.277n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  12.08n ± ∞ ¹    10.33n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.128n ± ∞ ¹    1.615n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5630n ± ∞ ¹   0.3899n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                23.33n          21.03n        -9.87%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 12.08 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 327.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 427.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.13 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 806.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 301.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 439.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 926.50 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.28 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670]
-    line "CheckMetricsAndSwap" [10,9,10,11,10,11,9,9,9,12]
-    line "CrushOptimized" [328,292,363,376,378,331,302,344,424,328]
-    line "CrushOriginal" [434,439,438,522,445,479,434,471,730,428]
-    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,1]
-    line "IndexSearch" [2,2,3,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [1065,831,831,1196,882,941,800,876,1066,806]
-    line "PadString" [2,2,3,3,2,2,2,2,2,2]
+    x-axis [51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf]
+    line "CheckMetricsAndSwap" [9,10,11,10,11,9,9,9,12,10]
+    line "CrushOptimized" [292,363,376,378,331,302,344,424,328,301]
+    line "CrushOriginal" [439,438,522,445,479,434,471,730,428,439]
+    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,1,0]
+    line "IndexSearch" [2,3,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [831,831,1196,882,941,800,876,1066,806,926]
+    line "PadString" [2,3,3,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670]
+    x-axis [51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6217a5a,51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670]
+    x-axis [51d89f3,b9a9671,24142be,06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/external_client_test.go
+++ b/src/transport/external_client_test.go
@@ -15,11 +15,22 @@ func TestS3Communicator_ExternalClientDetection(t *testing.T) {
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
 	t.Run("aws-cli without X-Momo-Requested-Mode is external", func(t *testing.T) {
+		amzDate := "20260604T120000Z"
+		dateStamp := "20260604"
+		region := "us-east-1"
+		payloadHash := "dummyhash"
+		signedHeaders := "host;x-amz-date"
+
+		canonicalRequest := "PUT\n/test-file.txt\n\nhost:127.0.0.1:4440\nx-amz-date:" + amzDate + "\n\n" + signedHeaders + "\n" + payloadHash
+		stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+		signingKey := deriveSigningKey(authToken, dateStamp, region)
+		signature := computeSignature(signingKey, stringToSign)
+
 		reqBody := "PUT /test-file.txt HTTP/1.1\r\n" +
 			"Host: 127.0.0.1:4440\r\n" +
-			"Authorization: AWS4-HMAC-SHA256 Credential=" + authToken + "/20260604/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=dummy\r\n" +
-			"X-Amz-Date: 20260604T120000Z\r\n" +
-			"X-Amz-Content-Sha256: dummyhash\r\n" +
+			"Authorization: AWS4-HMAC-SHA256 Credential=" + authToken + "/" + dateStamp + "/" + region + "/s3/aws4_request, SignedHeaders=" + signedHeaders + ", Signature=" + signature + "\r\n" +
+			"X-Amz-Date: " + amzDate + "\r\n" +
+			"X-Amz-Content-Sha256: " + payloadHash + "\r\n" +
 			"Content-Length: 1024\r\n\r\n"
 
 		clientConn, serverConn := net.Pipe()

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -243,15 +243,18 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 	authHeader := req.Header.Get("Authorization")
 	var token string
+	isSigV4 := false
 	if strings.HasPrefix(authHeader, "Bearer ") {
 		token = strings.TrimPrefix(authHeader, "Bearer ")
 	} else if strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256 ") {
-		// Extract Credential
-		parts := strings.Split(authHeader, "Credential=")
-		if len(parts) > 1 {
-			credPart := strings.Split(parts[1], "/")[0]
-			token = credPart
+		isSigV4 = true
+		components, ok := parseSigV4AuthHeader(authHeader)
+		if !ok {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.conn.Write([]byte("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			return 0, 0, syscall.EACCES
 		}
+		token = components.AccessKey
 	}
 
 	tokenBuf := []byte(common.PadString(token, common.AuthTokenLength))
@@ -259,6 +262,16 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		m.conn.Write([]byte("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 		return 0, 0, syscall.EACCES
+	}
+
+	if isSigV4 {
+		secretKey := common.TrimNullBytesString(expectedAuthToken)
+		if !verifySigV4Signature(req, authHeader, secretKey) {
+			log.Printf("AUDIT: SigV4 signature verification failed from %s", m.conn.RemoteAddr())
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.conn.Write([]byte("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			return 0, 0, syscall.EACCES
+		}
 	}
 
 	// 🛡️ Sentinel: Reject requests containing directory traversal characters (".." or "\") to prevent path traversal attacks.

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -89,8 +89,55 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
-	// AWS v4 style Auth header
-	authHeader := "AWS4-HMAC-SHA256 Credential=" + authToken + "/20260604/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=dummy"
+	amzDate := "20260604T120000Z"
+	dateStamp := "20260604"
+	region := "us-east-1"
+	payloadHash := "dummyhash"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := "PUT\n/test-file2.txt\n\nhost:127.0.0.1:4440\nx-amz-content-sha256:" + payloadHash + "\nx-amz-date:" + amzDate + "\n\n" + signedHeaders + "\n" + payloadHash
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+	signingKey := deriveSigningKey(authToken, dateStamp, region)
+	signature := computeSignature(signingKey, stringToSign)
+
+	authHeader := "AWS4-HMAC-SHA256 Credential=" + authToken + "/" + dateStamp + "/" + region + "/s3/aws4_request, SignedHeaders=" + signedHeaders + ", Signature=" + signature
+
+	reqBody := "PUT /test-file2.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: " + authHeader + "\r\n" +
+		"X-Amz-Date: " + amzDate + "\r\n" +
+		"X-Amz-Content-Sha256: " + payloadHash + "\r\n" +
+		"Content-Length: 2048\r\n\r\n"
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		clientConn.Write([]byte(reqBody))
+		buf := make([]byte, 1024)
+		for {
+			_, err := clientConn.Read(buf)
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	comm := NewS3Communicator(serverConn)
+	_, _, err := comm.HandshakeServer(expectedAuthToken)
+	if err != nil {
+		t.Fatalf("HandshakeServer failed with AWS v4 auth: %v", err)
+	}
+}
+
+func TestS3Communicator_SigV4InvalidSignature(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+	authHeader := "AWS4-HMAC-SHA256 Credential=" + authToken + "/20260604/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=" + strings.Repeat("0", 64)
 
 	reqBody := "PUT /test-file2.txt HTTP/1.1\r\n" +
 		"Host: 127.0.0.1:4440\r\n" +
@@ -105,8 +152,6 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 
 	go func() {
 		clientConn.Write([]byte(reqBody))
-		// ⚡ Bolt: Read in a loop to avoid deadlock on net.Pipe.
-		// http.Response.Write performs multiple writes which will block if not fully consumed.
 		buf := make([]byte, 1024)
 		for {
 			_, err := clientConn.Read(buf)
@@ -118,8 +163,11 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 
 	comm := NewS3Communicator(serverConn)
 	_, _, err := comm.HandshakeServer(expectedAuthToken)
-	if err != nil {
-		t.Fatalf("HandshakeServer failed with AWS v4 auth: %v", err)
+	if err == nil {
+		t.Fatal("HandshakeServer should reject invalid SigV4 signature")
+	}
+	if !errors.Is(err, syscall.EACCES) {
+		t.Fatalf("Expected EACCES for invalid signature, got: %v", err)
 	}
 }
 

--- a/src/transport/sigv4.go
+++ b/src/transport/sigv4.go
@@ -1,0 +1,194 @@
+package transport
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type sigV4Components struct {
+	AccessKey     string
+	DateStamp     string
+	Region        string
+	SignedHeaders string
+	Signature     string
+	AmzDate       string
+}
+
+func parseSigV4AuthHeader(authHeader string) (sigV4Components, bool) {
+	if !strings.HasPrefix(authHeader, "AWS4-HMAC-SHA256 ") {
+		return sigV4Components{}, false
+	}
+
+	rest := strings.TrimPrefix(authHeader, "AWS4-HMAC-SHA256 ")
+	parts := strings.Split(rest, ", ")
+	if len(parts) < 3 {
+		return sigV4Components{}, false
+	}
+
+	var c sigV4Components
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "Credential=") {
+			cred := strings.TrimPrefix(part, "Credential=")
+			credParts := strings.Split(cred, "/")
+			if len(credParts) < 5 {
+				return sigV4Components{}, false
+			}
+			c.AccessKey = credParts[0]
+			c.DateStamp = credParts[1]
+			c.Region = credParts[2]
+		} else if strings.HasPrefix(part, "SignedHeaders=") {
+			c.SignedHeaders = strings.TrimPrefix(part, "SignedHeaders=")
+		} else if strings.HasPrefix(part, "Signature=") {
+			c.Signature = strings.TrimPrefix(part, "Signature=")
+		}
+	}
+
+	if c.AccessKey == "" || c.Signature == "" || c.SignedHeaders == "" {
+		return sigV4Components{}, false
+	}
+	return c, true
+}
+
+func buildCanonicalRequest(req *http.Request, signedHeaders, payloadHash string) string {
+	canonicalURI := req.URL.Path
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	canonicalURI = encodeCanonicalURI(canonicalURI)
+
+	canonicalQueryString := buildCanonicalQueryString(req.URL.Query())
+
+	canonicalHeaders := buildCanonicalHeaders(req, signedHeaders)
+
+	return req.Method + "\n" +
+		canonicalURI + "\n" +
+		canonicalQueryString + "\n" +
+		canonicalHeaders + "\n" +
+		signedHeaders + "\n" +
+		payloadHash
+}
+
+func encodeCanonicalURI(uri string) string {
+	segments := strings.Split(uri, "/")
+	for i, seg := range segments {
+		segments[i] = url.QueryEscape(seg)
+	}
+	encoded := strings.Join(segments, "/")
+	encoded = strings.ReplaceAll(encoded, "+", "%20")
+	return encoded
+}
+
+func buildCanonicalQueryString(values url.Values) string {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteByte('&')
+		}
+		encodedKey := url.QueryEscape(k)
+		encodedKey = strings.ReplaceAll(encodedKey, "+", "%20")
+		sb.WriteString(encodedKey)
+		sb.WriteByte('=')
+		for j, v := range values[k] {
+			if j > 0 {
+				sb.WriteByte('&')
+				sb.WriteString(encodedKey)
+				sb.WriteByte('=')
+			}
+			encodedVal := url.QueryEscape(v)
+			encodedVal = strings.ReplaceAll(encodedVal, "+", "%20")
+			sb.WriteString(encodedVal)
+		}
+	}
+	return sb.String()
+}
+
+func buildCanonicalHeaders(req *http.Request, signedHeadersStr string) string {
+	headerNames := strings.Split(signedHeadersStr, ";")
+	sort.Strings(headerNames)
+
+	var sb strings.Builder
+	for _, h := range headerNames {
+		sb.WriteString(h)
+		sb.WriteByte(':')
+		val := req.Header.Get(h)
+		if h == "host" {
+			val = req.Host
+		}
+		val = strings.TrimSpace(val)
+		sb.WriteString(val)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func deriveSigningKey(secretKey, dateStamp, region string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secretKey), dateStamp)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, "s3")
+	return hmacSHA256(kService, "aws4_request")
+}
+
+func computeSignature(signingKey []byte, stringToSign string) string {
+	return hexHMAC(signingKey, stringToSign)
+}
+
+func buildStringToSign(canonicalRequest, amzDate, dateStamp, region string) string {
+	hashedCanonicalRequest := hexSHA256([]byte(canonicalRequest))
+	credentialScope := dateStamp + "/" + region + "/s3/aws4_request"
+	return "AWS4-HMAC-SHA256\n" + amzDate + "\n" + credentialScope + "\n" + hashedCanonicalRequest
+}
+
+func hexSHA256(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(data))
+	return h.Sum(nil)
+}
+
+func hexHMAC(key []byte, data string) string {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(data))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+var emptyStringSHA256 = hexSHA256(nil)
+
+func verifySigV4Signature(req *http.Request, authHeader, secretKey string) bool {
+	components, ok := parseSigV4AuthHeader(authHeader)
+	if !ok {
+		return false
+	}
+
+	amzDate := req.Header.Get("X-Amz-Date")
+	if amzDate == "" {
+		amzDate = components.AmzDate
+	}
+
+	payloadHash := req.Header.Get("X-Amz-Content-Sha256")
+	if payloadHash == "" {
+		payloadHash = emptyStringSHA256
+	}
+
+	canonicalRequest := buildCanonicalRequest(req, components.SignedHeaders, payloadHash)
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, components.DateStamp, components.Region)
+	signingKey := deriveSigningKey(secretKey, components.DateStamp, components.Region)
+	expectedSig := computeSignature(signingKey, stringToSign)
+
+	return hmac.Equal([]byte(expectedSig), []byte(components.Signature))
+}


### PR DESCRIPTION
## CVE-008: S3 SigV4 Signature Bypass

**Closes #539**

### Problem
The S3 gateway extracted the access key ID from the SigV4 `Authorization` header but never validated the cryptographic signature. Any request with a known access key (auth token) was accepted regardless of the signature value — even an all-zeros signature.

### Fix
Added full SigV4 signature verification in `HandshakeServer`:

- **`src/transport/sigv4.go`** (new): Implements SigV4 verification per AWS SDK spec:
  - `parseSigV4AuthHeader` — parses the `AWS4-HMAC-SHA256` Authorization header
  - `buildCanonicalRequest` / `buildCanonicalHeaders` / `buildCanonicalQueryString` — canonical request construction
  - `deriveSigningKey` — HMAC-SHA256 key derivation chain (kDate → kRegion → kService → kSigning)
  - `verifySigV4Signature` — constant-time signature comparison via `hmac.Equal`

- **`src/transport/s3_communicator.go`**: `HandshakeServer` now verifies the SigV4 signature after validating the access key ID. Bearer auth path is unchanged.

- **Tests updated** to compute real signatures:
  - `TestS3Communicator_AWSV4Auth` — uses a valid computed signature
  - `TestS3Communicator_SigV4InvalidSignature` (new) — verifies an invalid (all-zeros) signature is rejected with `EACCES`
  - `TestS3Communicator_ExternalClientDetection` — uses a valid computed signature

### Verification
- `go test ./src/transport/` — all pass
- `go test ./...` — all pass
- `go vet ./...` — clean
- `gofmt` — clean
- Notsecret scanner — passes