### PR TITLE
Fix CVE-005: Deduplication confusion attack — require proof-of-knowledge for new namespace aliases

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1982,3 +1982,10 @@ c7640ff,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 c7640ff,BenchmarkIndexSearch-8,1.54,0.00,0.00
 c7640ff,BenchmarkLoadGlobalConfig-8,793.90,160.00,1.00
 c7640ff,BenchmarkPadString-8,2.33,0.00,0.00
+4488220,BenchmarkCheckMetricsAndSwap-8,11.24,0.00,0.00
+4488220,BenchmarkCrushOptimized-8,497.40,0.00,0.00
+4488220,BenchmarkCrushOriginal-8,749.80,164.00,3.00
+4488220,BenchmarkIndexDirectTracking-8,0.53,0.00,0.00
+4488220,BenchmarkIndexSearch-8,1.98,0.00,0.00
+4488220,BenchmarkLoadGlobalConfig-8,1212.00,160.00,1.00
+4488220,BenchmarkPadString-8,2.68,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -1989,3 +1989,10 @@ c7640ff,BenchmarkPadString-8,2.33,0.00,0.00
 4488220,BenchmarkIndexSearch-8,1.98,0.00,0.00
 4488220,BenchmarkLoadGlobalConfig-8,1212.00,160.00,1.00
 4488220,BenchmarkPadString-8,2.68,0.00,0.00
+530e62d,BenchmarkCheckMetricsAndSwap-8,8.21,0.00,0.00
+530e62d,BenchmarkCrushOptimized-8,328.90,0.00,0.00
+530e62d,BenchmarkCrushOriginal-8,451.90,164.00,3.00
+530e62d,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+530e62d,BenchmarkIndexSearch-8,1.99,0.00,0.00
+530e62d,BenchmarkLoadGlobalConfig-8,913.00,160.00,1.00
+530e62d,BenchmarkPadString-8,2.03,0.00,0.00

--- a/.github/scripts/test-scale-cas.sh
+++ b/.github/scripts/test-scale-cas.sh
@@ -89,10 +89,9 @@ echo "content3" > $E2E_DIR/file3.txt
 
 sleep 3
 
-# 2. Test Deduplication
-echo "Testing CAS Deduplication (uploading file1 content again as duplicate.txt)..."
-echo "content1" > $E2E_DIR/duplicate.txt
-./bin/momo -imp client -file $E2E_DIR/duplicate.txt -config $E2E_DIR/e2e.conf >> $E2E_DIR/client.log 2>&1
+# 2. Test Deduplication (same filename, same content → should dedup)
+echo "Testing CAS Deduplication (re-uploading file1.txt with same content)..."
+./bin/momo -imp client -file $E2E_DIR/file1.txt -config $E2E_DIR/e2e.conf >> $E2E_DIR/client.log 2>&1
 
 sleep 2
 
@@ -100,6 +99,18 @@ sleep 2
 echo "Verifying Deduplication logs..."
 if ! grep -q "Deduplication hit" $E2E_DIR/s*.log; then
     echo "FAILED: Deduplication hit not found in server logs"
+    exit 1
+fi
+
+# 3. Verify CVE-005 fix: same content under a NEW name must NOT dedup (requires payload)
+echo "Testing CVE-005 fix: new name with same content should not dedup..."
+DEDUP_BEFORE=$(grep -c "Deduplication hit" $E2E_DIR/s*.log 2>/dev/null || echo 0)
+echo "content1" > $E2E_DIR/duplicate.txt
+./bin/momo -imp client -file $E2E_DIR/duplicate.txt -config $E2E_DIR/e2e.conf >> $E2E_DIR/client.log 2>&1
+sleep 2
+DEDUP_AFTER=$(grep -c "Deduplication hit" $E2E_DIR/s*.log 2>/dev/null || echo 0)
+if [ "$DEDUP_AFTER" -ne "$DEDUP_BEFORE" ]; then
+    echo "FAILED: New name should not trigger dedup (CVE-005 regression)"
     exit 1
 fi
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        458.7n ± ∞ ¹    453.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       305.5n ± ∞ ¹    327.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     856.3n ± ∞ ¹    793.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.254n ± ∞ ¹    2.332n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.164n ± ∞ ¹    7.905n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.722n ± ∞ ¹    1.543n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3278n ± ∞ ¹   0.3405n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.92n          19.68n        -1.22%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        453.7n ± ∞ ¹    749.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       327.8n ± ∞ ¹    497.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     793.9n ± ∞ ¹   1212.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.332n ± ∞ ¹    2.676n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.905n ± ∞ ¹   11.240n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.543n ± ∞ ¹    1.981n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3405n ± ∞ ¹   0.5302n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                19.68n          28.23n        +43.43%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 327.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 453.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.54 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 793.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.24 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 497.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 749.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1212.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.68 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff]
-    line "CheckMetricsAndSwap" [10,11,9,9,9,12,10,8,8,8]
-    line "CrushOptimized" [378,331,302,344,424,328,301,314,306,328]
-    line "CrushOriginal" [445,479,434,471,730,428,439,409,459,454]
-    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
+    x-axis [d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220]
+    line "CheckMetricsAndSwap" [11,9,9,9,12,10,8,8,8,11]
+    line "CrushOptimized" [331,302,344,424,328,301,314,306,328,497]
+    line "CrushOriginal" [479,434,471,730,428,439,409,459,454,750]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,1]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [882,941,800,876,1066,806,926,774,856,794]
-    line "PadString" [2,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [941,800,876,1066,806,926,774,856,794,1212]
+    line "PadString" [2,2,2,2,2,2,2,2,2,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff]
+    x-axis [d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [06940c3,d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff]
+    x-axis [d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        453.7n ± ∞ ¹    749.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       327.8n ± ∞ ¹    497.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     793.9n ± ∞ ¹   1212.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.332n ± ∞ ¹    2.676n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.905n ± ∞ ¹   11.240n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.543n ± ∞ ¹    1.981n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3405n ± ∞ ¹   0.5302n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                19.68n          28.23n        +43.43%
+CrushOriginal-8                        749.8n ± ∞ ¹    451.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       497.4n ± ∞ ¹    328.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1212.0n ± ∞ ¹    913.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.676n ± ∞ ¹    2.026n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 11.240n ± ∞ ¹    8.213n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.981n ± ∞ ¹    1.993n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5302n ± ∞ ¹   0.3346n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                28.23n          20.47n        -27.48%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.24 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 497.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 749.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1212.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.68 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.21 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 328.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 451.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 913.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.03 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220]
-    line "CheckMetricsAndSwap" [11,9,9,9,12,10,8,8,8,11]
-    line "CrushOptimized" [331,302,344,424,328,301,314,306,328,497]
-    line "CrushOriginal" [479,434,471,730,428,439,409,459,454,750]
-    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,1]
+    x-axis [aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d]
+    line "CheckMetricsAndSwap" [9,9,9,12,10,8,8,8,11,8]
+    line "CrushOptimized" [302,344,424,328,301,314,306,328,497,329]
+    line "CrushOriginal" [434,471,730,428,439,409,459,454,750,452]
+    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,1,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [941,800,876,1066,806,926,774,856,794,1212]
-    line "PadString" [2,2,2,2,2,2,2,2,2,3]
+    line "LoadGlobalConfig" [800,876,1066,806,926,774,856,794,1212,913]
+    line "PadString" [2,2,2,2,2,2,2,2,3,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220]
+    x-axis [aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [d729a65,aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220]
+    x-axis [aef7e26,0d8ab81,0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/client_extra_test.go
+++ b/src/client/client_extra_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConnect_PrimarySplay(t *testing.T) {
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
-	
+
 	file, err := os.CreateTemp("", "test_splay_*.txt")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
@@ -49,7 +49,7 @@ func TestConnect_PrimarySplay(t *testing.T) {
 
 func TestConnect_PrimarySplay_Failures(t *testing.T) {
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
-	
+
 	file, err := os.CreateTemp("", "test_splay_fail_*.txt")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
@@ -103,7 +103,7 @@ func startMockServerS3(t *testing.T, authToken string, mode int) (string, net.Li
 
 func handleMockConn(conn net.Conn, authToken string, mode int) {
 	defer conn.Close()
-	
+
 	// Handshake
 	buf := make([]byte, common.AuthTokenLength+common.TimestampLength)
 	if _, err := io.ReadFull(conn, buf); err != nil {

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -363,7 +363,7 @@ func TestSendFile_DeduplicationHit(t *testing.T) {
 	}()
 
 	// Server side
-	buf := make([]byte, 64 + common.FileInfoLength + common.FileInfoLength)
+	buf := make([]byte, 64+common.FileInfoLength+common.FileInfoLength)
 	if _, err := io.ReadFull(serverConn, buf); err != nil {
 		t.Fatalf("Server failed to read metadata: %v", err)
 	}

--- a/src/metrics/metrics_extra_test.go
+++ b/src/metrics/metrics_extra_test.go
@@ -13,11 +13,11 @@ func TestGetMetrics_Cancellation(t *testing.T) {
 	cfg := common.Configuration{
 		Global: common.ConfigurationGlobal{
 			PolymorphicSystem: true,
-			ReplicationOrder: []int{1, 2, 3, 4},
-			AuthToken: "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", // notsecret
+			ReplicationOrder:  []int{1, 2, 3, 4},
+			AuthToken:         "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", // notsecret
 		},
 		Metrics: common.ConfigurationMetrics{
-			Interval: 1,
+			Interval:     1,
 			MinThreshold: 0.2,
 			MaxThreshold: 0.8,
 		},
@@ -25,7 +25,6 @@ func TestGetMetrics_Cancellation(t *testing.T) {
 			{Host: "127.0.0.1:45697", ChangeReplication: "127.0.0.1:45696"},
 		},
 	}
-
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -39,7 +38,7 @@ func TestCheckMetricsAndSwap_EdgeCases(t *testing.T) {
 		memStat: &mem.VirtualMemoryStat{UsedPercent: 50.0},
 		cpuStat: []float64{50.0},
 	}
-	
+
 	// Test currentIndex == -1
 	idx, changed := checkMetricsAndSwap(sm, -1, []int{1}, 80.0, 20.0)
 	if idx != -1 || changed {

--- a/src/server/cas_integration_test.go
+++ b/src/server/cas_integration_test.go
@@ -91,9 +91,16 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 						return
 					}
 
-					// Check deduplication
+					// Check deduplication (CVE-005: require proof-of-knowledge for new names)
 					exists, _ := store.Has(meta.Hash)
+					canDedup := false
 					if exists {
+						existingHash, hashErr := store.GetHashForName(meta.Name)
+						if hashErr == nil && existingHash == meta.Hash {
+							canDedup = true
+						}
+					}
+					if canDedup {
 						comm.SendMetadataStatus(transport.MetadataStatusSkipPayload)
 						// Update metadata only
 						store.Put(meta.Name, meta.Hash, meta.Size, "", nil)
@@ -109,12 +116,14 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 
 	// 2. Simulate Client sending tiny files
 	files := []struct {
-		name    string
-		content string
+		name        string
+		content     string
+		expectDedup bool
 	}{
-		{"file1.txt", "tiny content 1"},
-		{"file2.txt", "different content"},
-		{"duplicate.txt", "tiny content 1"}, // Content identical to file1.txt
+		{"file1.txt", "tiny content 1", false},
+		{"file2.txt", "different content", false},
+		{"file1.txt", "tiny content 1", true},      // Same name, same content → dedup
+		{"duplicate.txt", "tiny content 1", false}, // New name, same content → no dedup (CVE-005)
 	}
 
 	// Pre-build ClusterMap
@@ -154,14 +163,13 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 			t.Fatalf("SendMetadata failed: %v", err)
 		}
 
-		if f.name == "duplicate.txt" {
-			// This should be a deduplication hit!
+		if f.expectDedup {
 			if status != transport.MetadataStatusSkipPayload {
-				t.Errorf("Expected SkipPayload for duplicate content, got %d", status)
+				t.Errorf("Expected SkipPayload for %s (dedup), got %d", f.name, status)
 			}
 		} else {
 			if status != transport.MetadataStatusSendPayload {
-				t.Errorf("Expected SendPayload for new content, got %d", status)
+				t.Errorf("Expected SendPayload for %s, got %d", f.name, status)
 			}
 			// Send payload
 			comm.Write(content)

--- a/src/server/contract_test.go
+++ b/src/server/contract_test.go
@@ -16,10 +16,10 @@ import (
 // without a protocol version bump. Tests in this file assert that the server
 // adheres to these exact byte-level contracts.
 const (
-	contractAuthTokenLen  = 64
-	contractTimestampLen  = 19
-	contractModeLen       = 1
-	contractHandshakeLen  = contractAuthTokenLen + contractTimestampLen + contractModeLen // 84
+	contractAuthTokenLen = 64
+	contractTimestampLen = 19
+	contractModeLen      = 1
+	contractHandshakeLen = contractAuthTokenLen + contractTimestampLen + contractModeLen // 84
 
 	contractHashLen     = 64
 	contractFileNameLen = 64

--- a/src/server/metrics_exporter_test.go
+++ b/src/server/metrics_exporter_test.go
@@ -25,15 +25,15 @@ func TestMetricsCollector_Counters(t *testing.T) {
 	output := captureMetricsOutput(mc)
 
 	checks := map[string]string{
-		"momo_connections_total 2":       "connections",
-		"momo_active_connections 1":      "active connections",
-		"momo_uploads_total 3":           "uploads",
-		"momo_bytes_uploaded_total 1024": "bytes uploaded",
-		"momo_downloads_total 1":         "downloads",
+		"momo_connections_total 2":        "connections",
+		"momo_active_connections 1":       "active connections",
+		"momo_uploads_total 3":            "uploads",
+		"momo_bytes_uploaded_total 1024":  "bytes uploaded",
+		"momo_downloads_total 1":          "downloads",
 		"momo_bytes_downloaded_total 512": "bytes downloaded",
-		"momo_deletes_total 1":           "deletes",
-		"momo_replication_total 2":       "replication",
-		"momo_errors_total 1":            "errors",
+		"momo_deletes_total 1":            "deletes",
+		"momo_replication_total 2":        "replication",
+		"momo_errors_total 1":             "errors",
 	}
 
 	for expected, name := range checks {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -334,7 +334,19 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				return
 			}
 
+			// 🛡️ CVE-005: Prevent deduplication confusion attack.
+			// Only skip payload if the name already maps to the same hash (legitimate re-upload).
+			// If the hash exists but the name is new or maps to a different hash, require the
+			// payload as proof of content knowledge before creating a new namespace alias.
+			canDedup := false
 			if exists {
+				existingHash, hashErr := store.GetHashForName(fileName)
+				if hashErr == nil && existingHash == metadata.Hash {
+					canDedup = true
+				}
+			}
+
+			if canDedup {
 				log.Printf("AUDIT: Deduplication hit for %s (hash: %s)", remoteAddr, metadata.Hash)
 				if err := comm.SendMetadataStatus(transport.MetadataStatusSkipPayload); err != nil {
 					log.Printf("AUDIT: Error sending metadata status to %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
@@ -372,7 +384,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			// Handle the file based on the replication mode
 			switch replicationMode {
 			case common.ReplicationNone, common.ReplicationPrimarySplay:
-				if exists {
+				if canDedup {
 					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
 					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
@@ -397,7 +409,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				}
 
 				wg.Add(1)
-				if exists {
+				if canDedup {
 					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
 					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
@@ -448,7 +460,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				// In Splay mode, the primary (first node in placement) forwards to all others.
 				if placement[0].ID == serverId {
 					wg.Add(len(placement) - 1)
-					if exists {
+					if canDedup {
 						// ⚡ Bolt: Deduplication hit. Just update metadata mapping.
 						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
@@ -494,7 +506,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 					wg.Wait()
 				} else {
 					// We are a secondary in a splay, just receive the file if needed.
-					if exists {
+					if canDedup {
 						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
 							metricsCollector.IncErrors()
@@ -515,7 +527,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			}
 			success = true
 			metricsCollector.IncUploads()
-			if !exists {
+			if !canDedup {
 				metricsCollector.AddBytesUploaded(uint64(metadata.Size))
 			}
 		}(connection)

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -176,6 +176,15 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 		if err := s.blobs.PutBlob(hash, content); err != nil {
 			return err
 		}
+	} else if exists && content != nil {
+		// Blob already exists, but we must still drain the content reader.
+		// Callers (e.g., getFile) wrap content in a TeeReader to compute the
+		// hash while streaming. If we skip reading, the TeeReader never reads
+		// from the underlying connection, producing an empty hash and leaving
+		// the payload data unconsumed on the wire.
+		if _, err := io.Copy(io.Discard, content); err != nil {
+			return fmt.Errorf("failed to drain content for existing blob: %w", err)
+		}
 	}
 
 	// 2. Update Metadata

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -65,6 +65,7 @@ type Store interface {
 	Put(name string, hash string, size int64, remotePath string, content io.Reader) error
 	Get(name string) (io.ReadCloser, common.FileMetadata, error)
 	Has(hash string) (bool, error)
+	GetHashForName(name string) (string, error)
 	Delete(name string) error
 	List() ([]common.FileMetadata, error)
 }
@@ -324,6 +325,34 @@ func (s *CASStore) hasInternal(hash string) (bool, error) {
 		return nil
 	})
 	return exists, err
+}
+
+// GetHashForName returns the content hash associated with the given name,
+// or syscall.ENOENT if the name does not exist in the namespace.
+// This is a lightweight metadata-only lookup that does not read the blob.
+func (s *CASStore) GetHashForName(name string) (hash string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in CASStore.GetHashForName for %s: %v", name, r)
+			err = fmt.Errorf("internal storage panic: %w", syscall.EIO)
+		}
+	}()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	err = s.db.View(func(tx *bbolt.Tx) error {
+		if ts := tx.Bucket(bucketTombstones).Get([]byte(name)); ts != nil {
+			return syscall.ENOENT
+		}
+		h := tx.Bucket(bucketNamespace).Get([]byte(name))
+		if h == nil {
+			return syscall.ENOENT
+		}
+		hash = string(h)
+		return nil
+	})
+	return
 }
 
 func (s *CASStore) Delete(name string) (err error) {

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alsotoes/momo/src/common"
 	"go.uber.org/goleak"
 )
 
@@ -280,5 +281,40 @@ func TestCASStore_List(t *testing.T) {
 
 	if len(found) != 3 {
 		t.Errorf("Not all files were found in list: %+v", found)
+	}
+}
+
+func TestCASStore_GetHashForName(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-hashname-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("hello world")
+	hash := common.HashBytes(content)
+
+	if err := store.Put("fileA.txt", hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Failed to Put fileA: %v", err)
+	}
+
+	gotHash, err := store.GetHashForName("fileA.txt")
+	if err != nil {
+		t.Fatalf("GetHashForName failed for existing name: %v", err)
+	}
+	if gotHash != hash {
+		t.Errorf("Expected hash %s, got %s", hash, gotHash)
+	}
+
+	_, err = store.GetHashForName("fileB.txt")
+	if err == nil {
+		t.Errorf("Expected error for non-existent name fileB.txt")
 	}
 }

--- a/src/transport/metrics_hook_test.go
+++ b/src/transport/metrics_hook_test.go
@@ -21,11 +21,11 @@ type mockMetricsHook struct {
 	errors      atomic.Uint64
 }
 
-func (m *mockMetricsHook) IncDownloads()         { m.downloads.Add(1) }
-func (m *mockMetricsHook) IncDeletes()           { m.deletes.Add(1) }
+func (m *mockMetricsHook) IncDownloads()               { m.downloads.Add(1) }
+func (m *mockMetricsHook) IncDeletes()                 { m.deletes.Add(1) }
 func (m *mockMetricsHook) AddBytesDownloaded(n uint64) { m.bytesDL.Add(n) }
-func (m *mockMetricsHook) IncReplication()       { m.replication.Add(1) }
-func (m *mockMetricsHook) IncErrors()            { m.errors.Add(1) }
+func (m *mockMetricsHook) IncReplication()             { m.replication.Add(1) }
+func (m *mockMetricsHook) IncErrors()                  { m.errors.Add(1) }
 
 func runS3TestRequestWithMetrics(t *testing.T, reqStr string, mock storage.Store, hook *mockMetricsHook) string {
 	expectedAuthToken := []byte(common.PadString("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", common.AuthTokenLength)) // notsecret

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -291,11 +291,12 @@ func TestS3Communicator_EdgeCases(t *testing.T) {
 }
 
 type mockStore struct {
-	putFunc    func(name string, hash string, size int64, remotePath string, content io.Reader) error
-	getFunc    func(name string) (io.ReadCloser, common.FileMetadata, error)
-	hasFunc    func(hash string) (bool, error)
-	deleteFunc func(name string) error
-	listFunc   func() ([]common.FileMetadata, error)
+	putFunc            func(name string, hash string, size int64, remotePath string, content io.Reader) error
+	getFunc            func(name string) (io.ReadCloser, common.FileMetadata, error)
+	hasFunc            func(hash string) (bool, error)
+	getHashForNameFunc func(name string) (string, error)
+	deleteFunc         func(name string) error
+	listFunc           func() ([]common.FileMetadata, error)
 }
 
 func (m *mockStore) Close() error { return nil }
@@ -316,6 +317,12 @@ func (m *mockStore) Has(hash string) (bool, error) {
 		return m.hasFunc(hash)
 	}
 	return false, nil
+}
+func (m *mockStore) GetHashForName(name string) (string, error) {
+	if m.getHashForNameFunc != nil {
+		return m.getHashForNameFunc(name)
+	}
+	return "", syscall.ENOENT
 }
 func (m *mockStore) Delete(name string) error {
 	if m.deleteFunc != nil {


### PR DESCRIPTION
## Summary

Fixes #540.

### Problem
An attacker could upload file A with hash H, then send metadata for a different name B with the same hash H. The server accepted the dedup hit without requiring the payload, allowing access to existing content via arbitrary filenames without proof of knowledge.

### Fix
Added `GetHashForName(name)` to the `Store` interface — a lightweight namespace-only lookup (no blob read). The dedup check now uses `canDedup` which is true only when:
1. `store.Has(hash)` — the blob exists, AND
2. `store.GetHashForName(fileName)` returns the same hash — the name already maps to this hash

If the name doesn't exist or maps to a different hash, the server requires the full payload (proof of knowledge). This prevents creating new namespace aliases to existing content without having the content.

### Changes
- `src/storage/storage.go`: Added `GetHashForName` to `Store` interface and `CASStore` implementation. Returns `syscall.ENOENT` for non-existent or tombstoned names.
- `src/server/server.go`: Changed dedup check from `if exists` to `if canDedup` across all 4 replication mode branches. Metrics check updated accordingly.
- `src/storage/storage_test.go`: Added `TestCASStore_GetHashForName`.
- `src/transport/s3_communicator_test.go`: Updated `mockStore` with `GetHashForName` support.

### Testing
- `go test ./...` — all pass
- `go vet ./...` — clean
- `gofmt -l .` — clean
- Notsecret scanner — passes