### PR TITLE
Fix CVE-009: Arbitrary file download via native GET — require content hash proof

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2010,3 +2010,10 @@ a90bb6c,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
 a90bb6c,BenchmarkIndexSearch-8,1.56,0.00,0.00
 a90bb6c,BenchmarkLoadGlobalConfig-8,813.90,160.00,1.00
 a90bb6c,BenchmarkPadString-8,1.99,0.00,0.00
+cd30ae6,BenchmarkCheckMetricsAndSwap-8,7.85,0.00,0.00
+cd30ae6,BenchmarkCrushOptimized-8,302.40,0.00,0.00
+cd30ae6,BenchmarkCrushOriginal-8,396.50,164.00,3.00
+cd30ae6,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+cd30ae6,BenchmarkIndexSearch-8,1.53,0.00,0.00
+cd30ae6,BenchmarkLoadGlobalConfig-8,755.80,160.00,1.00
+cd30ae6,BenchmarkPadString-8,1.90,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2017,3 +2017,10 @@ cd30ae6,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 cd30ae6,BenchmarkIndexSearch-8,1.53,0.00,0.00
 cd30ae6,BenchmarkLoadGlobalConfig-8,755.80,160.00,1.00
 cd30ae6,BenchmarkPadString-8,1.90,0.00,0.00
+33b4539,BenchmarkCheckMetricsAndSwap-8,8.00,0.00,0.00
+33b4539,BenchmarkCrushOptimized-8,314.50,0.00,0.00
+33b4539,BenchmarkCrushOriginal-8,384.80,164.00,3.00
+33b4539,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+33b4539,BenchmarkIndexSearch-8,1.54,0.00,0.00
+33b4539,BenchmarkLoadGlobalConfig-8,752.80,160.00,1.00
+33b4539,BenchmarkPadString-8,1.89,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        400.6n ± ∞ ¹    404.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       300.2n ± ∞ ¹    292.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     776.8n ± ∞ ¹    813.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.224n ± ∞ ¹    1.986n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.569n ± ∞ ¹    7.884n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.756n ± ∞ ¹    1.563n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3172n ± ∞ ¹   0.3595n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                19.28n          18.86n        -2.20%
+CrushOriginal-8                        404.9n ± ∞ ¹    396.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       292.8n ± ∞ ¹    302.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     813.9n ± ∞ ¹    755.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.986n ± ∞ ¹    1.901n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.884n ± ∞ ¹    7.852n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.563n ± ∞ ¹    1.534n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3595n ± ∞ ¹   0.3397n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.86n          18.37n        -2.62%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.88 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 292.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 404.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 813.90 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.85 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 302.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 396.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 755.80 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.90 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c]
-    line "CheckMetricsAndSwap" [9,12,10,8,8,8,11,8,9,8]
-    line "CrushOptimized" [424,328,301,314,306,328,497,329,300,293]
-    line "CrushOriginal" [730,428,439,409,459,454,750,452,401,405]
-    line "IndexDirectTracking" [0,1,0,0,0,0,1,0,0,0]
+    x-axis [893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6]
+    line "CheckMetricsAndSwap" [12,10,8,8,8,11,8,9,8,8]
+    line "CrushOptimized" [328,301,314,306,328,497,329,300,293,302]
+    line "CrushOriginal" [428,439,409,459,454,750,452,401,405,396]
+    line "IndexDirectTracking" [1,0,0,0,0,1,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [1066,806,926,774,856,794,1212,913,777,814]
-    line "PadString" [2,2,2,2,2,2,3,2,2,2]
+    line "LoadGlobalConfig" [806,926,774,856,794,1212,913,777,814,756]
+    line "PadString" [2,2,2,2,2,3,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c]
+    x-axis [893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0f28cb7,893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c]
+    x-axis [893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        404.9n ± ∞ ¹    396.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       292.8n ± ∞ ¹    302.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     813.9n ± ∞ ¹    755.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.986n ± ∞ ¹    1.901n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.884n ± ∞ ¹    7.852n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.563n ± ∞ ¹    1.534n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3595n ± ∞ ¹   0.3397n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.86n          18.37n        -2.62%
+CrushOriginal-8                        396.5n ± ∞ ¹    384.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       302.4n ± ∞ ¹    314.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     755.8n ± ∞ ¹    752.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.901n ± ∞ ¹    1.893n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.852n ± ∞ ¹    7.999n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.534n ± ∞ ¹    1.540n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3397n ± ∞ ¹   0.3408n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.37n          18.44n        +0.38%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.85 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 302.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 396.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 314.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 384.80 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 755.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.54 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 752.80 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6]
-    line "CheckMetricsAndSwap" [12,10,8,8,8,11,8,9,8,8]
-    line "CrushOptimized" [328,301,314,306,328,497,329,300,293,302]
-    line "CrushOriginal" [428,439,409,459,454,750,452,401,405,396]
-    line "IndexDirectTracking" [1,0,0,0,0,1,0,0,0,0]
+    x-axis [19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539]
+    line "CheckMetricsAndSwap" [10,8,8,8,11,8,9,8,8,8]
+    line "CrushOptimized" [301,314,306,328,497,329,300,293,302,314]
+    line "CrushOriginal" [439,409,459,454,750,452,401,405,396,385]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [806,926,774,856,794,1212,913,777,814,756]
-    line "PadString" [2,2,2,2,2,3,2,2,2,2]
+    line "LoadGlobalConfig" [926,774,856,794,1212,913,777,814,756,753]
+    line "PadString" [2,2,2,2,3,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6]
+    x-axis [19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [893a670,19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6]
+    x-axis [19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -99,14 +99,23 @@ When `RequestedMode` is `ModeDelete` (`'D'`), the client requests the deletion o
 
 ### Native File Retrieval (GET - `'G'`)
 
-When `RequestedMode` is `ModeGet` (`'G'`), the client requests the raw binary payload download of a specific file.
+When `RequestedMode` is `ModeGet` (`'G'`), the client requests the raw binary payload download of a specific file. The client must provide a proof-of-knowledge (content hash) to prevent unauthorized file discovery by name alone (CVE-009).
 
 1.  **Handshake:** Completed with `'G'`.
-2.  **Target Name (Client sends):** Client sends the 64-byte null-padded name of the file to retrieve.
+2.  **Target Name + Hash Proof (Client sends):** Client sends a 128-byte request containing:
+    -   **File Name:** 64-byte ASCII string, null-padded (`\x00`).
+    -   **Content Hash:** 64-byte hexadecimal SHA-256 checksum, null-padded (`\x00`).
+
+    ```
+    |------------------|-----------------|
+    | File Name (64)   | Content Hash (64)|
+    |------------------|-----------------|
+    ```
 3.  **Server Response (ACK/Payload):**
+    -   If the content hash does not match the namespace mapping for the given name, the server writes a 1-byte `'1'` (Unauthorized/Not Found) code and closes.
     -   If the file does not exist, the server writes a 1-byte `'1'` (Not Found) code and closes.
     -   If a server error occurs, the server writes a 1-byte `'2'` (Server Error) code and closes.
-    -   If the file exists, the server writes a 1-byte `'0'` (Success) code, followed by a 64-byte null-padded `FileSize` string, followed by the raw binary stream of the file until EOF.
+    -   If the file exists and the hash matches, the server writes a 1-byte `'0'` (Success) code, followed by a 64-byte null-padded `FileSize` string, followed by the raw binary stream of the file until EOF.
 
 ### Payload
 

--- a/pentest/scripts/momo_exploit.py
+++ b/pentest/scripts/momo_exploit.py
@@ -116,12 +116,14 @@ def exploit_download_file(filename):
     s = connect()
     handshake(s, ord('G'), read_response=False)
 
-    s.sendall(pad(filename.encode(), 64))
+    # CVE-009 fix: server now requires content hash (proof-of-knowledge).
+    # Send filename (64 bytes) + dummy hash (64 bytes) — should fail.
+    s.sendall(pad(filename.encode(), 64) + pad(b"0" * 64, 64))
     status = s.recv(1)
     status_code = status[0]
 
     if status_code == ord('1'):
-        print(f"  [-] File '{filename}' not found")
+        print(f"  [-] Download blocked — hash proof required (CVE-009 fix)")
         s.close()
         return None
     elif status_code == ord('2'):

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -424,6 +424,7 @@ func TestMomoQUICCommunicator_NativeDelete(t *testing.T) {
 
 func TestMomoQUICCommunicator_NativeGet(t *testing.T) {
 	fileContent := []byte("download native quic payload!")
+	fileHash := common.HashBytes(fileContent)
 	mock := &mockStore{
 		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
 			if name != "native-quic-get.txt" {
@@ -431,15 +432,23 @@ func TestMomoQUICCommunicator_NativeGet(t *testing.T) {
 			}
 			return io.NopCloser(bytes.NewReader(fileContent)), common.FileMetadata{
 				Name: "native-quic-get.txt",
+				Hash: fileHash,
 				Size: int64(len(fileContent)),
 			}, nil
+		},
+		getHashForNameFunc: func(name string) (string, error) {
+			if name != "native-quic-get.txt" {
+				return "", syscall.ENOENT
+			}
+			return fileHash, nil
 		},
 	}
 
 	clientFn := func(comm Communicator) {
-		// Write target get file (64 bytes padded)
+		// Write target get file (64 bytes padded) + content hash (64 bytes padded)
 		target := common.PadString("native-quic-get.txt", 64)
-		if _, err := comm.Write([]byte(target)); err != nil {
+		hash := common.PadString(fileHash, 64)
+		if _, err := comm.Write([]byte(target + hash)); err != nil {
 			t.Fatalf("Failed to write target: %v", err)
 		}
 

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -279,19 +279,28 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
-		// Read 64-byte file name
+		// Read 64-byte file name + 64-byte content hash (proof of knowledge)
 		m.Stream.SetReadDeadline(time.Now().Add(5 * time.Second))
-		var fileBuf [64]byte
-		if _, err := io.ReadFull(m, fileBuf[:]); err != nil {
+		var requestBuf [128]byte
+		if _, err := io.ReadFull(m, requestBuf[:]); err != nil {
 			return 0, 0, fmt.Errorf("failed to read get target: %w", err)
 		}
-		fileName := common.TrimNullBytesString(fileBuf[:])
+		fileName := common.TrimNullBytesString(requestBuf[:64])
+		providedHash := common.TrimNullBytesString(requestBuf[64:128])
 
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("invalid get target traversal: %s: %w", fileName, syscall.EBADMSG)
+		}
+
+		// 🛡️ CVE-009: Require proof-of-knowledge (content hash) for GET.
+		expectedHash, hashErr := m.store.GetHashForName(fileName)
+		if hashErr != nil || expectedHash != providedHash {
+			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.Write([]byte{'1'}) // not found / unauthorized
+			return 0, 0, ErrRequestHandled
 		}
 
 		rc, meta, err := m.store.Get(fileName)

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -272,19 +272,31 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
-		// Read 64-byte file name
+		// Read 64-byte file name + 64-byte content hash (proof of knowledge)
 		m.SetReadDeadline(time.Now().Add(5 * time.Second))
-		var fileBuf [64]byte
-		if _, err := io.ReadFull(m, fileBuf[:]); err != nil {
+		var requestBuf [128]byte
+		if _, err := io.ReadFull(m, requestBuf[:]); err != nil {
 			return 0, 0, fmt.Errorf("failed to read get target: %w", err)
 		}
-		fileName := common.TrimNullBytesString(fileBuf[:])
+		fileName := common.TrimNullBytesString(requestBuf[:64])
+		providedHash := common.TrimNullBytesString(requestBuf[64:128])
 
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("invalid get target traversal: %s: %w", fileName, syscall.EBADMSG)
+		}
+
+		// 🛡️ CVE-009: Require proof-of-knowledge (content hash) for GET.
+		// The client must provide the file's content hash, which is verified
+		// against the namespace mapping. This prevents downloading files by
+		// name alone without knowing the content hash.
+		expectedHash, hashErr := m.store.GetHashForName(fileName)
+		if hashErr != nil || expectedHash != providedHash {
+			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.Write([]byte{'1'}) // not found / unauthorized
+			return 0, 0, ErrRequestHandled
 		}
 
 		rc, meta, err := m.store.Get(fileName)

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -290,6 +290,7 @@ func TestMomoTCPCommunicator_NativeDelete(t *testing.T) {
 
 func TestMomoTCPCommunicator_NativeGet(t *testing.T) {
 	fileContent := []byte("download native payload!")
+	fileHash := common.HashBytes(fileContent)
 	mock := &mockStore{
 		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
 			if name != "native-get.txt" {
@@ -297,15 +298,23 @@ func TestMomoTCPCommunicator_NativeGet(t *testing.T) {
 			}
 			return io.NopCloser(bytes.NewReader(fileContent)), common.FileMetadata{
 				Name: "native-get.txt",
+				Hash: fileHash,
 				Size: int64(len(fileContent)),
 			}, nil
+		},
+		getHashForNameFunc: func(name string) (string, error) {
+			if name != "native-get.txt" {
+				return "", syscall.ENOENT
+			}
+			return fileHash, nil
 		},
 	}
 
 	clientFn := func(conn net.Conn) {
-		// Write target get file (64 bytes padded)
+		// Write target get file (64 bytes padded) + content hash (64 bytes padded)
 		target := common.PadString("native-get.txt", 64)
-		if _, err := conn.Write([]byte(target)); err != nil {
+		hash := common.PadString(fileHash, 64)
+		if _, err := conn.Write([]byte(target + hash)); err != nil {
 			t.Fatalf("Failed to write target: %v", err)
 		}
 


### PR DESCRIPTION
## CVE-009: Arbitrary File Download via Native GET

**Severity:** HIGH
**Issue:** #542
**Component:** `src/transport/momo_tcp.go`, `src/transport/momo_quic.go`

Resolves #542

### Problem
Any holder of the auth token could download ANY file by name using native GET mode — no proof-of-knowledge required. Combined with LIST (CVE-001), an attacker could enumerate and exfiltrate all stored files.

### Fix
GET handler now reads 128 bytes: 64-byte filename + 64-byte content hash. Server verifies the provided hash matches the namespace mapping via `GetHashForName(fileName)` before serving the file. If the hash doesn't match, the server returns status `1` (error) without serving any content.

This follows the same proof-of-knowledge pattern used in CVE-005 (dedup) — the client must demonstrate they already know the content hash to download by name.

### Changes
- `src/transport/momo_tcp.go`: GET handler reads 128 bytes, verifies hash via `GetHashForName`
- `src/transport/momo_quic.go`: Same changes as TCP
- `src/transport/momo_tcp_test.go`: Updated `TestMomoTCPCommunicator_NativeGet` — mockStore has `getHashForNameFunc`, client sends filename + hash
- `src/transport/factory_test.go`: Updated `TestMomoQUICCommunicator_NativeGet` similarly
- `pentest/scripts/momo_exploit.py`: Download exploit sends dummy hash (all zeros) — should be blocked by server (regression test)

### Reviewer Notes
- **Rule 7 (Protocol Stability):** GET request size changed from 64 to 128 bytes. Both TCP and QUIC implementations updated. S3 communicator uses HTTP range requests, not affected. No external language bindings use native GET mode.
- **Rule 10 (POSIX Error Mapping):** Returns `ErrRequestHandled` on hash mismatch — consistent with existing gateway-level error pattern. Response already written to client.
- **Rule 4/37 (Zero-Crash):** `GetHashForName` already has two-line panic recovery pattern (`log.Printf` + `syscall.EIO`) in `src/storage/storage.go:343-348`.
- **Rule 34 (Benchmark Integrity):** Benchmarks auto-generated by pre-commit hook. No logging in hot loops.

### Testing
- `go test ./...` passes
- `go vet ./...` clean
- `gofmt -l .` clean
- notsecret check passes