### PR TITLE
Fix CVE-003: Arbitrary file deletion via native DELETE — require content hash proof

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2024,3 +2024,10 @@ cd30ae6,BenchmarkPadString-8,1.90,0.00,0.00
 33b4539,BenchmarkIndexSearch-8,1.54,0.00,0.00
 33b4539,BenchmarkLoadGlobalConfig-8,752.80,160.00,1.00
 33b4539,BenchmarkPadString-8,1.89,0.00,0.00
+fe922ae,BenchmarkCheckMetricsAndSwap-8,8.25,0.00,0.00
+fe922ae,BenchmarkCrushOptimized-8,290.10,0.00,0.00
+fe922ae,BenchmarkCrushOriginal-8,391.70,164.00,3.00
+fe922ae,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+fe922ae,BenchmarkIndexSearch-8,1.56,0.00,0.00
+fe922ae,BenchmarkLoadGlobalConfig-8,728.60,160.00,1.00
+fe922ae,BenchmarkPadString-8,2.00,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        396.5n ± ∞ ¹    384.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       302.4n ± ∞ ¹    314.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     755.8n ± ∞ ¹    752.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.901n ± ∞ ¹    1.893n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.852n ± ∞ ¹    7.999n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.534n ± ∞ ¹    1.540n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3397n ± ∞ ¹   0.3408n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.37n          18.44n        +0.38%
+CrushOriginal-8                        384.8n ± ∞ ¹    391.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       314.5n ± ∞ ¹    290.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     752.8n ± ∞ ¹    728.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.893n ± ∞ ¹    2.005n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.999n ± ∞ ¹    8.253n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.540n ± ∞ ¹    1.562n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3408n ± ∞ ¹   0.3404n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                18.44n          18.45n        +0.09%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 314.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 384.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.25 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 290.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 391.70 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.54 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 752.80 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.56 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 728.60 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539]
-    line "CheckMetricsAndSwap" [10,8,8,8,11,8,9,8,8,8]
-    line "CrushOptimized" [301,314,306,328,497,329,300,293,302,314]
-    line "CrushOriginal" [439,409,459,454,750,452,401,405,396,385]
-    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
+    x-axis [e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae]
+    line "CheckMetricsAndSwap" [8,8,8,11,8,9,8,8,8,8]
+    line "CrushOptimized" [314,306,328,497,329,300,293,302,314,290]
+    line "CrushOriginal" [409,459,454,750,452,401,405,396,385,392]
+    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [926,774,856,794,1212,913,777,814,756,753]
-    line "PadString" [2,2,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [774,856,794,1212,913,777,814,756,753,729]
+    line "PadString" [2,2,2,3,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539]
+    x-axis [e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [19fffcf,e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539]
+    x-axis [e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -91,11 +91,19 @@ When `RequestedMode` is `ModeList` (`'L'`), the client queries the list of all f
 
 ### Native File Deletion (DELETE - `'D'`)
 
-When `RequestedMode` is `ModeDelete` (`'D'`), the client requests the deletion of a specific file.
+When `RequestedMode` is `ModeDelete` (`'D'`), the client requests the deletion of a specific file. The client must provide a proof-of-knowledge (content hash) to prevent unauthorized file deletion by name alone (CVE-003).
 
 1.  **Handshake:** Completed with `'D'`.
-2.  **Target Name (Client sends):** Client sends the 64-byte null-padded name of the file to delete.
-3.  **Server Response (ACK):** Server deletes the mapping on BoltDB and responds with a 1-byte status code (`'0'` for success, `'1'` for error).
+2.  **Target Name + Hash Proof (Client sends):** Client sends a 128-byte request containing:
+    -   **File Name:** 64-byte ASCII string, null-padded (`\x00`).
+    -   **Content Hash:** 64-byte hexadecimal SHA-256 checksum, null-padded (`\x00`).
+
+    ```
+    |------------------|-----------------|
+    | File Name (64)   | Content Hash (64)|
+    |------------------|-----------------|
+    ```
+3.  **Server Response (ACK):** Server verifies the content hash matches the namespace mapping, then deletes the mapping on BoltDB and responds with a 1-byte status code (`'0'` for success, `'1'` for error/unauthorized).
 
 ### Native File Retrieval (GET - `'G'`)
 

--- a/pentest/scripts/momo_exploit.py
+++ b/pentest/scripts/momo_exploit.py
@@ -149,24 +149,27 @@ def exploit_download_file(filename):
     return content
 
 # ============================================================
-# EXPLOIT 3: Arbitrary File Deletion (DELETE)
-# Any holder of the auth token can delete ANY file by name.
+# EXPLOIT 3: Arbitrary File Deletion (DELETE) — CVE-003
+# Fixed: Server now requires content hash proof. This exploit
+# sends a dummy hash and should be blocked (regression test).
 # ============================================================
 def exploit_delete_file(filename):
     print("\n" + "="*60)
-    print(f"EXPLOIT 3: Arbitrary File Deletion ({filename})")
+    print(f"EXPLOIT 3: Arbitrary File Deletion ({filename}) — CVE-003 regression")
     print("="*60)
     s = connect()
     handshake(s, ord('D'), read_response=False)
 
-    s.sendall(pad(filename.encode(), 64))
+    # Send filename + dummy hash (all zeros) — server should reject
+    dummy_hash = b'\x00' * 64
+    s.sendall(pad(filename.encode(), 64) + dummy_hash)
     status = s.recv(1)
     status_code = status[0]
 
     if status_code == ord('0'):
-        print(f"  [+] File '{filename}' deleted successfully")
+        print(f"  [!] VULNERABLE: File '{filename}' deleted without hash proof!")
     else:
-        print(f"  [-] Delete failed for '{filename}' (status={status_code})")
+        print(f"  [+] Blocked: Delete rejected without valid hash proof (status={status_code})")
 
     s.close()
 

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -391,17 +391,25 @@ func TestMomoQUICCommunicator_NativeList(t *testing.T) {
 
 func TestMomoQUICCommunicator_NativeDelete(t *testing.T) {
 	deletedKey := ""
+	fileHash := common.HashBytes([]byte("delete-me-quic-content"))
 	mock := &mockStore{
 		deleteFunc: func(name string) error {
 			deletedKey = name
 			return nil
 		},
+		getHashForNameFunc: func(name string) (string, error) {
+			if name != "target-to-delete-quic.txt" {
+				return "", syscall.ENOENT
+			}
+			return fileHash, nil
+		},
 	}
 
 	clientFn := func(comm Communicator) {
-		// Write target delete file (64 bytes padded)
+		// Write target delete file (64 bytes padded) + content hash (64 bytes padded)
 		target := common.PadString("target-to-delete-quic.txt", 64)
-		if _, err := comm.Write([]byte(target)); err != nil {
+		hash := common.PadString(fileHash, 64)
+		if _, err := comm.Write([]byte(target + hash)); err != nil {
 			t.Fatalf("Failed to write target: %v", err)
 		}
 

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -232,19 +232,31 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
-		// Read 64-byte file name
+		// Read 64-byte file name + 64-byte content hash (proof of knowledge)
 		m.Stream.SetReadDeadline(time.Now().Add(5 * time.Second))
-		var fileBuf [64]byte
-		if _, err := io.ReadFull(m, fileBuf[:]); err != nil {
+		var requestBuf [128]byte
+		if _, err := io.ReadFull(m, requestBuf[:]); err != nil {
 			return 0, 0, fmt.Errorf("failed to read delete target: %w", err)
 		}
-		fileName := common.TrimNullBytesString(fileBuf[:])
+		fileName := common.TrimNullBytesString(requestBuf[:64])
+		providedHash := common.TrimNullBytesString(requestBuf[64:128])
 
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("invalid delete target traversal: %s: %w", fileName, syscall.EBADMSG)
+		}
+
+		// 🛡️ CVE-003: Require proof-of-knowledge (content hash) for DELETE.
+		// The client must provide the file's content hash, which is verified
+		// against the namespace mapping. This prevents deleting files by
+		// name alone without knowing the content hash.
+		expectedHash, hashErr := m.store.GetHashForName(fileName)
+		if hashErr != nil || expectedHash != providedHash {
+			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.Write([]byte{'1'}) // not found / unauthorized
+			return 0, 0, ErrRequestHandled
 		}
 
 		if m.leaseAcquirer != nil {

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -225,19 +225,31 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
-		// Read 64-byte file name
+		// Read 64-byte file name + 64-byte content hash (proof of knowledge)
 		m.SetReadDeadline(time.Now().Add(5 * time.Second))
-		var fileBuf [64]byte
-		if _, err := io.ReadFull(m, fileBuf[:]); err != nil {
+		var requestBuf [128]byte
+		if _, err := io.ReadFull(m, requestBuf[:]); err != nil {
 			return 0, 0, fmt.Errorf("failed to read delete target: %w", err)
 		}
-		fileName := common.TrimNullBytesString(fileBuf[:])
+		fileName := common.TrimNullBytesString(requestBuf[:64])
+		providedHash := common.TrimNullBytesString(requestBuf[64:128])
 
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.Write([]byte{'1'}) // error status
 			return 0, 0, fmt.Errorf("invalid delete target traversal: %s: %w", fileName, syscall.EBADMSG)
+		}
+
+		// 🛡️ CVE-003: Require proof-of-knowledge (content hash) for DELETE.
+		// The client must provide the file's content hash, which is verified
+		// against the namespace mapping. This prevents deleting files by
+		// name alone without knowing the content hash.
+		expectedHash, hashErr := m.store.GetHashForName(fileName)
+		if hashErr != nil || expectedHash != providedHash {
+			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.Write([]byte{'1'}) // not found / unauthorized
+			return 0, 0, ErrRequestHandled
 		}
 
 		if m.leaseAcquirer != nil {

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -257,17 +257,25 @@ func TestMomoTCPCommunicator_NativeList(t *testing.T) {
 
 func TestMomoTCPCommunicator_NativeDelete(t *testing.T) {
 	deletedKey := ""
+	fileHash := common.HashBytes([]byte("delete-me-content"))
 	mock := &mockStore{
 		deleteFunc: func(name string) error {
 			deletedKey = name
 			return nil
 		},
+		getHashForNameFunc: func(name string) (string, error) {
+			if name != "target-to-delete.txt" {
+				return "", syscall.ENOENT
+			}
+			return fileHash, nil
+		},
 	}
 
 	clientFn := func(conn net.Conn) {
-		// Write target delete file (64 bytes padded)
+		// Write target delete file (64 bytes padded) + content hash (64 bytes padded)
 		target := common.PadString("target-to-delete.txt", 64)
-		if _, err := conn.Write([]byte(target)); err != nil {
+		hash := common.PadString(fileHash, 64)
+		if _, err := conn.Write([]byte(target + hash)); err != nil {
 			t.Fatalf("Failed to write target: %v", err)
 		}
 


### PR DESCRIPTION
## CVE-003: Arbitrary File Deletion via Native DELETE

**Severity:** HIGH
**Issue:** #543
**Component:** `src/transport/momo_tcp.go`, `src/transport/momo_quic.go`

Resolves #543

### Problem
Any holder of the auth token could delete ANY file by name using native DELETE mode — no proof-of-knowledge required. An attacker could delete arbitrary files, causing data loss and availability impact.

### Fix
DELETE handler now reads 128 bytes: 64-byte filename + 64-byte content hash. Server verifies the provided hash matches the namespace mapping via `GetHashForName(fileName)` before deleting the file. If the hash doesn't match, the server returns status `1` (error) without deleting.

This follows the same proof-of-knowledge pattern used in CVE-009 (GET) and CVE-005 (dedup).

### Changes
- `src/transport/momo_tcp.go`: DELETE handler reads 128 bytes, verifies hash via `GetHashForName`
- `src/transport/momo_quic.go`: Same changes as TCP
- `src/transport/momo_tcp_test.go`: Updated `TestMomoTCPCommunicator_NativeDelete` — mockStore has `getHashForNameFunc`, client sends filename + hash
- `src/transport/factory_test.go`: Updated `TestMomoQUICCommunicator_NativeDelete` similarly
- `pentest/scripts/momo_exploit.py`: Delete exploit sends dummy hash (all zeros) — should be blocked by server (regression test)
- `docs/PROTOCOL.md`: Updated DELETE section to document 128-byte request format (Rule 27)

### Reviewer Notes
- **Rule 7 (Protocol Stability):** DELETE request size changed from 64 to 128 bytes. Both TCP and QUIC implementations updated. S3 communicator uses HTTP DELETE, not affected.
- **Rule 10 (POSIX Error Mapping):** Returns `ErrRequestHandled` on hash mismatch — consistent with existing gateway-level error pattern.
- **Rule 4/37 (Zero-Crash):** `HandshakeServer` already has `defer recover()` block. `GetHashForName` has panic recovery in `src/storage/storage.go`.
- **Rule 11 (Traceability):** `Resolves #543` included in PR body and commit message.
- **Rule 27 (Documentation):** `docs/PROTOCOL.md` updated with new 128-byte DELETE format.

### Testing
- `go test ./...` passes
- `go vet ./...` clean
- `gofmt -l .` clean
- notsecret check passes