### PR TITLE
fix: restrict native LIST to peer connections only — CVE-001

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2031,3 +2031,10 @@ fe922ae,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 fe922ae,BenchmarkIndexSearch-8,1.56,0.00,0.00
 fe922ae,BenchmarkLoadGlobalConfig-8,728.60,160.00,1.00
 fe922ae,BenchmarkPadString-8,2.00,0.00,0.00
+e2febb4,BenchmarkCheckMetricsAndSwap-8,8.47,0.00,0.00
+e2febb4,BenchmarkCrushOptimized-8,341.20,0.00,0.00
+e2febb4,BenchmarkCrushOriginal-8,484.00,164.00,3.00
+e2febb4,BenchmarkIndexDirectTracking-8,0.51,0.00,0.00
+e2febb4,BenchmarkIndexSearch-8,1.89,0.00,0.00
+e2febb4,BenchmarkLoadGlobalConfig-8,912.10,160.00,1.00
+e2febb4,BenchmarkPadString-8,1.99,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        384.8n ± ∞ ¹    391.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       314.5n ± ∞ ¹    290.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     752.8n ± ∞ ¹    728.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.893n ± ∞ ¹    2.005n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.999n ± ∞ ¹    8.253n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.540n ± ∞ ¹    1.562n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3408n ± ∞ ¹   0.3404n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                18.44n          18.45n        +0.09%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        753.4n ± ∞ ¹    484.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       505.8n ± ∞ ¹    341.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1464.0n ± ∞ ¹    912.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            3.406n ± ∞ ¹    1.989n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 13.140n ± ∞ ¹    8.473n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.173n ± ∞ ¹    1.893n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5241n ± ∞ ¹   0.5077n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                31.15n          21.93n        -29.59%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.25 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 290.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 391.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 728.60 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 341.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 484.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.51 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 912.10 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae]
-    line "CheckMetricsAndSwap" [8,8,8,11,8,9,8,8,8,8]
-    line "CrushOptimized" [314,306,328,497,329,300,293,302,314,290]
-    line "CrushOriginal" [409,459,454,750,452,401,405,396,385,392]
-    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
+    x-axis [cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4]
+    line "CheckMetricsAndSwap" [8,8,11,8,9,8,8,8,8,8]
+    line "CrushOptimized" [306,328,497,329,300,293,302,314,290,341]
+    line "CrushOriginal" [459,454,750,452,401,405,396,385,392,484]
+    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,1]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [774,856,794,1212,913,777,814,756,753,729]
-    line "PadString" [2,2,2,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [856,794,1212,913,777,814,756,753,729,912]
+    line "PadString" [2,2,3,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae]
+    x-axis [cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e685736,cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae]
+    x-axis [cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -70,9 +70,9 @@ The metadata consists of three fixed-size fields:
 
 ### Native Directory Listing (LIST - `'L'`)
 
-When `RequestedMode` is `ModeList` (`'L'`), the client queries the list of all file metadata stored on the server.
+When `RequestedMode` is `ModeList` (`'L'`), the client queries the list of all file metadata stored on the server. This operation is restricted to peer connections only (authenticated with the derived peer token) to prevent file enumeration by direct clients (CVE-001). Non-peer connections receive a 0-count empty list.
 
-1.  **Handshake:** Completed with `'L'`.
+1.  **Handshake:** Completed with `'L'`. Must use the derived peer token.
 2.  **Server Response (File Count):** Server writes a 4-byte big-endian integer representing the number of files:
     ```
     |-----------------|

--- a/pentest/scripts/momo_exploit.py
+++ b/pentest/scripts/momo_exploit.py
@@ -74,12 +74,13 @@ def recv_ack(s):
     return data
 
 # ============================================================
-# EXPLOIT 1: Unauthenticated Information Disclosure (LIST)
-# Any holder of the auth token can enumerate ALL files.
+# EXPLOIT 1: Information Disclosure (LIST) — CVE-001
+# Blocked: LIST is restricted to peer connections only.
+# Direct clients receive a 0-count empty list.
 # ============================================================
 def exploit_list_all_files():
     print("\n" + "="*60)
-    print("EXPLOIT 1: List All Files (Information Disclosure)")
+    print("EXPLOIT 1: List All Files (Information Disclosure) — CVE-001")
     print("="*60)
     s = connect()
     handshake(s, ord('L'), read_response=False)
@@ -92,6 +93,9 @@ def exploit_list_all_files():
         count_data += chunk
     file_count = struct.unpack('>I', count_data)[0]
     print(f"  [*] Total files on server: {file_count}")
+
+    if file_count == 0:
+        print("  [-] Blocked: LIST restricted to peer connections only (CVE-001 fix)")
 
     files = []
     for i in range(file_count):

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -283,7 +283,7 @@ func TestMomoQUICCommunicator_EdgeCases(t *testing.T) {
 	}
 }
 
-func runNativeQUICTest(t *testing.T, requestedMode int, clientFn func(Communicator), mock *mockStore) {
+func runNativeQUICTest(t *testing.T, requestedMode int, clientFn func(Communicator), mock *mockStore, usePeerToken bool) {
 	authToken := "test-token" // notsecret
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	addr := "127.0.0.1:0"
@@ -330,8 +330,12 @@ func runNativeQUICTest(t *testing.T, requestedMode int, clientFn func(Communicat
 	defer clientComm.Close()
 
 	// Write Handshake manually to bypass HandshakeClient's ACK expectation
+	tokenToSend := authToken
+	if usePeerToken {
+		tokenToSend = string(common.DerivePeerToken(expectedAuthToken))
+	}
 	var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
-	copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
+	copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(tokenToSend, common.AuthTokenLength))
 	copy(handshakeBuf[common.AuthTokenLength:], common.PadString("1557906926566451195", common.TimestampLength))
 	handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode)
 
@@ -386,7 +390,29 @@ func TestMomoQUICCommunicator_NativeList(t *testing.T) {
 		}
 	}
 
-	runNativeQUICTest(t, common.ModeList, clientFn, mock)
+	runNativeQUICTest(t, common.ModeList, clientFn, mock, true)
+}
+
+func TestMomoQUICCommunicator_NativeListDeniedForClient(t *testing.T) {
+	mock := &mockStore{
+		listFunc: func() ([]common.FileMetadata, error) {
+			return []common.FileMetadata{
+				{Name: "secret-quic-file.txt", Hash: "secret-quic-hash", Size: 999},
+			}, nil
+		},
+	}
+
+	clientFn := func(comm Communicator) {
+		var fileCount int32
+		if err := binary.Read(comm, binary.BigEndian, &fileCount); err != nil {
+			t.Fatalf("Failed to read file count: %v", err)
+		}
+		if fileCount != 0 {
+			t.Fatalf("Expected file count 0 for non-peer client, got %d", fileCount)
+		}
+	}
+
+	runNativeQUICTest(t, common.ModeList, clientFn, mock, false)
 }
 
 func TestMomoQUICCommunicator_NativeDelete(t *testing.T) {
@@ -423,7 +449,7 @@ func TestMomoQUICCommunicator_NativeDelete(t *testing.T) {
 		}
 	}
 
-	runNativeQUICTest(t, common.ModeDelete, clientFn, mock)
+	runNativeQUICTest(t, common.ModeDelete, clientFn, mock, false)
 
 	if deletedKey != "target-to-delete-quic.txt" {
 		t.Errorf("Expected store.Delete to be called with 'target-to-delete-quic.txt', got %q", deletedKey)
@@ -485,5 +511,5 @@ func TestMomoQUICCommunicator_NativeGet(t *testing.T) {
 		}
 	}
 
-	runNativeQUICTest(t, common.ModeGet, clientFn, mock)
+	runNativeQUICTest(t, common.ModeGet, clientFn, mock, false)
 }

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -178,6 +178,16 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 
 	// 🛡️ Sentinel: Handle non-replication API queries (LIST, DELETE, GET) natively on Momo-QUIC.
 	if requestedMode == common.ModeList {
+		// 🛡️ CVE-001: Restrict LIST to peer connections only.
+		// Direct clients cannot enumerate all files. Peers need LIST for
+		// replication (scatter-gather). Clients should track their own files.
+		if !m.isPeer {
+			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			var emptyCount [4]byte
+			binary.BigEndian.PutUint32(emptyCount[:], 0)
+			m.Write(emptyCount[:])
+			return 0, 0, ErrRequestHandled
+		}
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -171,6 +171,16 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 
 	// 🛡️ Sentinel: Handle non-replication API queries (LIST, DELETE, GET) natively on Momo-TCP.
 	if requestedMode == common.ModeList {
+		// 🛡️ CVE-001: Restrict LIST to peer connections only.
+		// Direct clients cannot enumerate all files. Peers need LIST for
+		// replication (scatter-gather). Clients should track their own files.
+		if !m.isPeer {
+			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			var emptyCount [4]byte
+			binary.BigEndian.PutUint32(emptyCount[:], 0)
+			m.Write(emptyCount[:])
+			return 0, 0, ErrRequestHandled
+		}
 		if m.store == nil {
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -158,7 +158,7 @@ func TestMomoTCPCommunicator_EdgeCases(t *testing.T) {
 	}
 }
 
-func runNativeTCPTest(t *testing.T, requestedMode int, clientFn func(net.Conn), mock *mockStore) {
+func runNativeTCPTest(t *testing.T, requestedMode int, clientFn func(net.Conn), mock *mockStore, usePeerToken bool) {
 	authToken := "test-token-1234567890123456789012345678901234567890123456789012345" // notsecret
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	addr := "127.0.0.1:0"
@@ -196,8 +196,12 @@ func runNativeTCPTest(t *testing.T, requestedMode int, clientFn func(net.Conn), 
 	defer conn.Close()
 
 	// Write Handshake
+	tokenToSend := authToken
+	if usePeerToken {
+		tokenToSend = string(common.DerivePeerToken(expectedAuthToken))
+	}
 	var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
-	copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
+	copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(tokenToSend, common.AuthTokenLength))
 	copy(handshakeBuf[common.AuthTokenLength:], common.PadString("1557906926566451195", common.TimestampLength))
 	handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode)
 
@@ -252,7 +256,29 @@ func TestMomoTCPCommunicator_NativeList(t *testing.T) {
 		}
 	}
 
-	runNativeTCPTest(t, common.ModeList, clientFn, mock)
+	runNativeTCPTest(t, common.ModeList, clientFn, mock, true)
+}
+
+func TestMomoTCPCommunicator_NativeListDeniedForClient(t *testing.T) {
+	mock := &mockStore{
+		listFunc: func() ([]common.FileMetadata, error) {
+			return []common.FileMetadata{
+				{Name: "secret-file.txt", Hash: "secret-hash", Size: 999},
+			}, nil
+		},
+	}
+
+	clientFn := func(conn net.Conn) {
+		var fileCount int32
+		if err := binary.Read(conn, binary.BigEndian, &fileCount); err != nil {
+			t.Fatalf("Failed to read file count: %v", err)
+		}
+		if fileCount != 0 {
+			t.Fatalf("Expected file count 0 for non-peer client, got %d", fileCount)
+		}
+	}
+
+	runNativeTCPTest(t, common.ModeList, clientFn, mock, false)
 }
 
 func TestMomoTCPCommunicator_NativeDelete(t *testing.T) {
@@ -289,7 +315,7 @@ func TestMomoTCPCommunicator_NativeDelete(t *testing.T) {
 		}
 	}
 
-	runNativeTCPTest(t, common.ModeDelete, clientFn, mock)
+	runNativeTCPTest(t, common.ModeDelete, clientFn, mock, false)
 
 	if deletedKey != "target-to-delete.txt" {
 		t.Errorf("Expected store.Delete to be called with 'target-to-delete.txt', got %q", deletedKey)
@@ -351,7 +377,7 @@ func TestMomoTCPCommunicator_NativeGet(t *testing.T) {
 		}
 	}
 
-	runNativeTCPTest(t, common.ModeGet, clientFn, mock)
+	runNativeTCPTest(t, common.ModeGet, clientFn, mock, false)
 }
 
 func TestMomoTCPCommunicator_SendMetadataPathTraversal(t *testing.T) {


### PR DESCRIPTION
Resolves #544

## CVE-001: Arbitrary File Enumeration via Native LIST

**Severity:** MEDIUM
**Component:** `src/transport/momo_tcp.go`, `src/transport/momo_quic.go`

### Problem
Any holder of the auth token can enumerate ALL files on the server using native LIST mode. This returns all filenames, content hashes, and sizes — bypassing the CVE-009 (GET) and CVE-003 (DELETE) hash-proof protections, since an attacker can discover the required hashes via LIST.

### Fix
Restrict native LIST to peer connections only (`m.isPeer == true`). Direct clients (authenticated with the regular auth token) receive a 0-count empty list. Peers (authenticated with the derived peer token) retain full LIST access for replication scatter-gather.

This is consistent with the existing security model:
- **GET** requires proof-of-knowledge (content hash) — CVE-009
- **DELETE** requires proof-of-knowledge (content hash) — CVE-003
- **LIST** restricted to peer connections only — CVE-001
- Clients should track their own files (they uploaded them with PUT)
- S3 clients have their own listing via the S3 API (`?list-type=2`)

### Changes
- `src/transport/momo_tcp.go`: Added `!m.isPeer` gate at top of LIST handler — writes 0-count and returns `ErrRequestHandled` for non-peers
- `src/transport/momo_quic.go`: Same change
- `src/transport/momo_tcp_test.go`: Added `usePeerToken bool` param to `runNativeTCPTest`; updated `NativeList` to use peer token; added `NativeListDeniedForClient` test (auth token → 0 count)
- `src/transport/factory_test.go`: Same pattern for QUIC tests
- `pentest/scripts/momo_exploit.py`: Updated `exploit_list_all_files` to report blocked (0 files = regression test)
- `docs/PROTOCOL.md`: Documented LIST is peer-only

### Test Coverage
- `TestMomoTCPCommunicator_NativeList` — peer token → full list (unchanged behavior)
- `TestMomoTCPCommunicator_NativeListDeniedForClient` — auth token → 0 count (new)
- `TestMomoQUICCommunicator_NativeList` — peer token → full list (unchanged behavior)
- `TestMomoQUICCommunicator_NativeListDeniedForClient` — auth token → 0 count (new)