### PR TITLE
fix: immediately delete blob content on Delete when refcount reaches 0 — CVE-006

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2038,3 +2038,10 @@ e2febb4,BenchmarkIndexDirectTracking-8,0.51,0.00,0.00
 e2febb4,BenchmarkIndexSearch-8,1.89,0.00,0.00
 e2febb4,BenchmarkLoadGlobalConfig-8,912.10,160.00,1.00
 e2febb4,BenchmarkPadString-8,1.99,0.00,0.00
+1acac21,BenchmarkCheckMetricsAndSwap-8,15.42,0.00,0.00
+1acac21,BenchmarkCrushOptimized-8,544.00,0.00,0.00
+1acac21,BenchmarkCrushOriginal-8,832.60,164.00,3.00
+1acac21,BenchmarkIndexDirectTracking-8,0.76,0.00,0.00
+1acac21,BenchmarkIndexSearch-8,3.01,0.00,0.00
+1acac21,BenchmarkLoadGlobalConfig-8,1568.00,160.00,1.00
+1acac21,BenchmarkPadString-8,3.52,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        753.4n ± ∞ ¹    484.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       505.8n ± ∞ ¹    341.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1464.0n ± ∞ ¹    912.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            3.406n ± ∞ ¹    1.989n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 13.140n ± ∞ ¹    8.473n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.173n ± ∞ ¹    1.893n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.5241n ± ∞ ¹   0.5077n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                31.15n          21.93n        -29.59%
+CrushOriginal-8                        484.0n ± ∞ ¹    832.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       341.2n ± ∞ ¹    544.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     912.1n ± ∞ ¹   1568.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.989n ± ∞ ¹    3.515n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.473n ± ∞ ¹   15.420n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.893n ± ∞ ¹    3.009n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5077n ± ∞ ¹   0.7590n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                21.93n          36.60n        +66.87%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 341.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 484.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.51 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 912.10 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 15.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 544.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 832.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.76 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.01 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1568.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 3.52 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4]
-    line "CheckMetricsAndSwap" [8,8,11,8,9,8,8,8,8,8]
-    line "CrushOptimized" [306,328,497,329,300,293,302,314,290,341]
-    line "CrushOriginal" [459,454,750,452,401,405,396,385,392,484]
-    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,1]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [856,794,1212,913,777,814,756,753,729,912]
-    line "PadString" [2,2,3,2,2,2,2,2,2,2]
+    x-axis [c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21]
+    line "CheckMetricsAndSwap" [8,11,8,9,8,8,8,8,8,15]
+    line "CrushOptimized" [328,497,329,300,293,302,314,290,341,544]
+    line "CrushOriginal" [454,750,452,401,405,396,385,392,484,833]
+    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,1,1]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,2,3]
+    line "LoadGlobalConfig" [794,1212,913,777,814,756,753,729,912,1568]
+    line "PadString" [2,3,2,2,2,2,2,2,2,4]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4]
+    x-axis [c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cef07b6,c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4]
+    x-axis [c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/pentest/scripts/momo_exploit.py
+++ b/pentest/scripts/momo_exploit.py
@@ -292,14 +292,13 @@ def exploit_dedup_confusion():
             print(f"  [!] Dedup confusion: attacker accessed content via different name")
 
 # ============================================================
-# EXPLOIT 6: Fake Hash Upload (Disk Waste / DoS)
-# Upload a file claiming a fake hash. The server stores the blob
-# under the fake hash, then detects the mismatch and deletes the
-# namespace mapping. But the blob may remain until GC.
+# EXPLOIT 6: Fake Hash Upload (Disk Waste / DoS) — CVE-006
+# Blocked: Blob is now deleted immediately on hash mismatch.
+# CASStore.Delete removes blob content when refcount reaches 0.
 # ============================================================
 def exploit_fake_hash_upload():
     print("\n" + "="*60)
-    print("EXPLOIT 6: Fake Hash Upload (Blob Pollution)")
+    print("EXPLOIT 6: Fake Hash Upload (Blob Pollution) — CVE-006")
     print("="*60)
 
     content = b"x" * 1024  # 1KB of junk
@@ -326,7 +325,7 @@ def exploit_fake_hash_upload():
         print(f"  [*] Dedup hit (fake hash already exists)")
 
     s.close()
-    print(f"  [!] Blob may persist on disk until GC runs (potential disk waste)")
+    print(f"  [-] Blocked: Blob deleted immediately on hash mismatch (CVE-006 fix)")
 
 # ============================================================
 # EXPLOIT 7: Peer Impersonation

--- a/src/server/file_test.go
+++ b/src/server/file_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/alsotoes/momo/src/common"
@@ -194,6 +195,47 @@ func TestGetFileTraversal(t *testing.T) {
 	}
 	if _, err := os.Stat(safeFilePath); os.IsNotExist(err) {
 		t.Errorf("Expected file to be created at %s, but it was not", safeFilePath)
+	}
+}
+
+func TestGetFileHashMismatchCleansUpBlob(t *testing.T) {
+	server, client := net.Pipe()
+
+	tempDir, err := os.MkdirTemp("", "test-getfile-hashmismatch")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	storageDir := filepath.Join(tempDir, "storage")
+	store, err := storage.NewCASStore(storageDir)
+	if err != nil {
+		t.Fatalf("Failed to create CAS store: %v", err)
+	}
+	defer store.Close()
+
+	fileContent := "fake hash content"
+	fakeHash := strings.Repeat("a", 64) // notsecret
+	fileSize := int64(len(fileContent))
+
+	go func() {
+		defer client.Close()
+		client.Write([]byte(fileContent))
+	}()
+
+	comm := transport.NewMomoTCPCommunicator(server)
+	err = getFile(comm, store, "fake_hash_file.txt", fakeHash, fileSize, "")
+
+	if err == nil {
+		t.Fatal("Expected error for hash mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "hash mismatch") {
+		t.Errorf("Expected 'hash mismatch' in error, got: %v", err)
+	}
+
+	exists, _ := store.Has(fakeHash)
+	if exists {
+		t.Fatal("Blob should be cleaned up immediately after hash mismatch (CVE-006)")
 	}
 }
 

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -376,8 +376,9 @@ func (s *CASStore) Delete(name string) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var orphanedHash string
 	now := time.Now().UnixNano()
-	return s.db.Update(func(tx *bbolt.Tx) error {
+	err = s.db.Update(func(tx *bbolt.Tx) error {
 		ns := tx.Bucket(bucketNamespace)
 		obj := tx.Bucket(bucketObjects)
 		paths := tx.Bucket(bucketPaths)
@@ -400,6 +401,7 @@ func (s *CASStore) Delete(name string) (err error) {
 				if meta.RefCount <= 0 {
 					meta.RefCount = 0
 					meta.DeletedAt = now
+					orphanedHash = hash
 				}
 				if err := obj.Put([]byte(hash), meta.encode()); err != nil {
 					return fmt.Errorf("metadata error: %w", syscall.EIO)
@@ -416,6 +418,24 @@ func (s *CASStore) Delete(name string) (err error) {
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// 🛡️ CVE-006: Immediately delete blob content when refcount reaches 0.
+	// Don't wait for GC — the blob is already orphaned. Blob deletion is
+	// performed outside the bbolt transaction (same pattern as GC) to avoid
+	// blocking all db operations during potential network I/O (S3 backends).
+	if orphanedHash != "" {
+		if delErr := s.blobs.DeleteBlob(orphanedHash); delErr != nil {
+			log.Printf("AUDIT: Failed to delete orphaned blob %s: %v", orphanedHash, delErr)
+		} else {
+			_ = s.db.Update(func(tx *bbolt.Tx) error {
+				return tx.Bucket(bucketObjects).Delete([]byte(orphanedHash))
+			})
+		}
+	}
+	return nil
 }
 
 // List retrieves all file metadata entries in the store.

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -318,3 +318,43 @@ func TestCASStore_GetHashForName(t *testing.T) {
 		t.Errorf("Expected error for non-existent name fileB.txt")
 	}
 }
+
+func TestCASStoreDeleteRemovesBlobImmediately(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-cve006-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("orphan me")
+	hash := common.HashBytes(content)
+
+	if err := store.Put("orphan.txt", hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Failed to Put: %v", err)
+	}
+
+	blobPath := store.getBlobPath(hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatal("Blob file should exist before Delete")
+	}
+
+	if err := store.Delete("orphan.txt"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if _, err := os.Stat(blobPath); !os.IsNotExist(err) {
+		t.Fatal("Blob file should be removed immediately by Delete (CVE-006)")
+	}
+
+	exists, _ := store.Has(hash)
+	if exists {
+		t.Fatal("Has should return false after Delete removed the blob")
+	}
+}


### PR DESCRIPTION
Resolves #545

## CVE-006: Blob Pollution / Disk Waste via Fake Hash Upload

**Severity:** MEDIUM
**Component:** `src/storage/storage.go` (`CASStore.Delete`)

### Problem
When a client uploads with a fake hash, `getFile` calls `store.Put` (writes blob to disk under fake hash), then detects the mismatch and calls `store.Delete(fileName)`. But `Delete` only decremented refcount to 0 and removed the namespace mapping — the **blob content remained on disk** until GC ran (default 5 minutes). An attacker could fill disk with orphaned blobs faster than GC could reclaim them.

### Root Cause
`CASStore.Delete` (`storage.go:367`) never called `s.blobs.DeleteBlob(hash)`. Blob reclamation was entirely deferred to the background GC sweeper (`gc.go`), which runs every 5 minutes by default.

### Fix
Modified `CASStore.Delete` to immediately delete blob content when refcount reaches 0:

1. During the bbolt transaction, collect the orphaned hash when `RefCount` drops to 0
2. After the transaction, call `s.blobs.DeleteBlob(hash)` (outside transaction — same pattern as GC, avoids blocking db operations during network I/O for S3 backends)
3. If blob deletion succeeds, remove the `objects` metadata entry (so `Has` returns `false` and GC won't find a stale entry)
4. If blob deletion fails, log it and leave the `objects` metadata for GC to retry

This benefits **all** delete paths:
- Hash mismatch cleanup in `file.go:119` (the CVE-006 path)
- Native DELETE handler (`momo_tcp.go`, `momo_quic.go`)
- P2P query delete handler (`query_handler.go`)

### Why This Approach
- `DeleteBlob` is idempotent on missing blobs (interface contract + `LocalBlobStore` implementation)
- Blob deletion happens outside the bbolt transaction (same pattern as `sweepOrphanedBlobs` in GC)
- No `Store` interface change needed — fix is internal to `CASStore`
- No change to `file.go` — `Delete` now handles cleanup transparently

### Changes
- `src/storage/storage.go`: `CASStore.Delete` — collect orphaned hash when refcount→0, delete blob after transaction, remove objects metadata on success
- `src/storage/storage_test.go`: Added `TestCASStoreDeleteRemovesBlobImmediately` — Put blob, Delete name, verify blob file is gone and `Has` returns false
- `src/server/file_test.go`: Added `TestGetFileHashMismatchCleansUpBlob` — `getFile` with fake hash, verify error returned + blob cleaned up
- `pentest/scripts/momo_exploit.py`: Updated `exploit_fake_hash_upload` to report blob cleaned up immediately (CVE-006 fix)

### Test Coverage
- `TestCASStoreDeleteRemovesBlobImmediately` — unit test: Put → Delete → blob file gone + Has=false
- `TestGetFileHashMismatchCleansUpBlob` — integration test: getFile with fake hash → error + blob cleaned up
- `TestGCSweeperRemovesOrphanedBlobs` — existing GC test still passes (GC now finds fewer orphans since Delete handles them immediately)