### PR TITLE
fix: key namespace by full virtual path to prevent collision (#548)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2045,3 +2045,10 @@ e2febb4,BenchmarkPadString-8,1.99,0.00,0.00
 1acac21,BenchmarkIndexSearch-8,3.01,0.00,0.00
 1acac21,BenchmarkLoadGlobalConfig-8,1568.00,160.00,1.00
 1acac21,BenchmarkPadString-8,3.52,0.00,0.00
+58348d3,BenchmarkCheckMetricsAndSwap-8,13.57,0.00,0.00
+58348d3,BenchmarkCrushOptimized-8,466.00,0.00,0.00
+58348d3,BenchmarkCrushOriginal-8,650.30,164.00,3.00
+58348d3,BenchmarkIndexDirectTracking-8,0.55,0.00,0.00
+58348d3,BenchmarkIndexSearch-8,2.38,0.00,0.00
+58348d3,BenchmarkLoadGlobalConfig-8,1350.00,160.00,1.00
+58348d3,BenchmarkPadString-8,3.18,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        484.0n ± ∞ ¹    832.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       341.2n ± ∞ ¹    544.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     912.1n ± ∞ ¹   1568.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.989n ± ∞ ¹    3.515n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.473n ± ∞ ¹   15.420n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.893n ± ∞ ¹    3.009n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.5077n ± ∞ ¹   0.7590n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                21.93n          36.60n        +66.87%
+CrushOriginal-8                        832.6n ± ∞ ¹    650.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       544.0n ± ∞ ¹    466.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     1.568µ ± ∞ ¹    1.350µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            3.515n ± ∞ ¹    3.176n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  15.42n ± ∞ ¹    13.57n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.009n ± ∞ ¹    2.384n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.7590n ± ∞ ¹   0.5468n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                36.60n          30.21n        -17.44%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 15.42 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 544.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 832.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.76 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.01 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 1568.00 ns/op | 160.00 B/op | 1.00 allocs/op |
-| BenchmarkPadString-8 | 3.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 13.57 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 466.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 650.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 1350.00 ns/op | 160.00 B/op | 1.00 allocs/op |
+| BenchmarkPadString-8 | 3.18 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21]
-    line "CheckMetricsAndSwap" [8,11,8,9,8,8,8,8,8,15]
-    line "CrushOptimized" [328,497,329,300,293,302,314,290,341,544]
-    line "CrushOriginal" [454,750,452,401,405,396,385,392,484,833]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,1,1]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,3]
-    line "LoadGlobalConfig" [794,1212,913,777,814,756,753,729,912,1568]
-    line "PadString" [2,3,2,2,2,2,2,2,2,4]
+    x-axis [4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21,58348d3]
+    line "CheckMetricsAndSwap" [11,8,9,8,8,8,8,8,15,14]
+    line "CrushOptimized" [497,329,300,293,302,314,290,341,544,466]
+    line "CrushOriginal" [750,452,401,405,396,385,392,484,833,650]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,1,1,1]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,3,2]
+    line "LoadGlobalConfig" [1212,913,777,814,756,753,729,912,1568,1350]
+    line "PadString" [3,2,2,2,2,2,2,2,4,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21]
+    x-axis [4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21,58348d3]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c7640ff,4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21]
+    x-axis [4488220,530e62d,2698cfb,a90bb6c,cd30ae6,33b4539,fe922ae,e2febb4,1acac21,58348d3]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -135,6 +135,10 @@ The file payload is streamed until EOF. The server reads exactly the number of b
 - **MaxPathLength:** 4096 bytes. Virtual paths exceeding this limit are rejected with `EBADMSG` in `DecodeFileMetadataList`.
 - **FileInfoLength:** 64 bytes. Hash and name fields exceeding this length are rejected with `EBADMSG` in `DecodeFileMetadataList`.
 
+### Namespace Keying
+
+The namespace bucket is keyed by the **full virtual path** (e.g., `dirA/file.txt`), not the base filename. This means `dirA/file.txt` and `dirB/file.txt` are distinct namespace entries pointing to potentially different content hashes. The full virtual path is sent over the wire as the `fileName` field (constructed by the client as `remotePath + "/" + baseName`). The server uses this full path directly as the storage key, preventing namespace collisions between files with the same base name in different virtual directories.
+
 ## Replication Modes in Detail
 
 The following diagrams illustrate the message flow for each replication mode.

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"log"
+	"strings"
 	"syscall"
 
 	"github.com/alsotoes/momo/src/common"
@@ -60,8 +61,9 @@ func (h *StorageQueryHandler) handleGet(data []byte) (result []byte, err error) 
 		return nil, fmt.Errorf("empty file name: %w", syscall.EINVAL)
 	}
 	name := string(data)
-	// 🛡️ Sentinel: Sanitize name immediately to prevent path traversal in local storage queries.
-	if common.HasPathTraversalChars(name) {
+	// 🛡️ Sentinel: Sanitize name to prevent path traversal. Allow forward slashes
+	// for full virtual paths (e.g., "dirA/file.txt") but reject ".." and backslashes.
+	if strings.Contains(name, "..") || strings.Contains(name, "\\") {
 		return nil, fmt.Errorf("invalid name: %w", syscall.EBADMSG)
 	}
 	rc, meta, err := h.store.Get(name)
@@ -116,8 +118,9 @@ func (h *StorageQueryHandler) handleDelete(data []byte) (result []byte, err erro
 		return nil, fmt.Errorf("empty file name: %w", syscall.EINVAL)
 	}
 	name := string(data)
-	// 🛡️ Sentinel: Sanitize name immediately to prevent path traversal in local storage queries.
-	if common.HasPathTraversalChars(name) {
+	// 🛡️ Sentinel: Sanitize name to prevent path traversal. Allow forward slashes
+	// for full virtual paths (e.g., "dirA/file.txt") but reject ".." and backslashes.
+	if strings.Contains(name, "..") || strings.Contains(name, "\\") {
 		return nil, fmt.Errorf("invalid name: %w", syscall.EBADMSG)
 	}
 	if err := h.store.Delete(name); err != nil {
@@ -235,7 +238,7 @@ func DecodeFileMetadataList(data []byte) (result []common.FileMetadata, err erro
 		if common.HasPathTraversalChars(hash) {
 			return nil, fmt.Errorf("invalid hash at entry %d: %w", i, syscall.EBADMSG)
 		}
-		if common.HasPathTraversalChars(name) {
+		if strings.Contains(name, "..") || strings.Contains(name, "\\") {
 			return nil, fmt.Errorf("invalid name at entry %d: %w", i, syscall.EBADMSG)
 		}
 		if fileSize < 0 || fileSize > common.MaxFileSize {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -311,6 +311,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				metricsCollector.IncErrors()
 				return
 			}
+			storageKey := rawFileName
 
 			// 🛡️ Sentinel: Enforce maximum file size to prevent Denial of Service via resource exhaustion
 			if metadata.Size < 0 || metadata.Size > common.MaxFileSize {
@@ -342,7 +343,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			// payload as proof of content knowledge before creating a new namespace alias.
 			canDedup := false
 			if exists {
-				existingHash, hashErr := store.GetHashForName(fileName)
+				existingHash, hashErr := store.GetHashForName(storageKey)
 				if hashErr == nil && existingHash == metadata.Hash {
 					canDedup = true
 				}
@@ -388,13 +389,13 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			case common.ReplicationNone, common.ReplicationPrimarySplay:
 				if canDedup {
 					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
-					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+					if err := store.Put(storageKey, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
 						metricsCollector.IncErrors()
 						return
 					}
 				} else {
-					if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
+					if err := getFile(comm, store, storageKey, metadata.Hash, metadata.Size, remotePath); err != nil {
 						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 						metricsCollector.IncErrors()
 						return
@@ -413,14 +414,14 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				wg.Add(1)
 				if canDedup {
 					// ⚡ Bolt: Deduplication hit. Just update metadata mapping without reading payload.
-					if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+					if err := store.Put(storageKey, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 						log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
 						wg.Done()
 						metricsCollector.IncErrors()
 						return
 					}
 				} else {
-					if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
+					if err := getFile(comm, store, storageKey, metadata.Hash, metadata.Size, remotePath); err != nil {
 						log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 						wg.Done()
 						metricsCollector.IncErrors()
@@ -441,7 +442,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 								metricsCollector.IncErrors()
 							}
 						}()
-						reader, _, err := store.Get(fileName)
+						reader, _, err := store.Get(storageKey)
 						if err != nil {
 							log.Printf("AUDIT: Failed to get blob for chain forwarding: %v", common.SanitizeLog(err.Error()))
 							wg.Done()
@@ -450,7 +451,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 						}
 						defer reader.Close()
 						// ⚡ Bolt: connectToPeerStream (client.ConnectStream) handles wg.Done() internally via defer.
-						connectToPeerStream(&wg, cfg, reader, fileName, metadata.Hash, metadata.Size, remotePath, id, finalTs, replicationMode, factor)
+						connectToPeerStream(&wg, cfg, reader, storageKey, metadata.Hash, metadata.Size, "", id, finalTs, replicationMode, factor)
 						metricsCollector.IncReplication()
 					}(nextHop.ID)
 				} else {
@@ -464,7 +465,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 					wg.Add(len(placement) - 1)
 					if canDedup {
 						// ⚡ Bolt: Deduplication hit. Just update metadata mapping.
-						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+						if err := store.Put(storageKey, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
 							for i := 0; i < len(placement)-1; i++ {
 								wg.Done()
@@ -473,7 +474,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 							return
 						}
 					} else {
-						if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
+						if err := getFile(comm, store, storageKey, metadata.Hash, metadata.Size, remotePath); err != nil {
 							log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 							for i := 0; i < len(placement)-1; i++ {
 								wg.Done()
@@ -493,7 +494,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 									metricsCollector.IncErrors()
 								}
 							}()
-							reader, _, err := store.Get(fileName)
+							reader, _, err := store.Get(storageKey)
 							if err != nil {
 								log.Printf("AUDIT: Failed to get blob for splay forwarding: %v", common.SanitizeLog(err.Error()))
 								wg.Done()
@@ -501,7 +502,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 								return
 							}
 							defer reader.Close()
-							connectToPeerStream(&wg, cfg, reader, fileName, metadata.Hash, metadata.Size, remotePath, id, finalTs, replicationMode, factor)
+							connectToPeerStream(&wg, cfg, reader, storageKey, metadata.Hash, metadata.Size, "", id, finalTs, replicationMode, factor)
 							metricsCollector.IncReplication()
 						}(targetId)
 					}
@@ -509,13 +510,13 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				} else {
 					// We are a secondary in a splay, just receive the file if needed.
 					if canDedup {
-						if err := store.Put(fileName, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
+						if err := store.Put(storageKey, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
 							metricsCollector.IncErrors()
 							return
 						}
 					} else {
-						if err := getFile(comm, store, fileName, metadata.Hash, metadata.Size, remotePath); err != nil {
+						if err := getFile(comm, store, storageKey, metadata.Hash, metadata.Size, remotePath); err != nil {
 							log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
 							metricsCollector.IncErrors()
 							return

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -218,8 +218,8 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 			if err != nil {
 				return fmt.Errorf("invalid virtual path %q: %w", remotePath, err)
 			}
-			if len(normalized)+1+len(name) > common.FileInfoLength {
-				return fmt.Errorf("virtual path and name concatenation too long: %w", syscall.ENAMETOOLONG)
+			if len(name) > common.FileInfoLength {
+				return fmt.Errorf("name exceeds maximum length: %w", syscall.ENAMETOOLONG)
 			}
 			paths := tx.Bucket(bucketPaths)
 			if err := paths.Put([]byte(name), []byte(normalized)); err != nil {

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -358,3 +358,93 @@ func TestCASStoreDeleteRemovesBlobImmediately(t *testing.T) {
 		t.Fatal("Has should return false after Delete removed the blob")
 	}
 }
+
+func TestCASStore_NamespaceCollision(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-ns-collision-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	contentA := []byte("content from dirA")
+	contentB := []byte("content from dirB")
+	hashA := common.HashBytes(contentA)
+	hashB := common.HashBytes(contentB)
+
+	keyA := "dirA/file.txt"
+	keyB := "dirB/file.txt"
+
+	if err := store.Put(keyA, hashA, int64(len(contentA)), "dirA", bytes.NewReader(contentA)); err != nil {
+		t.Fatalf("Failed to Put %s: %v", keyA, err)
+	}
+	if err := store.Put(keyB, hashB, int64(len(contentB)), "dirB", bytes.NewReader(contentB)); err != nil {
+		t.Fatalf("Failed to Put %s: %v", keyB, err)
+	}
+
+	readerA, metaA, err := store.Get(keyA)
+	if err != nil {
+		t.Fatalf("Failed to Get %s: %v", keyA, err)
+	}
+	defer readerA.Close()
+	if metaA.Hash != hashA {
+		t.Errorf("Expected hash %s for %s, got %s", hashA, keyA, metaA.Hash)
+	}
+	gotA, _ := io.ReadAll(readerA)
+	if string(gotA) != string(contentA) {
+		t.Errorf("Expected content %q for %s, got %q", contentA, keyA, gotA)
+	}
+
+	readerB, metaB, err := store.Get(keyB)
+	if err != nil {
+		t.Fatalf("Failed to Get %s: %v", keyB, err)
+	}
+	defer readerB.Close()
+	if metaB.Hash != hashB {
+		t.Errorf("Expected hash %s for %s, got %s", hashB, keyB, metaB.Hash)
+	}
+	gotB, _ := io.ReadAll(readerB)
+	if string(gotB) != string(contentB) {
+		t.Errorf("Expected content %q for %s, got %q", contentB, keyB, gotB)
+	}
+
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("Expected 2 entries in list, got %d", len(list))
+	}
+
+	names := make(map[string]bool)
+	for _, f := range list {
+		names[f.Name] = true
+	}
+	if !names[keyA] {
+		t.Errorf("Expected %s in list", keyA)
+	}
+	if !names[keyB] {
+		t.Errorf("Expected %s in list", keyB)
+	}
+
+	hashA2, err := store.GetHashForName(keyA)
+	if err != nil {
+		t.Fatalf("GetHashForName failed for %s: %v", keyA, err)
+	}
+	if hashA2 != hashA {
+		t.Errorf("Expected hash %s for %s, got %s", hashA, keyA, hashA2)
+	}
+	hashB2, err := store.GetHashForName(keyB)
+	if err != nil {
+		t.Fatalf("GetHashForName failed for %s: %v", keyB, err)
+	}
+	if hashB2 != hashB {
+		t.Errorf("Expected hash %s for %s, got %s", hashB, keyB, hashB2)
+	}
+}

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -860,9 +860,6 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 		}
 
 		key := file.Name
-		if file.RemotePath != "" {
-			key = file.RemotePath + "/" + file.Name
-		}
 
 		if prefix != "" && !strings.HasPrefix(key, prefix) {
 			continue

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -498,8 +498,8 @@ func TestS3Communicator_KeyTraversalValidation(t *testing.T) {
 func TestS3Communicator_XMLFormatting(t *testing.T) {
 	files := []common.FileMetadata{
 		{Name: "file1.txt", Hash: "hash1", Size: 100, RemotePath: ""},
-		{Name: "file2.txt", Hash: "hash2", Size: 200, RemotePath: "docs"},
-		{Name: "file3.txt", Hash: "hash3", Size: 300, RemotePath: "docs/nested"},
+		{Name: "docs/file2.txt", Hash: "hash2", Size: 200, RemotePath: "docs"},
+		{Name: "docs/nested/file3.txt", Hash: "hash3", Size: 300, RemotePath: "docs/nested"},
 		{Name: "oversized-filename-exceeding-sixty-four-characters-limit-should-be-skipped-entirely.txt", Hash: "hash4", Size: 400},
 		{Name: "valid.txt", Hash: "oversized-hash-exceeding-sixty-four-characters-limit-should-be-skipped-entirely", Size: 500},
 	}


### PR DESCRIPTION
Resolves #548

## Problem

The namespace bucket was keyed by `filepath.Base(rawFileName)` — the base filename only. When two files in different virtual directories share the same base name, the second upload silently overwrites the first's namespace mapping.

```
Upload "dirA/file.txt" → namespace["file.txt"] = hash_A
Upload "dirB/file.txt" → namespace["file.txt"] = hash_B  ← overwrites
```

## Root Cause

`server.go:304` strips the full virtual path to `filepath.Base(rawFileName)` before using it as the storage key. But the wire format already sends the full path (`SendMetadata` constructs `wireName = remotePath + "/" + name`). The server receives it as `rawFileName = "dirA/file.txt"` but then strips it to the base name for storage.

## Fix

Use `rawFileName` (the full virtual path) as the storage key, keeping `filepath.Base(rawFileName)` for validation only.

### Changes (7 files)

- **`src/server/server.go`**: `storageKey := rawFileName` for all `store.Put`/`store.Get`/`store.Delete`/`store.GetHashForName` calls. `connectToPeerStream` receives full path as name with empty remotePath (prevents double-prefixing).
- **`src/server/query_handler.go`**: Allow `/` in names (full virtual paths) while still rejecting `..` and `\` for traversal prevention.
- **`src/transport/s3_communicator.go`**: ListObjects `key = file.Name` (Name is now the full path, no need for `RemotePath + "/" + Name`).
- **`src/storage/storage.go`**: Length check on `name` only (not `remotePath + name` concatenation), since name is now the full path bounded by protocol's 64-byte field.
- **`src/transport/s3_communicator_test.go`**: Mock data uses full paths as `Name`.
- **`src/storage/storage_test.go`**: `TestCASStore_NamespaceCollision` verifies `dirA/file.txt` and `dirB/file.txt` are distinct entries.
- **`docs/PROTOCOL.md`**: Document namespace keying by full virtual path.

### Migration

No migration script. Existing data keyed by base filename would need re-upload. Acceptable for a LOW severity design fix (issue explicitly states this can be deferred to MomoFS Phase 1).

### Changelog

- Namespace bucket now keyed by full virtual path (e.g., `dirA/file.txt`) instead of base filename
- Files with same base name in different directories no longer collide
- S3 ListObjects uses `file.Name` directly as the object key
- Query handler allows `/` in names for full virtual path support