### PR TITLE
feat: E2EE Phase 2 — crypto package (AES-GCM-256, streaming, convergent, HKDF)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2094,3 +2094,10 @@ ade4126,BenchmarkPadString-8,2.84,0.00,0.00
 8f1153c,BenchmarkIndexSearch-8,2.93,0.00,0.00
 8f1153c,BenchmarkLoadGlobalConfig-8,5724.00,672.00,17.00
 8f1153c,BenchmarkPadString-8,3.23,0.00,0.00
+f5fee58,BenchmarkCheckMetricsAndSwap-8,13.94,0.00,0.00
+f5fee58,BenchmarkCrushOptimized-8,592.20,0.00,0.00
+f5fee58,BenchmarkCrushOriginal-8,860.40,164.00,3.00
+f5fee58,BenchmarkIndexDirectTracking-8,0.60,0.00,0.00
+f5fee58,BenchmarkIndexSearch-8,2.69,0.00,0.00
+f5fee58,BenchmarkLoadGlobalConfig-8,8465.00,1056.00,29.00
+f5fee58,BenchmarkPadString-8,3.07,0.00,0.00

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HTML_DOCS := $(DOCS_DIR)/html
 SRC := $(shell find src -name '*.go')
 BIN := $(BIN_DIR)/momo
 MAIN := src/momo.go
-MODULES := ./src/common ./src/transport ./src/client ./src/metrics ./src/p2p ./src/server ./src/storage
+MODULES := ./src/common ./src/crypto ./src/transport ./src/client ./src/metrics ./src/p2p ./src/server ./src/storage
 
 .PHONY: all build clean tidy vendor test vet coverage doc doc-live benchmark test-e2e smoke-tcp smoke-quic smoke-scale-cas test-contract test-load test-stress test-chaos test-metrics test-external-client monitoring-up monitoring-down pentest
 

--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -13,6 +13,11 @@ polymorphic_system=false
 # tls_insecure=false
 # CA cert for QUIC peer verification. When empty, QUIC requires tls_insecure=true.
 # ca_cert=/path/to/ca.pem
+# E2EE encryption (AES-GCM-256). When enabled, content is encrypted before
+# storage/transfer. Requires a 64-char hex key (256-bit).
+# encryption_enabled=false
+# encryption_key=0000000000000000000000000000000000000000000000000000000000000000
+# encryption_tenant=default
 
 [metrics]
 interval=1000

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,46 +6,48 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        477.6n ± ∞ ¹    781.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       369.5n ± ∞ ¹    501.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     3.519µ ± ∞ ¹    5.724µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.078n ± ∞ ¹    3.231n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.670n ± ∞ ¹   15.380n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.847n ± ∞ ¹    2.929n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3899n ± ∞ ¹   0.7015n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                26.42n          41.95n        +58.80%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        781.3n ± ∞ ¹    860.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       501.1n ± ∞ ¹    592.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.724µ ± ∞ ¹    8.465µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            3.231n ± ∞ ¹    3.067n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  15.38n ± ∞ ¹    13.94n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.929n ± ∞ ¹    2.687n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.7015n ± ∞ ¹   0.6036n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                41.95n          43.59n        +3.90%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
-                      │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
-                      │            B/op             │    B/op      vs base                │
-CrushOriginal-8                         164.0 ± ∞ ¹   164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      672.0 ± ∞ ¹   672.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                             0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ³                +0.00%               ³
+                      │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt      │
+                      │            B/op             │     B/op      vs base                │
+CrushOriginal-8                         164.0 ± ∞ ¹    164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                        0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                      672.0 ± ∞ ¹   1056.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
+PadString-8                             0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                   0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                           0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                   0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                           ⁴                 +6.67%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ summaries must be >0 to compute geomean
+³ need >= 4 samples to detect a difference at alpha level 0.05
+⁴ summaries must be >0 to compute geomean
 
                       │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                       │          allocs/op          │  allocs/op   vs base                │
 CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      17.00 ± ∞ ¹   17.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                      17.00 ± ∞ ¹   29.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
 PadString-8                             0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ³                +0.00%               ³
+geomean                                           ⁴                +7.93%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ summaries must be >0 to compute geomean
+³ need >= 4 samples to detect a difference at alpha level 0.05
+⁴ summaries must be >0 to compute geomean
 ```
 
 ### Latest Benchmark Results
@@ -53,13 +55,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 15.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 501.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 781.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.93 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5724.00 ns/op | 672.00 B/op | 17.00 allocs/op |
-| BenchmarkPadString-8 | 3.23 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 13.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 592.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 860.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8465.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 3.07 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +84,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [fe922ae,e2febb4,1acac21,58348d3,51b845f,eec8e9d,cf91a6b,ade4126,844727b,8f1153c]
-    line "CheckMetricsAndSwap" [8,8,15,14,11,11,15,13,10,15]
-    line "CrushOptimized" [290,341,544,466,437,449,463,458,370,501]
-    line "CrushOriginal" [392,484,833,650,568,624,726,740,478,781]
-    line "IndexDirectTracking" [0,1,1,1,0,0,1,1,0,1]
-    line "IndexSearch" [2,2,3,2,2,2,2,2,2,3]
-    line "LoadGlobalConfig" [729,912,1568,1350,1163,1661,2063,1870,3519,5724]
-    line "PadString" [2,2,4,3,2,3,3,3,2,3]
+    x-axis [e2febb4,1acac21,58348d3,51b845f,eec8e9d,cf91a6b,ade4126,844727b,8f1153c,f5fee58]
+    line "CheckMetricsAndSwap" [8,15,14,11,11,15,13,10,15,14]
+    line "CrushOptimized" [341,544,466,437,449,463,458,370,501,592]
+    line "CrushOriginal" [484,833,650,568,624,726,740,478,781,860]
+    line "IndexDirectTracking" [1,1,1,0,0,1,1,0,1,1]
+    line "IndexSearch" [2,3,2,2,2,2,2,2,3,3]
+    line "LoadGlobalConfig" [912,1568,1350,1163,1661,2063,1870,3519,5724,8465]
+    line "PadString" [2,4,3,2,3,3,3,2,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,13 +101,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [fe922ae,e2febb4,1acac21,58348d3,51b845f,eec8e9d,cf91a6b,ade4126,844727b,8f1153c]
+    x-axis [e2febb4,1acac21,58348d3,51b845f,eec8e9d,cf91a6b,ade4126,844727b,8f1153c,f5fee58]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [160,160,160,160,160,208,208,208,672,672]
+    line "LoadGlobalConfig" [160,160,160,160,208,208,208,672,672,1056]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -116,13 +118,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [fe922ae,e2febb4,1acac21,58348d3,51b845f,eec8e9d,cf91a6b,ade4126,844727b,8f1153c]
+    x-axis [e2febb4,1acac21,58348d3,51b845f,eec8e9d,cf91a6b,ade4126,844727b,8f1153c,f5fee58]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1,1,1,1,1,3,3,3,17,17]
+    line "LoadGlobalConfig" [1,1,1,1,3,3,3,17,17,29]
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	.
 	./src/client
 	./src/common
+	./src/crypto
 	./src/metrics
 	./src/p2p
 	./src/server

--- a/openspec/changes/add-e2e-encryption/tasks.md
+++ b/openspec/changes/add-e2e-encryption/tasks.md
@@ -14,17 +14,17 @@
 
 ## Phase 2: Crypto Package — AES-GCM-256, Convergent, Streaming
 
-- [ ] 2.1 Create `src/crypto/` package with `go.mod`.
-- [ ] 2.2 Implement `Encrypt(plaintext, key []byte) ([]byte, error)` — AES-GCM-256, 12-byte random IV, IV prepended to output.
-- [ ] 2.3 Implement `Decrypt(ciphertext, key []byte) ([]byte, error)` — extract IV, AES-GCM authenticated decryption.
-- [ ] 2.4 Implement `EncryptStream(reader io.Reader, key []byte) (io.Reader, error)` — 4KB chunked streaming AEAD.
-- [ ] 2.5 Implement `DecryptStream(reader io.Reader, key []byte) (io.Reader, error)` — streaming decryption with per-chunk auth tag verification.
-- [ ] 2.6 Implement `ConvergentEncrypt(plaintext []byte) (ciphertext, dedupKey []byte, err error)` — content-derived key via SHA-256, then AES-GCM-256.
-- [ ] 2.7 Implement `DeriveKey(masterKey []byte, tenantID string) ([]byte, error)` — HKDF-SHA256.
-- [ ] 2.8 Add config fields: `encryption_enabled`, `encryption_key`, `encryption_tenant` to `ConfigurationGlobal`.
-- [ ] 2.9 Parse and validate new config fields (64-char hex key, non-empty when enabled).
-- [ ] 2.10 Write unit tests: encrypt/decrypt round-trip, streaming round-trip, convergent dedup (identical plaintext → identical ciphertext), tamper detection, key derivation determinism, key derivation tenant isolation.
-- [ ] 2.11 Write benchmarks: encrypt/decrypt throughput, streaming overhead, convergent encryption overhead.
+- [x] 2.1 Create `src/crypto/` package with `go.mod`.
+- [x] 2.2 Implement `Encrypt(plaintext, key []byte) ([]byte, error)` — AES-GCM-256, 12-byte random IV, IV prepended to output.
+- [x] 2.3 Implement `Decrypt(ciphertext, key []byte) ([]byte, error)` — extract IV, AES-GCM authenticated decryption.
+- [x] 2.4 Implement `EncryptStream(reader io.Reader, key []byte) (io.Reader, error)` — 4KB chunked streaming AEAD.
+- [x] 2.5 Implement `DecryptStream(reader io.Reader, key []byte) (io.Reader, error)` — streaming decryption with per-chunk auth tag verification.
+- [x] 2.6 Implement `ConvergentEncrypt(plaintext []byte) (ciphertext, dedupKey []byte, err error)` — content-derived key via SHA-256, then AES-GCM-256.
+- [x] 2.7 Implement `DeriveKey(masterKey []byte, tenantID string) ([]byte, error)` — HKDF-SHA256.
+- [x] 2.8 Add config fields: `encryption_enabled`, `encryption_key`, `encryption_tenant` to `ConfigurationGlobal`.
+- [x] 2.9 Parse and validate new config fields (64-char hex key, non-empty when enabled).
+- [x] 2.10 Write unit tests: encrypt/decrypt round-trip, streaming round-trip, convergent dedup (identical plaintext → identical ciphertext), tamper detection, key derivation determinism, key derivation tenant isolation.
+- [x] 2.11 Write benchmarks: encrypt/decrypt throughput, streaming overhead, convergent encryption overhead.
 
 ## Phase 3: E2EE momo Protocol — Content + Metadata Encryption
 

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -2,6 +2,7 @@
 package common
 
 import (
+	"encoding/hex"
 	"fmt"
 	"log"
 	"strconv"
@@ -250,6 +251,33 @@ func loadGlobalConfig(section *ini.Section) (ConfigurationGlobal, error) {
 		if v, e := key.Bool(); e == nil {
 			globalCfg.TLSInsecure = v
 		}
+	}
+
+	if key, err := section.GetKey("encryption_enabled"); err == nil {
+		if v, e := key.Bool(); e == nil {
+			globalCfg.EncryptionEnabled = v
+		}
+	}
+
+	if key, err := section.GetKey("encryption_key"); err == nil {
+		globalCfg.EncryptionKey = key.String()
+	}
+
+	if key, err := section.GetKey("encryption_tenant"); err == nil {
+		globalCfg.EncryptionTenant = key.String()
+	}
+
+	if globalCfg.EncryptionEnabled {
+		if len(globalCfg.EncryptionKey) != 64 {
+			return ConfigurationGlobal{}, fmt.Errorf("'encryption_key' must be 64 hex characters (256-bit) when encryption is enabled: %w", syscall.EINVAL)
+		}
+		if _, err := hex.DecodeString(globalCfg.EncryptionKey); err != nil {
+			return ConfigurationGlobal{}, fmt.Errorf("'encryption_key' must be valid hex: %w", err)
+		}
+	}
+
+	if globalCfg.EncryptionTenant == "" {
+		globalCfg.EncryptionTenant = "default"
 	}
 
 	return globalCfg, nil

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -65,6 +65,15 @@ type ConfigurationGlobal struct {
 	// When true, QUIC InsecureSkipVerify is used and TCP TLS skip verification.
 	// Must be explicitly set to true to opt in; not recommended for production.
 	TLSInsecure bool
+	// EncryptionEnabled controls whether E2EE encryption is applied to content.
+	// When true, all content is encrypted with AES-GCM-256 before storage/transfer.
+	EncryptionEnabled bool
+	// EncryptionKey is the 64-char hex-encoded 256-bit master encryption key.
+	// Required when EncryptionEnabled is true.
+	EncryptionKey string
+	// EncryptionTenant is the tenant identifier for per-tenant key derivation.
+	// Defaults to "default" when empty. Used with HKDF-SHA256 to derive per-tenant keys.
+	EncryptionTenant string
 }
 
 // ConfigurationMetrics holds the metrics configuration for the application.

--- a/src/crypto/bench_test.go
+++ b/src/crypto/bench_test.go
@@ -1,0 +1,107 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func BenchmarkEncrypt(b *testing.B) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := make([]byte, 4096)
+	rand.Read(plaintext)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(plaintext)))
+	for i := 0; i < b.N; i++ {
+		_, err := c.Encrypt(plaintext)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecrypt(b *testing.B) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := make([]byte, 4096)
+	rand.Read(plaintext)
+	ciphertext, _ := c.Encrypt(plaintext)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(plaintext)))
+	for i := 0; i < b.N; i++ {
+		_, err := c.Decrypt(ciphertext)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncryptStream(b *testing.B) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := make([]byte, 64*1024)
+	rand.Read(plaintext)
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(plaintext)))
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := c.EncryptStream(bytes.NewReader(plaintext), &buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecryptStream(b *testing.B) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := make([]byte, 64*1024)
+	rand.Read(plaintext)
+
+	var encBuf bytes.Buffer
+	c.EncryptStream(bytes.NewReader(plaintext), &encBuf)
+	ciphertext := encBuf.Bytes()
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(plaintext)))
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := c.DecryptStream(bytes.NewReader(ciphertext), &buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDeriveKey(b *testing.B) {
+	master, _ := GenerateKey()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := DeriveKey(master, "tenant-a", nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConvergentEncrypt(b *testing.B) {
+	plaintext := make([]byte, 4096)
+	rand.Read(plaintext)
+	pepper := []byte("server-pepper")
+
+	b.ResetTimer()
+	b.SetBytes(int64(len(plaintext)))
+	for i := 0; i < b.N; i++ {
+		_, err := ConvergentEncrypt(plaintext, pepper)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/src/crypto/convergent.go
+++ b/src/crypto/convergent.go
@@ -1,0 +1,68 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"fmt"
+	"io"
+)
+
+type ConvergentResult struct {
+	Ciphertext []byte
+	ContentHash []byte
+}
+
+func ConvergentEncrypt(plaintext []byte, pepper []byte) (*ConvergentResult, error) {
+	h := sha256.New()
+	h.Write(plaintext)
+	if len(pepper) > 0 {
+		h.Write(pepper)
+	}
+	contentKey := h.Sum(nil)
+
+	block, err := aes.NewCipher(contentKey)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to create convergent cipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, NonceSize)
+	ciphertext := aead.Seal(nonce, nonce, plaintext, nil)
+
+	return &ConvergentResult{
+		Ciphertext:  ciphertext,
+		ContentHash: contentKey,
+	}, nil
+}
+
+func ConvergentDecrypt(ciphertext []byte, contentHash []byte) ([]byte, error) {
+	if len(contentHash) != KeySize {
+		return nil, ErrInvalidKeySize
+	}
+
+	cipher, err := NewCipher(contentHash)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to create convergent cipher: %w", err)
+	}
+
+	plaintext, err := cipher.Decrypt(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
+func ConvergentEncryptStream(plaintext io.Reader, pepper []byte) (*ConvergentResult, error) {
+	data, err := io.ReadAll(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to read plaintext for convergent encryption: %w", err)
+	}
+
+	return ConvergentEncrypt(data, pepper)
+}

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -1,0 +1,115 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	KeySize       = 32
+	NonceSize     = 12
+	TagSize       = 16
+	MaxKeyHexSize = 64
+)
+
+var (
+	ErrInvalidKeySize     = errors.New("crypto: key must be 32 bytes")
+	ErrInvalidNonceSize   = errors.New("crypto: nonce must be 12 bytes")
+	ErrCiphertextTooShort = errors.New("crypto: ciphertext too short")
+	ErrTampered           = errors.New("crypto: authentication failed (tampered data)")
+	ErrInvalidHexKey      = errors.New("crypto: encryption_key must be 64 hex characters (256-bit)")
+)
+
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+func NewCipher(key []byte) (*Cipher, error) {
+	if len(key) != KeySize {
+		return nil, ErrInvalidKeySize
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to create AES cipher: %w", err)
+	}
+
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to create GCM: %w", err)
+	}
+
+	return &Cipher{aead: aead}, nil
+}
+
+func NewCipherFromHex(hexKey string) (*Cipher, error) {
+	if len(hexKey) != MaxKeyHexSize {
+		return nil, ErrInvalidHexKey
+	}
+
+	key, err := hex.DecodeString(hexKey)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to decode hex key: %w", err)
+	}
+
+	return NewCipher(key)
+}
+
+func (c *Cipher) Encrypt(plaintext []byte) ([]byte, error) {
+	nonce := make([]byte, NonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("crypto: failed to generate nonce: %w", err)
+	}
+
+	ciphertext := c.aead.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+func (c *Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	if len(ciphertext) < NonceSize+TagSize {
+		return nil, ErrCiphertextTooShort
+	}
+
+	nonce := ciphertext[:NonceSize]
+	sealed := ciphertext[NonceSize:]
+
+	plaintext, err := c.aead.Open(nil, nonce, sealed, nil)
+	if err != nil {
+		return nil, ErrTampered
+	}
+
+	return plaintext, nil
+}
+
+func GenerateKey() ([]byte, error) {
+	key := make([]byte, KeySize)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, fmt.Errorf("crypto: failed to generate key: %w", err)
+	}
+	return key, nil
+}
+
+func DeriveKey(masterKey []byte, tenant string, context []byte) ([]byte, error) {
+	if len(masterKey) != KeySize {
+		return nil, ErrInvalidKeySize
+	}
+
+	info := tenant
+	if len(context) > 0 {
+		info += string(context)
+	}
+
+	derived, err := hkdf.Key(sha256.New, masterKey, nil, info, KeySize)
+	if err != nil {
+		return nil, fmt.Errorf("crypto: failed to derive key: %w", err)
+	}
+
+	return derived, nil
+}

--- a/src/crypto/crypto_test.go
+++ b/src/crypto/crypto_test.go
@@ -1,0 +1,304 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+
+	c, err := NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher failed: %v", err)
+	}
+
+	tests := [][]byte{
+		[]byte(""),
+		[]byte("hello world"),
+		bytes.Repeat([]byte("a"), 4096),
+		bytes.Repeat([]byte("b"), 4097),
+		bytes.Repeat([]byte("c"), 100*1024),
+	}
+
+	for i, plaintext := range tests {
+		ciphertext, err := c.Encrypt(plaintext)
+		if err != nil {
+			t.Fatalf("test %d: Encrypt failed: %v", i, err)
+		}
+
+		decrypted, err := c.Decrypt(ciphertext)
+		if err != nil {
+			t.Fatalf("test %d: Decrypt failed: %v", i, err)
+		}
+
+		if !bytes.Equal(plaintext, decrypted) {
+			t.Fatalf("test %d: round-trip mismatch", i)
+		}
+	}
+}
+
+func TestEncryptProducesDifferentCiphertexts(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := []byte("same plaintext")
+
+	ct1, _ := c.Encrypt(plaintext)
+	ct2, _ := c.Encrypt(plaintext)
+
+	if bytes.Equal(ct1, ct2) {
+		t.Fatal("same plaintext produced identical ciphertexts (nonce not random)")
+	}
+}
+
+func TestDecryptTampered(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := []byte("sensitive data")
+	ciphertext, _ := c.Encrypt(plaintext)
+
+	ciphertext[len(ciphertext)-1] ^= 0xFF
+
+	_, err := c.Decrypt(ciphertext)
+	if err != ErrTampered {
+		t.Fatalf("expected ErrTampered, got: %v", err)
+	}
+}
+
+func TestDecryptTooShort(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	_, err := c.Decrypt([]byte("short"))
+	if err != ErrCiphertextTooShort {
+		t.Fatalf("expected ErrCiphertextTooShort, got: %v", err)
+	}
+}
+
+func TestNewCipherInvalidKeySize(t *testing.T) {
+	_, err := NewCipher([]byte("too short"))
+	if err != ErrInvalidKeySize {
+		t.Fatalf("expected ErrInvalidKeySize, got: %v", err)
+	}
+}
+
+func TestNewCipherFromHex(t *testing.T) {
+	key, _ := GenerateKey()
+	hexKey := hex.EncodeToString(key)
+
+	c, err := NewCipherFromHex(hexKey)
+	if err != nil {
+		t.Fatalf("NewCipherFromHex failed: %v", err)
+	}
+
+	plaintext := []byte("test")
+	ciphertext, _ := c.Encrypt(plaintext)
+	decrypted, _ := c.Decrypt(ciphertext)
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Fatal("hex key round-trip failed")
+	}
+}
+
+func TestNewCipherFromHexInvalid(t *testing.T) {
+	_, err := NewCipherFromHex("short")
+	if err != ErrInvalidHexKey {
+		t.Fatalf("expected ErrInvalidHexKey, got: %v", err)
+	}
+
+	_, err = NewCipherFromHex("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+	if err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+}
+
+func TestDeriveKey(t *testing.T) {
+	master, _ := GenerateKey()
+
+	k1, err := DeriveKey(master, "tenant-a", nil)
+	if err != nil {
+		t.Fatalf("DeriveKey failed: %v", err)
+	}
+
+	k2, err := DeriveKey(master, "tenant-b", nil)
+	if err != nil {
+		t.Fatalf("DeriveKey failed: %v", err)
+	}
+
+	if bytes.Equal(k1, k2) {
+		t.Fatal("different tenants produced same derived key")
+	}
+
+	k3, err := DeriveKey(master, "tenant-a", nil)
+	if err != nil {
+		t.Fatalf("DeriveKey failed: %v", err)
+	}
+
+	if !bytes.Equal(k1, k3) {
+		t.Fatal("same tenant produced different derived keys")
+	}
+}
+
+func TestDeriveKeyInvalidMaster(t *testing.T) {
+	_, err := DeriveKey([]byte("short"), "tenant", nil)
+	if err != ErrInvalidKeySize {
+		t.Fatalf("expected ErrInvalidKeySize, got: %v", err)
+	}
+}
+
+func TestDeriveKeyWithContext(t *testing.T) {
+	master, _ := GenerateKey()
+
+	k1, _ := DeriveKey(master, "tenant", []byte("context-a"))
+	k2, _ := DeriveKey(master, "tenant", []byte("context-b"))
+
+	if bytes.Equal(k1, k2) {
+		t.Fatal("different contexts produced same derived key")
+	}
+}
+
+func TestEncryptStreamDecryptStreamRoundTrip(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	tests := [][]byte{
+		[]byte(""),
+		[]byte("hello"),
+		bytes.Repeat([]byte("x"), ChunkSize),
+		bytes.Repeat([]byte("y"), ChunkSize+1),
+		bytes.Repeat([]byte("z"), 10*ChunkSize),
+		bytes.Repeat([]byte("w"), 10*ChunkSize+500),
+	}
+
+	for i, plaintext := range tests {
+		var encBuf, decBuf bytes.Buffer
+
+		if err := c.EncryptStream(bytes.NewReader(plaintext), &encBuf); err != nil {
+			t.Fatalf("test %d: EncryptStream failed: %v", i, err)
+		}
+
+		if err := c.DecryptStream(&encBuf, &decBuf); err != nil {
+			t.Fatalf("test %d: DecryptStream failed: %v", i, err)
+		}
+
+		if !bytes.Equal(plaintext, decBuf.Bytes()) {
+			t.Fatalf("test %d: stream round-trip mismatch (len %d vs %d)", i, len(plaintext), decBuf.Len())
+		}
+	}
+}
+
+func TestDecryptStreamTampered(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := bytes.Repeat([]byte("A"), 2*ChunkSize)
+	var encBuf bytes.Buffer
+	c.EncryptStream(bytes.NewReader(plaintext), &encBuf)
+
+	encBuf.Bytes()[10] ^= 0xFF
+
+	var decBuf bytes.Buffer
+	err := c.DecryptStream(&encBuf, &decBuf)
+	if err != ErrTampered {
+		t.Fatalf("expected ErrTampered, got: %v", err)
+	}
+}
+
+func TestConvergentEncryptDecrypt(t *testing.T) {
+	plaintext := []byte("dedup-friendly content")
+	pepper := []byte("server-pepper")
+
+	result, err := ConvergentEncrypt(plaintext, pepper)
+	if err != nil {
+		t.Fatalf("ConvergentEncrypt failed: %v", err)
+	}
+
+	decrypted, err := ConvergentDecrypt(result.Ciphertext, result.ContentHash)
+	if err != nil {
+		t.Fatalf("ConvergentDecrypt failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Fatal("convergent round-trip mismatch")
+	}
+}
+
+func TestConvergentEncryptDedup(t *testing.T) {
+	plaintext := []byte("same content for dedup")
+	pepper := []byte("server-pepper")
+
+	r1, _ := ConvergentEncrypt(plaintext, pepper)
+	r2, _ := ConvergentEncrypt(plaintext, pepper)
+
+	if !bytes.Equal(r1.Ciphertext, r2.Ciphertext) {
+		t.Fatal("same plaintext produced different convergent ciphertexts (dedup broken)")
+	}
+
+	if !bytes.Equal(r1.ContentHash, r2.ContentHash) {
+		t.Fatal("same plaintext produced different content hashes")
+	}
+}
+
+func TestConvergentEncryptDifferentContent(t *testing.T) {
+	pepper := []byte("server-pepper")
+
+	r1, _ := ConvergentEncrypt([]byte("content-a"), pepper)
+	r2, _ := ConvergentEncrypt([]byte("content-b"), pepper)
+
+	if bytes.Equal(r1.ContentHash, r2.ContentHash) {
+		t.Fatal("different plaintexts produced same content hash")
+	}
+}
+
+func TestConvergentEncryptPepper(t *testing.T) {
+	plaintext := []byte("same content")
+
+	r1, _ := ConvergentEncrypt(plaintext, []byte("pepper-a"))
+	r2, _ := ConvergentEncrypt(plaintext, []byte("pepper-b"))
+
+	if bytes.Equal(r1.ContentHash, r2.ContentHash) {
+		t.Fatal("different peppers produced same content hash (pepper not mixed in)")
+	}
+}
+
+func TestGenerateKeyRandomness(t *testing.T) {
+	k1, _ := GenerateKey()
+	k2, _ := GenerateKey()
+
+	if bytes.Equal(k1, k2) {
+		t.Fatal("GenerateKey produced identical keys")
+	}
+
+	if len(k1) != KeySize {
+		t.Fatalf("key size = %d, want %d", len(k1), KeySize)
+	}
+}
+
+func TestLargePayloadRoundTrip(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := make([]byte, 1024*1024)
+	rand.Read(plaintext)
+
+	ciphertext, err := c.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	decrypted, err := c.Decrypt(ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt failed: %v", err)
+	}
+
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Fatal("1MB round-trip mismatch")
+	}
+}

--- a/src/crypto/go.mod
+++ b/src/crypto/go.mod
@@ -1,0 +1,3 @@
+module github.com/alsotoes/momo/src/crypto
+
+go 1.25.10

--- a/src/crypto/streaming.go
+++ b/src/crypto/streaming.go
@@ -1,0 +1,130 @@
+package crypto
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const (
+	ChunkSize     = 4096
+	ChunkHeader   = 4
+	MaxChunkSize  = ChunkSize + ChunkHeader + NonceSize + TagSize
+	StreamVersion = 1
+)
+
+var (
+	ErrStreamFormat = errors.New("crypto: invalid stream format")
+)
+
+func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) error {
+	header := []byte{StreamVersion}
+	if _, err := dst.Write(header); err != nil {
+		return fmt.Errorf("crypto: failed to write stream header: %w", err)
+	}
+
+	buf := make([]byte, ChunkSize)
+	chunkIndex := uint32(0)
+
+	for {
+		n, err := io.ReadFull(plaintext, buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil && err != io.ErrUnexpectedEOF {
+			return fmt.Errorf("crypto: failed to read plaintext chunk: %w", err)
+		}
+
+		isLast := err == io.ErrUnexpectedEOF
+
+		nonce := make([]byte, NonceSize)
+		binary.BigEndian.PutUint32(nonce[0:4], chunkIndex)
+
+		chunkData := buf[:n]
+		sealed := c.aead.Seal(nil, nonce, chunkData, nil)
+
+		lenBuf := make([]byte, ChunkHeader)
+		binary.BigEndian.PutUint32(lenBuf, uint32(len(sealed)))
+
+		if _, err := dst.Write(lenBuf); err != nil {
+			return fmt.Errorf("crypto: failed to write chunk length: %w", err)
+		}
+		if _, err := dst.Write(sealed); err != nil {
+			return fmt.Errorf("crypto: failed to write chunk ciphertext: %w", err)
+		}
+
+		chunkIndex++
+
+		if isLast {
+			break
+		}
+	}
+
+	if chunkIndex == 0 {
+		nonce := make([]byte, NonceSize)
+		sealed := c.aead.Seal(nil, nonce, nil, nil)
+
+		lenBuf := make([]byte, ChunkHeader)
+		binary.BigEndian.PutUint32(lenBuf, uint32(len(sealed)))
+
+		if _, err := dst.Write(lenBuf); err != nil {
+			return fmt.Errorf("crypto: failed to write empty chunk length: %w", err)
+		}
+		if _, err := dst.Write(sealed); err != nil {
+			return fmt.Errorf("crypto: failed to write empty chunk ciphertext: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) error {
+	versionBuf := make([]byte, 1)
+	if _, err := io.ReadFull(ciphertext, versionBuf); err != nil {
+		return fmt.Errorf("crypto: failed to read stream header: %w", err)
+	}
+
+	if versionBuf[0] != StreamVersion {
+		return fmt.Errorf("%w: unsupported version %d", ErrStreamFormat, versionBuf[0])
+	}
+
+	chunkIndex := uint32(0)
+
+	for {
+		lenBuf := make([]byte, ChunkHeader)
+		_, err := io.ReadFull(ciphertext, lenBuf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("crypto: failed to read chunk length: %w", err)
+		}
+
+		sealedLen := binary.BigEndian.Uint32(lenBuf)
+		if sealedLen == 0 || sealedLen > uint32(MaxChunkSize) {
+			return fmt.Errorf("%w: invalid chunk size %d", ErrStreamFormat, sealedLen)
+		}
+
+		sealed := make([]byte, sealedLen)
+		if _, err := io.ReadFull(ciphertext, sealed); err != nil {
+			return fmt.Errorf("crypto: failed to read chunk ciphertext: %w", err)
+		}
+
+		nonce := make([]byte, NonceSize)
+		binary.BigEndian.PutUint32(nonce[0:4], chunkIndex)
+
+		plaintext, err := c.aead.Open(nil, nonce, sealed, nil)
+		if err != nil {
+			return ErrTampered
+		}
+
+		if _, err := dst.Write(plaintext); err != nil {
+			return fmt.Errorf("crypto: failed to write decrypted chunk: %w", err)
+		}
+
+		chunkIndex++
+	}
+
+	return nil
+}


### PR DESCRIPTION
## E2EE Phase 2: Crypto Package

Resolves #566.

Part of the E2EE implementation plan (#152, Phase 1 merged in PR #565).

### New Package: `src/crypto/`

**AES-GCM-256 Encrypt/Decrypt** (`crypto.go`)
- `NewCipher(key)` / `NewCipherFromHex(hexKey)` — 32-byte key, 12-byte nonce
- `Encrypt(plaintext)` — random nonce prepended to ciphertext
- `Decrypt(ciphertext)` — authenticated decryption with tamper detection
- `GenerateKey()` — random 256-bit key

**Streaming AEAD** (`streaming.go`)
- `EncryptStream(reader, writer)` — 4KB chunked encryption with per-chunk nonce (chunk index)
- `DecryptStream(reader, writer)` — streaming decryption with per-chunk auth verification
- Stream format: version byte + [4-byte len + sealed chunk]*

**Convergent Encryption** (`convergent.go`)
- `ConvergentEncrypt(plaintext, pepper)` — content-derived key via SHA-256(content + pepper)
- Deterministic nonce (zero) — same plaintext → same ciphertext (enables dedup under E2EE)
- `ConvergentDecrypt(ciphertext, contentHash)` — decrypt with stored content hash

**HKDF-SHA256 Key Derivation** (`crypto.go`)
- `DeriveKey(masterKey, tenant, context)` — per-tenant key isolation via `crypto/hkdf`
- Different tenants → different derived keys (tested)

### Config Additions (`src/common/`)
- `encryption_enabled` (bool, default: false)
- `encryption_key` (64-char hex = 256-bit master key, required when enabled)
- `encryption_tenant` (string, default: "default")
- Validation: 64-char hex enforced when `encryption_enabled=true`

### Tests
- 18 unit tests: round-trip (empty, small, chunk-boundary, large), tamper detection, nonce randomness, hex key validation, key derivation (determinism, tenant isolation, context), streaming round-trip (empty, multi-chunk), streaming tamper, convergent dedup, convergent pepper, 1MB payload
- 6 benchmarks: encrypt/decrypt 4KB, encrypt/decrypt stream 64KB, derive key, convergent encrypt

### Files
- `src/crypto/{go.mod, crypto.go, streaming.go, convergent.go, crypto_test.go, bench_test.go}` — new package
- `src/common/struct.go` — 3 new config fields
- `src/common/config.go` — parse + validate encryption config
- `go.work` — add `./src/crypto`
- `Makefile` — add `./src/crypto` to MODULES
- `conf/momo.conf` — commented encryption config examples
- `openspec/changes/add-e2e-encryption/tasks.md` — Phase 2 tasks checked off