### PR TITLE
fix: wrap panic recovery in defer for EncryptedBlobStore.PutBlob (#579)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2178,3 +2178,10 @@ ea32943,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
 ea32943,BenchmarkIndexSearch-8,1.62,0.00,0.00
 ea32943,BenchmarkLoadGlobalConfig-8,4514.00,1056.00,29.00
 ea32943,BenchmarkPadString-8,1.95,0.00,0.00
+c82aafa,BenchmarkCheckMetricsAndSwap-8,8.26,0.00,0.00
+c82aafa,BenchmarkCrushOptimized-8,294.80,0.00,0.00
+c82aafa,BenchmarkCrushOriginal-8,419.30,164.00,3.00
+c82aafa,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+c82aafa,BenchmarkIndexSearch-8,1.64,0.00,0.00
+c82aafa,BenchmarkLoadGlobalConfig-8,4627.00,1056.00,29.00
+c82aafa,BenchmarkPadString-8,2.31,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        448.7n ± ∞ ¹    449.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       326.8n ± ∞ ¹    323.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.148µ ± ∞ ¹    4.514µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.217n ± ∞ ¹    1.954n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.070n ± ∞ ¹    7.605n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.832n ± ∞ ¹    1.622n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3574n ± ∞ ¹   0.3308n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                27.21n          24.46n        -10.10%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        449.4n ± ∞ ¹    419.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       323.7n ± ∞ ¹    294.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.514µ ± ∞ ¹    4.627µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.954n ± ∞ ¹    2.314n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.605n ± ∞ ¹    8.262n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.622n ± ∞ ¹    1.637n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3308n ± ∞ ¹   0.3399n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.46n          24.99n        +2.17%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 323.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 449.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.62 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4514.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.95 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.26 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 294.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 419.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4627.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.31 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,14 +82,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [3e6aaec,846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943]
-    line "CheckMetricsAndSwap" [11,8,8,9,13,9,9,11,10,8]
-    line "CrushOptimized" [393,297,329,295,389,396,555,408,327,324]
-    line "CrushOriginal" [545,396,415,403,442,705,1033,485,449,449]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,3,2,2]
-    line "LoadGlobalConfig" [6633,4524,4742,4516,4948,5528,4804,5443,5148,4514]
-    line "PadString" [3,2,2,2,2,2,2,2,2,2]
+    x-axis [846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa]
+    line "CheckMetricsAndSwap" [8,8,9,13,9,9,11,10,8,8]
+    line "CrushOptimized" [297,329,295,389,396,555,408,327,324,295]
+    line "CrushOriginal" [396,415,403,442,705,1033,485,449,449,419]
+    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,2,3,2,2,2]
+    line "LoadGlobalConfig" [4524,4742,4516,4948,5528,4804,5443,5148,4514,4627]
+    line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [3e6aaec,846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943]
+    x-axis [846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [3e6aaec,846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943]
+    x-axis [846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/encrypted_blobstore.go
+++ b/src/storage/encrypted_blobstore.go
@@ -36,11 +36,13 @@ func NewEncryptedBlobStore(inner BlobStore, encKeyHex string) (*EncryptedBlobSto
 // PutBlob encrypts the content stream and stores the ciphertext in the
 // underlying BlobStore. The hash is the plaintext content hash, preserving
 // CAS dedup semantics.
-func (e *EncryptedBlobStore) PutBlob(hash string, content io.Reader) error {
-	if r := recover(); r != nil {
-		log.Printf("CRITICAL: Panic recovered in EncryptedBlobStore.PutBlob: %v", r)
-		return fmt.Errorf("panic in PutBlob: %v: %w", r, syscall.EIO)
-	}
+func (e *EncryptedBlobStore) PutBlob(hash string, content io.Reader) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in EncryptedBlobStore.PutBlob: %v", r)
+			err = fmt.Errorf("panic in PutBlob: %v: %w", r, syscall.EIO)
+		}
+	}()
 
 	// ⚡ Bolt: Stream encryption avoids loading the entire plaintext into
 	// memory. EncryptStream reads in 4KB chunks and writes to a pipe,


### PR DESCRIPTION
Resolves #579

## Problem
The `recover()` call in `EncryptedBlobStore.PutBlob` was not inside a deferred function. Per Go semantics, `recover()` only returns non-nil when called directly from a deferred function. A direct call at function entry always returns `nil`, making the panic recovery completely non-functional.

## Fix
Wrapped the recovery in `defer func() { ... recover() ... }()` with a named return value `(err error)`, matching the pattern already used in `GetBlob`.

## Changes
- `src/storage/encrypted_blobstore.go`: Changed `PutBlob` signature to use named return, wrapped `recover()` in `defer`.