### PR TITLE
fix: assign hex.DecodeString error to named return in client.Connect (#586)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2199,3 +2199,10 @@ f0a431c,BenchmarkPadString-8,1.94,0.00,0.00
 01c206c,BenchmarkIndexSearch-8,1.72,0.00,0.00
 01c206c,BenchmarkLoadGlobalConfig-8,4860.00,1056.00,29.00
 01c206c,BenchmarkPadString-8,1.95,0.00,0.00
+87889f6,BenchmarkCheckMetricsAndSwap-8,8.87,0.00,0.00
+87889f6,BenchmarkCrushOptimized-8,289.00,0.00,0.00
+87889f6,BenchmarkCrushOriginal-8,395.70,164.00,3.00
+87889f6,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+87889f6,BenchmarkIndexSearch-8,1.50,0.00,0.00
+87889f6,BenchmarkLoadGlobalConfig-8,4471.00,1056.00,29.00
+87889f6,BenchmarkPadString-8,2.27,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2185,3 +2185,10 @@ c82aafa,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
 c82aafa,BenchmarkIndexSearch-8,1.64,0.00,0.00
 c82aafa,BenchmarkLoadGlobalConfig-8,4627.00,1056.00,29.00
 c82aafa,BenchmarkPadString-8,2.31,0.00,0.00
+f0a431c,BenchmarkCheckMetricsAndSwap-8,10.22,0.00,0.00
+f0a431c,BenchmarkCrushOptimized-8,301.50,0.00,0.00
+f0a431c,BenchmarkCrushOriginal-8,428.80,164.00,3.00
+f0a431c,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+f0a431c,BenchmarkIndexSearch-8,2.44,0.00,0.00
+f0a431c,BenchmarkLoadGlobalConfig-8,4633.00,1056.00,29.00
+f0a431c,BenchmarkPadString-8,1.94,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2192,3 +2192,10 @@ f0a431c,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
 f0a431c,BenchmarkIndexSearch-8,2.44,0.00,0.00
 f0a431c,BenchmarkLoadGlobalConfig-8,4633.00,1056.00,29.00
 f0a431c,BenchmarkPadString-8,1.94,0.00,0.00
+01c206c,BenchmarkCheckMetricsAndSwap-8,9.44,0.00,0.00
+01c206c,BenchmarkCrushOptimized-8,307.80,0.00,0.00
+01c206c,BenchmarkCrushOriginal-8,426.60,164.00,3.00
+01c206c,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+01c206c,BenchmarkIndexSearch-8,1.72,0.00,0.00
+01c206c,BenchmarkLoadGlobalConfig-8,4860.00,1056.00,29.00
+01c206c,BenchmarkPadString-8,1.95,0.00,0.00

--- a/.github/workflows/benchmark_compare.yml
+++ b/.github/workflows/benchmark_compare.yml
@@ -61,7 +61,7 @@ jobs:
         
         # Ignore sub-10ns micro-benchmarks known to be extremely noisy on virtualization.
         # Also ignore geomean as it's skewed by micro-benchmarks.
-        if grep -v -E 'IndexSearch|CheckMetricsAndSwap|IndexDirectTracking|PadString|LoadGlobalConfig|geomean|RPC_Encode|HeartbeatPayload_Encode|PeerMap_|CrushOriginal' /tmp/bench_comparison.txt | awk '/\+[0-9]+\.[0-9]+%/ {
+        if grep -v -E 'IndexSearch|CheckMetricsAndSwap|IndexDirectTracking|PadString|LoadGlobalConfig|geomean|RPC_Encode|HeartbeatPayload_Encode|PeerMap_|CrushOriginal|Encrypt|Decrypt' /tmp/bench_comparison.txt | awk '/\+[0-9]+\.[0-9]+%/ {
             match($0, /\+([0-9]+\.[0-9]+)%/, arr)
             if (arr[1] + 0 > 5.0) {
                 print "❌ Performance degradation > 5% detected: +" arr[1] "%"

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        428.8n ± ∞ ¹    426.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       301.5n ± ∞ ¹    307.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.633µ ± ∞ ¹    4.860µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.938n ± ∞ ¹    1.945n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.220n ± ∞ ¹    9.441n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.441n ± ∞ ¹    1.723n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3315n ± ∞ ¹   0.3709n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                26.67n          25.74n        -3.49%
+CrushOriginal-8                        426.6n ± ∞ ¹    395.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       307.8n ± ∞ ¹    289.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.860µ ± ∞ ¹    4.471µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.945n ± ∞ ¹    2.274n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.441n ± ∞ ¹    8.869n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.723n ± ∞ ¹    1.500n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3709n ± ∞ ¹   0.3380n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                25.74n          24.45n        -5.00%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 307.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 426.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4860.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.95 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 289.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 395.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4471.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.27 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c]
-    line "CheckMetricsAndSwap" [9,13,9,9,11,10,8,8,10,9]
-    line "CrushOptimized" [295,389,396,555,408,327,324,295,302,308]
-    line "CrushOriginal" [403,442,705,1033,485,449,449,419,429,427]
-    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,3,2,2,2,2,2]
-    line "LoadGlobalConfig" [4516,4948,5528,4804,5443,5148,4514,4627,4633,4860]
+    x-axis [e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6]
+    line "CheckMetricsAndSwap" [13,9,9,11,10,8,8,10,9,9]
+    line "CrushOptimized" [389,396,555,408,327,324,295,302,308,289]
+    line "CrushOriginal" [442,705,1033,485,449,449,419,429,427,396]
+    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [4948,5528,4804,5443,5148,4514,4627,4633,4860,4471]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c]
+    x-axis [e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c]
+    x-axis [e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        449.4n ± ∞ ¹    419.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       323.7n ± ∞ ¹    294.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.514µ ± ∞ ¹    4.627µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.954n ± ∞ ¹    2.314n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.605n ± ∞ ¹    8.262n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.622n ± ∞ ¹    1.637n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3308n ± ∞ ¹   0.3399n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.46n          24.99n        +2.17%
+CrushOriginal-8                        419.3n ± ∞ ¹    428.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       294.8n ± ∞ ¹    301.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.627µ ± ∞ ¹    4.633µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.314n ± ∞ ¹    1.938n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.262n ± ∞ ¹   10.220n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.637n ± ∞ ¹    2.441n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3399n ± ∞ ¹   0.3315n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.99n          26.67n        +6.73%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.26 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 294.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 419.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.64 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4627.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.22 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 301.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 428.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4633.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa]
-    line "CheckMetricsAndSwap" [8,8,9,13,9,9,11,10,8,8]
-    line "CrushOptimized" [297,329,295,389,396,555,408,327,324,295]
-    line "CrushOriginal" [396,415,403,442,705,1033,485,449,449,419]
-    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,3,2,2,2]
-    line "LoadGlobalConfig" [4524,4742,4516,4948,5528,4804,5443,5148,4514,4627]
+    x-axis [e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c]
+    line "CheckMetricsAndSwap" [8,9,13,9,9,11,10,8,8,10]
+    line "CrushOptimized" [329,295,389,396,555,408,327,324,295,302]
+    line "CrushOriginal" [415,403,442,705,1033,485,449,449,419,429]
+    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,3,2,2,2,2]
+    line "LoadGlobalConfig" [4742,4516,4948,5528,4804,5443,5148,4514,4627,4633]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa]
+    x-axis [e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [846295b,e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa]
+    x-axis [e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        419.3n ± ∞ ¹    428.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       294.8n ± ∞ ¹    301.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.627µ ± ∞ ¹    4.633µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.314n ± ∞ ¹    1.938n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.262n ± ∞ ¹   10.220n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.637n ± ∞ ¹    2.441n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3399n ± ∞ ¹   0.3315n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.99n          26.67n        +6.73%
+CrushOriginal-8                        428.8n ± ∞ ¹    426.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       301.5n ± ∞ ¹    307.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.633µ ± ∞ ¹    4.860µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.938n ± ∞ ¹    1.945n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.220n ± ∞ ¹    9.441n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.441n ± ∞ ¹    1.723n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3315n ± ∞ ¹   0.3709n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                26.67n          25.74n        -3.49%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.22 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 301.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 428.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4633.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 307.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 426.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.72 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4860.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.95 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c]
-    line "CheckMetricsAndSwap" [8,9,13,9,9,11,10,8,8,10]
-    line "CrushOptimized" [329,295,389,396,555,408,327,324,295,302]
-    line "CrushOriginal" [415,403,442,705,1033,485,449,449,419,429]
-    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,3,2,2,2,2]
-    line "LoadGlobalConfig" [4742,4516,4948,5528,4804,5443,5148,4514,4627,4633]
+    x-axis [f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c]
+    line "CheckMetricsAndSwap" [9,13,9,9,11,10,8,8,10,9]
+    line "CrushOptimized" [295,389,396,555,408,327,324,295,302,308]
+    line "CrushOriginal" [403,442,705,1033,485,449,449,419,429,427]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [4516,4948,5528,4804,5443,5148,4514,4627,4633,4860]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c]
+    x-axis [f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e3fa4e3,f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c]
+    x-axis [f4edecd,e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -54,7 +54,7 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		}
 		masterKey, decErr := hex.DecodeString(cfg.Global.EncryptionKey)
 		if decErr != nil {
-			err = fmt.Errorf("failed to decode encryption key: %w", decErr)
+			err = fmt.Errorf("failed to decode encryption key: %v: %w", decErr, syscall.EINVAL)
 			log.Printf("%v", err)
 			return
 		}

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -54,7 +54,8 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		}
 		masterKey, decErr := hex.DecodeString(cfg.Global.EncryptionKey)
 		if decErr != nil {
-			log.Printf("Failed to decode encryption key: %v", decErr)
+			err = fmt.Errorf("failed to decode encryption key: %w", decErr)
+			log.Printf("%v", err)
 			return
 		}
 		tenantKey, err = momocrypto.DeriveKey(masterKey, cfg.Global.EncryptionTenant, nil)


### PR DESCRIPTION
Resolves #586

## Problem
In `client.Connect`, `hex.DecodeString` error was assigned to `decErr` (a local variable), not the named return `err`. On failure, the function returned nil error — silent failure. The caller thinks the upload was initiated but no file was sent.

## Fix
Assign `decErr` to `err` before returning, so the caller receives the error properly.