### PR TITLE
fix: validate name length regardless of remotePath (#590)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2206,3 +2206,10 @@ f0a431c,BenchmarkPadString-8,1.94,0.00,0.00
 87889f6,BenchmarkIndexSearch-8,1.50,0.00,0.00
 87889f6,BenchmarkLoadGlobalConfig-8,4471.00,1056.00,29.00
 87889f6,BenchmarkPadString-8,2.27,0.00,0.00
+b2d21a7,BenchmarkCheckMetricsAndSwap-8,9.47,0.00,0.00
+b2d21a7,BenchmarkCrushOptimized-8,364.80,0.00,0.00
+b2d21a7,BenchmarkCrushOriginal-8,445.20,164.00,3.00
+b2d21a7,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+b2d21a7,BenchmarkIndexSearch-8,1.65,0.00,0.00
+b2d21a7,BenchmarkLoadGlobalConfig-8,4992.00,1056.00,29.00
+b2d21a7,BenchmarkPadString-8,2.37,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        426.6n ± ∞ ¹    395.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       307.8n ± ∞ ¹    289.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.860µ ± ∞ ¹    4.471µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.945n ± ∞ ¹    2.274n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.441n ± ∞ ¹    8.869n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.723n ± ∞ ¹    1.500n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3709n ± ∞ ¹   0.3380n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                25.74n          24.45n        -5.00%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        395.7n ± ∞ ¹    445.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       289.0n ± ∞ ¹    364.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.471µ ± ∞ ¹    4.992µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.274n ± ∞ ¹    2.370n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.869n ± ∞ ¹    9.473n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.500n ± ∞ ¹    1.647n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3380n ± ∞ ¹   0.3615n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                24.45n          27.14n        +10.98%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 289.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 395.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4471.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.27 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 364.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 445.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4992.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.37 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6]
-    line "CheckMetricsAndSwap" [13,9,9,11,10,8,8,10,9,9]
-    line "CrushOptimized" [389,396,555,408,327,324,295,302,308,289]
-    line "CrushOriginal" [442,705,1033,485,449,449,419,429,427,396]
-    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,3,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [4948,5528,4804,5443,5148,4514,4627,4633,4860,4471]
+    x-axis [fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7]
+    line "CheckMetricsAndSwap" [9,9,11,10,8,8,10,9,9,9]
+    line "CrushOptimized" [396,555,408,327,324,295,302,308,289,365]
+    line "CrushOriginal" [705,1033,485,449,449,419,429,427,396,445]
+    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [5528,4804,5443,5148,4514,4627,4633,4860,4471,4992]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6]
+    x-axis [fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e2fc32b,fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6]
+    x-axis [fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -213,13 +213,13 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 		}
 
 		// Store RemotePath
+		if len(name) > common.FileInfoLength {
+			return fmt.Errorf("name exceeds maximum length: %w", syscall.ENAMETOOLONG)
+		}
 		if remotePath != "" {
 			normalized, err := common.NormalizeVirtualPath(remotePath)
 			if err != nil {
 				return fmt.Errorf("invalid virtual path %q: %w", remotePath, err)
-			}
-			if len(name) > common.FileInfoLength {
-				return fmt.Errorf("name exceeds maximum length: %w", syscall.ENAMETOOLONG)
 			}
 			paths := tx.Bucket(bucketPaths)
 			if err := paths.Put([]byte(name), []byte(normalized)); err != nil {


### PR DESCRIPTION
Resolves #590

## Problem
The `len(name) > common.FileInfoLength` check was nested inside the `if remotePath != ""` block. When `remotePath` is empty, names of arbitrary length were accepted into the namespace and paths buckets.

## Fix
Moved the name length check outside the `remotePath != ""` block so it runs unconditionally for all Put operations.