### PR TITLE
fix: send HTTP 400 error response on invalid S3 PUT path/hash (#593)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2220,3 +2220,10 @@ b2d21a7,BenchmarkPadString-8,2.37,0.00,0.00
 816c5b9,BenchmarkIndexSearch-8,1.84,0.00,0.00
 816c5b9,BenchmarkLoadGlobalConfig-8,5220.00,1056.00,29.00
 816c5b9,BenchmarkPadString-8,2.34,0.00,0.00
+93d3d95,BenchmarkCheckMetricsAndSwap-8,7.75,0.00,0.00
+93d3d95,BenchmarkCrushOptimized-8,317.10,0.00,0.00
+93d3d95,BenchmarkCrushOriginal-8,457.80,164.00,3.00
+93d3d95,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+93d3d95,BenchmarkIndexSearch-8,1.69,0.00,0.00
+93d3d95,BenchmarkLoadGlobalConfig-8,5157.00,1056.00,29.00
+93d3d95,BenchmarkPadString-8,2.27,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2227,3 +2227,10 @@ b2d21a7,BenchmarkPadString-8,2.37,0.00,0.00
 93d3d95,BenchmarkIndexSearch-8,1.69,0.00,0.00
 93d3d95,BenchmarkLoadGlobalConfig-8,5157.00,1056.00,29.00
 93d3d95,BenchmarkPadString-8,2.27,0.00,0.00
+1c1ef76,BenchmarkCheckMetricsAndSwap-8,8.00,0.00,0.00
+1c1ef76,BenchmarkCrushOptimized-8,376.40,0.00,0.00
+1c1ef76,BenchmarkCrushOriginal-8,531.10,164.00,3.00
+1c1ef76,BenchmarkIndexDirectTracking-8,0.44,0.00,0.00
+1c1ef76,BenchmarkIndexSearch-8,1.77,0.00,0.00
+1c1ef76,BenchmarkLoadGlobalConfig-8,6408.00,1056.00,29.00
+1c1ef76,BenchmarkPadString-8,2.34,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2213,3 +2213,10 @@ b2d21a7,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
 b2d21a7,BenchmarkIndexSearch-8,1.65,0.00,0.00
 b2d21a7,BenchmarkLoadGlobalConfig-8,4992.00,1056.00,29.00
 b2d21a7,BenchmarkPadString-8,2.37,0.00,0.00
+816c5b9,BenchmarkCheckMetricsAndSwap-8,11.07,0.00,0.00
+816c5b9,BenchmarkCrushOptimized-8,398.10,0.00,0.00
+816c5b9,BenchmarkCrushOriginal-8,499.00,164.00,3.00
+816c5b9,BenchmarkIndexDirectTracking-8,0.45,0.00,0.00
+816c5b9,BenchmarkIndexSearch-8,1.84,0.00,0.00
+816c5b9,BenchmarkLoadGlobalConfig-8,5220.00,1056.00,29.00
+816c5b9,BenchmarkPadString-8,2.34,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        395.7n ± ∞ ¹    445.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       289.0n ± ∞ ¹    364.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.471µ ± ∞ ¹    4.992µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.274n ± ∞ ¹    2.370n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.869n ± ∞ ¹    9.473n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.500n ± ∞ ¹    1.647n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3380n ± ∞ ¹   0.3615n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                24.45n          27.14n        +10.98%
+CrushOriginal-8                        445.2n ± ∞ ¹    499.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       364.8n ± ∞ ¹    398.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.992µ ± ∞ ¹    5.220µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.370n ± ∞ ¹    2.341n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.473n ± ∞ ¹   11.070n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.647n ± ∞ ¹    1.844n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3615n ± ∞ ¹   0.4469n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                27.14n          30.05n        +10.75%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 364.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 445.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4992.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.07 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 398.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 499.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.45 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5220.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.34 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7]
-    line "CheckMetricsAndSwap" [9,9,11,10,8,8,10,9,9,9]
-    line "CrushOptimized" [396,555,408,327,324,295,302,308,289,365]
-    line "CrushOriginal" [705,1033,485,449,449,419,429,427,396,445]
-    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,3,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5528,4804,5443,5148,4514,4627,4633,4860,4471,4992]
+    x-axis [6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9]
+    line "CheckMetricsAndSwap" [9,11,10,8,8,10,9,9,9,11]
+    line "CrushOptimized" [555,408,327,324,295,302,308,289,365,398]
+    line "CrushOriginal" [1033,485,449,449,419,429,427,396,445,499]
+    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,3,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [4804,5443,5148,4514,4627,4633,4860,4471,4992,5220]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7]
+    x-axis [6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [fcc3df6,6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7]
+    x-axis [6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        499.0n ± ∞ ¹    457.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       398.1n ± ∞ ¹    317.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.220µ ± ∞ ¹    5.157µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.341n ± ∞ ¹    2.266n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 11.070n ± ∞ ¹    7.748n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.844n ± ∞ ¹    1.690n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4469n ± ∞ ¹   0.3522n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                30.05n          25.90n        -13.81%
+CrushOriginal-8                        457.8n ± ∞ ¹    531.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       317.1n ± ∞ ¹    376.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.157µ ± ∞ ¹    6.408µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.266n ± ∞ ¹    2.340n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.748n ± ∞ ¹    8.003n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.690n ± ∞ ¹    1.766n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3522n ± ∞ ¹   0.4360n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                25.90n          29.28n        +13.06%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 317.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 457.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5157.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.27 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 376.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 531.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.77 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6408.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.34 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95]
-    line "CheckMetricsAndSwap" [11,10,8,8,10,9,9,9,11,8]
-    line "CrushOptimized" [408,327,324,295,302,308,289,365,398,317]
-    line "CrushOriginal" [485,449,449,419,429,427,396,445,499,458]
-    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5443,5148,4514,4627,4633,4860,4471,4992,5220,5157]
+    x-axis [bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76]
+    line "CheckMetricsAndSwap" [10,8,8,10,9,9,9,11,8,8]
+    line "CrushOptimized" [327,324,295,302,308,289,365,398,317,376]
+    line "CrushOriginal" [449,449,419,429,427,396,445,499,458,531]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [5148,4514,4627,4633,4860,4471,4992,5220,5157,6408]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95]
+    x-axis [bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95]
+    x-axis [bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        445.2n ± ∞ ¹    499.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       364.8n ± ∞ ¹    398.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.992µ ± ∞ ¹    5.220µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.370n ± ∞ ¹    2.341n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.473n ± ∞ ¹   11.070n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.647n ± ∞ ¹    1.844n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3615n ± ∞ ¹   0.4469n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                27.14n          30.05n        +10.75%
+CrushOriginal-8                        499.0n ± ∞ ¹    457.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       398.1n ± ∞ ¹    317.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.220µ ± ∞ ¹    5.157µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.341n ± ∞ ¹    2.266n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 11.070n ± ∞ ¹    7.748n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.844n ± ∞ ¹    1.690n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4469n ± ∞ ¹   0.3522n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                30.05n          25.90n        -13.81%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.07 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 398.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 499.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.45 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5220.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 317.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 457.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5157.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.27 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9]
-    line "CheckMetricsAndSwap" [9,11,10,8,8,10,9,9,9,11]
-    line "CrushOptimized" [555,408,327,324,295,302,308,289,365,398]
-    line "CrushOriginal" [1033,485,449,449,419,429,427,396,445,499]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,3,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [4804,5443,5148,4514,4627,4633,4860,4471,4992,5220]
+    x-axis [c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95]
+    line "CheckMetricsAndSwap" [11,10,8,8,10,9,9,9,11,8]
+    line "CrushOptimized" [408,327,324,295,302,308,289,365,398,317]
+    line "CrushOriginal" [485,449,449,419,429,427,396,445,499,458]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [3,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [5443,5148,4514,4627,4633,4860,4471,4992,5220,5157]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9]
+    x-axis [c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6ccc19f,c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9]
+    x-axis [c0cb2ea,bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -484,6 +484,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		rawPath := req.URL.Path
 		cleanPath := path.Clean(rawPath)
 		if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") || cleanPath == "/" {
+			m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 			return 0, 0, fmt.Errorf("invalid S3 path: %s: %w", rawPath, syscall.EBADMSG)
 		}
 
@@ -496,6 +497,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 		// 🛡️ Sentinel: Sanitize S3 hash to prevent directory traversal via malicious metadata.
 		if m.meta.Hash != "" && common.HasPathTraversalChars(m.meta.Hash) {
+			m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 			return 0, 0, fmt.Errorf("invalid hash: %s: %w", m.meta.Hash, syscall.EBADMSG)
 		}
 	}


### PR DESCRIPTION
Resolves #593

## Problem
When a PUT request had an invalid S3 path or hash with path traversal chars, the function returned an error without writing any HTTP response. The client blocked indefinitely waiting for a response.

## Fix
Write `HTTP/1.1 400 Bad Request` with `Connection: close` before returning the error, matching the pattern used in other error paths in the same file (lines 286, 330, 411).