### PR TITLE
fix: include original error in DialQUIC error messages (#594)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2234,3 +2234,10 @@ b2d21a7,BenchmarkPadString-8,2.37,0.00,0.00
 1c1ef76,BenchmarkIndexSearch-8,1.77,0.00,0.00
 1c1ef76,BenchmarkLoadGlobalConfig-8,6408.00,1056.00,29.00
 1c1ef76,BenchmarkPadString-8,2.34,0.00,0.00
+0abe3fd,BenchmarkCheckMetricsAndSwap-8,7.72,0.00,0.00
+0abe3fd,BenchmarkCrushOptimized-8,346.30,0.00,0.00
+0abe3fd,BenchmarkCrushOriginal-8,458.00,164.00,3.00
+0abe3fd,BenchmarkIndexDirectTracking-8,0.45,0.00,0.00
+0abe3fd,BenchmarkIndexSearch-8,1.62,0.00,0.00
+0abe3fd,BenchmarkLoadGlobalConfig-8,5015.00,1056.00,29.00
+0abe3fd,BenchmarkPadString-8,2.41,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        457.8n ± ∞ ¹    531.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       317.1n ± ∞ ¹    376.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.157µ ± ∞ ¹    6.408µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.266n ± ∞ ¹    2.340n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.748n ± ∞ ¹    8.003n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.690n ± ∞ ¹    1.766n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3522n ± ∞ ¹   0.4360n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                25.90n          29.28n        +13.06%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        531.1n ± ∞ ¹    458.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       376.4n ± ∞ ¹    346.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.408µ ± ∞ ¹    5.015µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.340n ± ∞ ¹    2.410n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.003n ± ∞ ¹    7.716n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.766n ± ∞ ¹    1.624n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4360n ± ∞ ¹   0.4537n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                29.28n          27.16n        -7.26%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 376.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 531.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.77 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6408.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.72 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 346.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 458.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.45 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.62 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5015.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.41 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76]
-    line "CheckMetricsAndSwap" [10,8,8,10,9,9,9,11,8,8]
-    line "CrushOptimized" [327,324,295,302,308,289,365,398,317,376]
-    line "CrushOriginal" [449,449,419,429,427,396,445,499,458,531]
+    x-axis [ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76,0abe3fd]
+    line "CheckMetricsAndSwap" [8,8,10,9,9,9,11,8,8,8]
+    line "CrushOptimized" [324,295,302,308,289,365,398,317,376,346]
+    line "CrushOriginal" [449,419,429,427,396,445,499,458,531,458]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5148,4514,4627,4633,4860,4471,4992,5220,5157,6408]
+    line "LoadGlobalConfig" [4514,4627,4633,4860,4471,4992,5220,5157,6408,5015]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76]
+    x-axis [ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76,0abe3fd]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bf62ecf,ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76]
+    x-axis [ea32943,c82aafa,f0a431c,01c206c,87889f6,b2d21a7,816c5b9,93d3d95,1c1ef76,0abe3fd]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -670,12 +670,12 @@ func DialQUIC(ctx context.Context, address string, caCertPool *x509.CertPool, tl
 	}
 	conn, err = quic.DialAddr(ctx, address, tlsConf, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("quic dial failed: %w", syscall.ECONNREFUSED)
+		return nil, nil, fmt.Errorf("quic dial failed: %v: %w", err, syscall.ECONNREFUSED)
 	}
 	stream, err = conn.OpenStreamSync(ctx)
 	if err != nil {
 		conn.CloseWithError(0, "failed to open stream")
-		return nil, nil, fmt.Errorf("quic stream open failed: %w", syscall.ECONNREFUSED)
+		return nil, nil, fmt.Errorf("quic stream open failed: %v: %w", err, syscall.ECONNREFUSED)
 	}
 	return conn, stream, nil
 }


### PR DESCRIPTION
Resolves #594

## Problem
DialQUIC discarded the actual error from `quic.DialAddr` and `conn.OpenStreamSync`, replacing it with `syscall.ECONNREFUSED`. The caller could not distinguish between DNS failure, TLS handshake error, timeout, or connection refused.

## Fix
Include the original error in the formatted error message: `fmt.Errorf("quic dial failed: %v: %w", err, syscall.ECONNREFUSED)`.