### PR TITLE
fix: include local node files in GlobalList results (#599)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2311,3 +2311,10 @@ ee5caeb,BenchmarkPadString-8,1.91,0.00,0.00
 6acd872,BenchmarkIndexSearch-8,1.53,0.00,0.00
 6acd872,BenchmarkLoadGlobalConfig-8,4463.00,1056.00,29.00
 6acd872,BenchmarkPadString-8,1.99,0.00,0.00
+81fe5bc,BenchmarkCheckMetricsAndSwap-8,9.04,0.00,0.00
+81fe5bc,BenchmarkCrushOptimized-8,318.20,0.00,0.00
+81fe5bc,BenchmarkCrushOriginal-8,443.20,164.00,3.00
+81fe5bc,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+81fe5bc,BenchmarkIndexSearch-8,1.72,0.00,0.00
+81fe5bc,BenchmarkLoadGlobalConfig-8,4804.00,1056.00,29.00
+81fe5bc,BenchmarkPadString-8,2.29,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2304,3 +2304,10 @@ ee5caeb,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
 ee5caeb,BenchmarkIndexSearch-8,1.50,0.00,0.00
 ee5caeb,BenchmarkLoadGlobalConfig-8,4517.00,1056.00,29.00
 ee5caeb,BenchmarkPadString-8,1.91,0.00,0.00
+6acd872,BenchmarkCheckMetricsAndSwap-8,7.75,0.00,0.00
+6acd872,BenchmarkCrushOptimized-8,314.60,0.00,0.00
+6acd872,BenchmarkCrushOriginal-8,408.10,164.00,3.00
+6acd872,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+6acd872,BenchmarkIndexSearch-8,1.53,0.00,0.00
+6acd872,BenchmarkLoadGlobalConfig-8,4463.00,1056.00,29.00
+6acd872,BenchmarkPadString-8,1.99,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2297,3 +2297,10 @@ eed1ef0,BenchmarkPadString-8,1.93,0.00,0.00
 762b445,BenchmarkIndexSearch-8,1.67,0.00,0.00
 762b445,BenchmarkLoadGlobalConfig-8,4281.00,1056.00,29.00
 762b445,BenchmarkPadString-8,1.86,0.00,0.00
+ee5caeb,BenchmarkCheckMetricsAndSwap-8,7.79,0.00,0.00
+ee5caeb,BenchmarkCrushOptimized-8,319.90,0.00,0.00
+ee5caeb,BenchmarkCrushOriginal-8,406.50,164.00,3.00
+ee5caeb,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+ee5caeb,BenchmarkIndexSearch-8,1.50,0.00,0.00
+ee5caeb,BenchmarkLoadGlobalConfig-8,4517.00,1056.00,29.00
+ee5caeb,BenchmarkPadString-8,1.91,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2290,3 +2290,10 @@ eed1ef0,BenchmarkPadString-8,1.93,0.00,0.00
 40545d2,BenchmarkIndexSearch-8,1.74,0.00,0.00
 40545d2,BenchmarkLoadGlobalConfig-8,4739.00,1056.00,29.00
 40545d2,BenchmarkPadString-8,1.94,0.00,0.00
+762b445,BenchmarkCheckMetricsAndSwap-8,7.30,0.00,0.00
+762b445,BenchmarkCrushOptimized-8,315.90,0.00,0.00
+762b445,BenchmarkCrushOriginal-8,388.20,164.00,3.00
+762b445,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+762b445,BenchmarkIndexSearch-8,1.67,0.00,0.00
+762b445,BenchmarkLoadGlobalConfig-8,4281.00,1056.00,29.00
+762b445,BenchmarkPadString-8,1.86,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        474.1n ± ∞ ¹    434.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       337.2n ± ∞ ¹    356.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.595µ ± ∞ ¹    4.739µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.320n ± ∞ ¹    1.938n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.150n ± ∞ ¹    9.405n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.572n ± ∞ ¹    1.739n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3647n ± ∞ ¹   0.3746n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                26.80n          26.30n        -1.84%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        434.5n ± ∞ ¹    388.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       356.3n ± ∞ ¹    315.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.739µ ± ∞ ¹    4.281µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.938n ± ∞ ¹    1.856n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.405n ± ∞ ¹    7.296n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.739n ± ∞ ¹    1.667n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3746n ± ∞ ¹   0.3432n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                26.30n          23.59n        -10.31%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 356.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 434.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.74 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4739.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 315.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 388.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.67 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4281.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.86 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [93d3d95,1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2]
-    line "CheckMetricsAndSwap" [8,8,8,11,9,9,8,9,10,9]
-    line "CrushOptimized" [317,376,346,342,303,340,351,332,337,356]
-    line "CrushOriginal" [458,531,458,405,434,429,480,425,474,434]
-    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
+    x-axis [1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445]
+    line "CheckMetricsAndSwap" [8,8,11,9,9,8,9,10,9,7]
+    line "CrushOptimized" [376,346,342,303,340,351,332,337,356,316]
+    line "CrushOriginal" [531,458,405,434,429,480,425,474,434,388]
+    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5157,6408,5015,4683,5014,4721,5222,4592,4595,4739]
+    line "LoadGlobalConfig" [6408,5015,4683,5014,4721,5222,4592,4595,4739,4281]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [93d3d95,1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2]
+    x-axis [1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [93d3d95,1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2]
+    x-axis [1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        406.5n ± ∞ ¹    408.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       319.9n ± ∞ ¹    314.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.517µ ± ∞ ¹    4.463µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.912n ± ∞ ¹    1.988n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.795n ± ∞ ¹    7.750n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.502n ± ∞ ¹    1.532n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3209n ± ∞ ¹   0.3321n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                23.72n          23.93n        +0.90%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        408.1n ± ∞ ¹    443.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       314.6n ± ∞ ¹    318.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.463µ ± ∞ ¹    4.804µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.988n ± ∞ ¹    2.290n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.750n ± ∞ ¹    9.042n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.532n ± ∞ ¹    1.717n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3321n ± ∞ ¹   0.3649n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                23.93n          26.34n        +10.07%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 314.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 408.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4463.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.04 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 318.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 443.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.72 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4804.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872]
-    line "CheckMetricsAndSwap" [11,9,9,8,9,10,9,7,8,8]
-    line "CrushOptimized" [342,303,340,351,332,337,356,316,320,315]
-    line "CrushOriginal" [405,434,429,480,425,474,434,388,406,408]
-    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    x-axis [ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc]
+    line "CheckMetricsAndSwap" [9,9,8,9,10,9,7,8,8,9]
+    line "CrushOptimized" [303,340,351,332,337,356,316,320,315,318]
+    line "CrushOriginal" [434,429,480,425,474,434,388,406,408,443]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [4683,5014,4721,5222,4592,4595,4739,4281,4517,4463]
+    line "LoadGlobalConfig" [5014,4721,5222,4592,4595,4739,4281,4517,4463,4804]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872]
+    x-axis [ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872]
+    x-axis [ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        434.5n ± ∞ ¹    388.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       356.3n ± ∞ ¹    315.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.739µ ± ∞ ¹    4.281µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.938n ± ∞ ¹    1.856n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.405n ± ∞ ¹    7.296n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.739n ± ∞ ¹    1.667n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3746n ± ∞ ¹   0.3432n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                26.30n          23.59n        -10.31%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        388.2n ± ∞ ¹    406.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       315.9n ± ∞ ¹    319.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.281µ ± ∞ ¹    4.517µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.856n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.296n ± ∞ ¹    7.795n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.667n ± ∞ ¹    1.502n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3432n ± ∞ ¹   0.3209n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                23.59n          23.72n        +0.53%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 315.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 388.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.67 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4281.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.86 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.79 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 319.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 406.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4517.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445]
-    line "CheckMetricsAndSwap" [8,8,11,9,9,8,9,10,9,7]
-    line "CrushOptimized" [376,346,342,303,340,351,332,337,356,316]
-    line "CrushOriginal" [531,458,405,434,429,480,425,474,434,388]
-    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,0]
+    x-axis [0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb]
+    line "CheckMetricsAndSwap" [8,11,9,9,8,9,10,9,7,8]
+    line "CrushOptimized" [346,342,303,340,351,332,337,356,316,320]
+    line "CrushOriginal" [458,405,434,429,480,425,474,434,388,406]
+    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [6408,5015,4683,5014,4721,5222,4592,4595,4739,4281]
+    line "LoadGlobalConfig" [5015,4683,5014,4721,5222,4592,4595,4739,4281,4517]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445]
+    x-axis [0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [1c1ef76,0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445]
+    x-axis [0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        388.2n ± ∞ ¹    406.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       315.9n ± ∞ ¹    319.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.281µ ± ∞ ¹    4.517µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.856n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.296n ± ∞ ¹    7.795n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.667n ± ∞ ¹    1.502n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3432n ± ∞ ¹   0.3209n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                23.59n          23.72n        +0.53%
+CrushOriginal-8                        406.5n ± ∞ ¹    408.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       319.9n ± ∞ ¹    314.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.517µ ± ∞ ¹    4.463µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.912n ± ∞ ¹    1.988n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.795n ± ∞ ¹    7.750n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.502n ± ∞ ¹    1.532n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3209n ± ∞ ¹   0.3321n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                23.72n          23.93n        +0.90%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.79 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 319.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4517.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 314.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 408.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4463.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb]
-    line "CheckMetricsAndSwap" [8,11,9,9,8,9,10,9,7,8]
-    line "CrushOptimized" [346,342,303,340,351,332,337,356,316,320]
-    line "CrushOriginal" [458,405,434,429,480,425,474,434,388,406]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
+    x-axis [0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872]
+    line "CheckMetricsAndSwap" [11,9,9,8,9,10,9,7,8,8]
+    line "CrushOptimized" [342,303,340,351,332,337,356,316,320,315]
+    line "CrushOriginal" [405,434,429,480,425,474,434,388,406,408]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5015,4683,5014,4721,5222,4592,4595,4739,4281,4517]
+    line "LoadGlobalConfig" [4683,5014,4721,5222,4592,4595,4739,4281,4517,4463]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb]
+    x-axis [0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0abe3fd,0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb]
+    x-axis [0801871,ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/p2p_adapters.go
+++ b/src/server/p2p_adapters.go
@@ -8,31 +8,43 @@ import (
 
 	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/p2p"
+	"github.com/alsotoes/momo/src/storage"
 )
 
 // ScatterGatherLister adapts p2p.ScatterGather to the transport.GlobalLister interface.
 type ScatterGatherLister struct {
 	sg      *p2p.ScatterGather
+	store   storage.Store
 	timeout time.Duration
 }
 
 // NewScatterGatherLister creates a new ScatterGatherLister adapter.
-func NewScatterGatherLister(sg *p2p.ScatterGather, timeout time.Duration) *ScatterGatherLister {
-	return &ScatterGatherLister{sg: sg, timeout: timeout}
+func NewScatterGatherLister(sg *p2p.ScatterGather, store storage.Store, timeout time.Duration) *ScatterGatherLister {
+	return &ScatterGatherLister{sg: sg, store: store, timeout: timeout}
 }
 
-// GlobalList queries all peers for their local file lists and: merges and deduplicates results.
+// GlobalList queries all peers for their local file lists, includes the local node's files, and merges and deduplicates results.
 func (s *ScatterGatherLister) GlobalList(timeout time.Duration) ([]common.FileMetadata, error) {
 	if s.sg == nil {
 		return nil, fmt.Errorf("scatter-gather not initialized")
 	}
 
+	var allLists [][]common.FileMetadata
+
+	if s.store != nil {
+		localFiles, err := s.store.List()
+		if err != nil {
+			log.Printf("AUDIT: GlobalList local store error: %v", common.SanitizeLog(err.Error()))
+		} else if len(localFiles) > 0 {
+			allLists = append(allLists, localFiles)
+		}
+	}
+
 	responses, count := s.sg.Query(p2p.QueryList, nil, timeout)
-	if count == 0 {
+	if count == 0 && len(allLists) == 0 {
 		return nil, nil
 	}
 
-	var allLists [][]common.FileMetadata
 	for _, resp := range responses {
 		if resp.Error != "" {
 			log.Printf("AUDIT: GlobalList peer error: %s", common.SanitizeLog(resp.Error))

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -174,8 +174,8 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			// Inject scatter-gather and lease capabilities if P2P is enabled
 			if scatterGather != nil {
 				if glComm, ok := comm.(interface{ SetGlobalLister(transport.GlobalLister) }); ok {
-					glComm.SetGlobalLister(NewScatterGatherLister(scatterGather,
-						time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
+				glComm.SetGlobalLister(NewScatterGatherLister(scatterGather, store,
+					time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
 				}
 				if dpComm, ok := comm.(interface {
 					SetDeletePropagator(transport.DeletePropagator)


### PR DESCRIPTION
Resolves #599

## Problem
`ScatterGatherLister.GlobalList` only broadcast to remote peers and collected their responses. The local node own files were never queried or included in the merged result. A "global list" operation would silently miss all files stored on the local node.

## Fix
- Added `store storage.Store` field to `ScatterGatherLister`
- Call `store.List()` at the start of `GlobalList` to get local files
- Include local files in the merge/dedup alongside remote peer results
- Updated `NewScatterGatherLister` constructor and call site in `server.go`