### PR TITLE
fix: override QUICNetConn.Close to close both stream and conn (#581)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2318,3 +2318,10 @@ ee5caeb,BenchmarkPadString-8,1.91,0.00,0.00
 81fe5bc,BenchmarkIndexSearch-8,1.72,0.00,0.00
 81fe5bc,BenchmarkLoadGlobalConfig-8,4804.00,1056.00,29.00
 81fe5bc,BenchmarkPadString-8,2.29,0.00,0.00
+a847fed,BenchmarkCheckMetricsAndSwap-8,7.63,0.00,0.00
+a847fed,BenchmarkCrushOptimized-8,316.80,0.00,0.00
+a847fed,BenchmarkCrushOriginal-8,399.60,164.00,3.00
+a847fed,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+a847fed,BenchmarkIndexSearch-8,1.73,0.00,0.00
+a847fed,BenchmarkLoadGlobalConfig-8,4497.00,1056.00,29.00
+a847fed,BenchmarkPadString-8,1.98,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2325,3 +2325,10 @@ a847fed,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
 a847fed,BenchmarkIndexSearch-8,1.73,0.00,0.00
 a847fed,BenchmarkLoadGlobalConfig-8,4497.00,1056.00,29.00
 a847fed,BenchmarkPadString-8,1.98,0.00,0.00
+d21c9c7,BenchmarkCheckMetricsAndSwap-8,8.63,0.00,0.00
+d21c9c7,BenchmarkCrushOptimized-8,290.40,0.00,0.00
+d21c9c7,BenchmarkCrushOriginal-8,422.10,164.00,3.00
+d21c9c7,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+d21c9c7,BenchmarkIndexSearch-8,1.73,0.00,0.00
+d21c9c7,BenchmarkLoadGlobalConfig-8,4897.00,1056.00,29.00
+d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2332,3 +2332,10 @@ d21c9c7,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
 d21c9c7,BenchmarkIndexSearch-8,1.73,0.00,0.00
 d21c9c7,BenchmarkLoadGlobalConfig-8,4897.00,1056.00,29.00
 d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
+34c3f2c,BenchmarkCheckMetricsAndSwap-8,9.37,0.00,0.00
+34c3f2c,BenchmarkCrushOptimized-8,300.70,0.00,0.00
+34c3f2c,BenchmarkCrushOriginal-8,401.90,164.00,3.00
+34c3f2c,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+34c3f2c,BenchmarkIndexSearch-8,1.61,0.00,0.00
+34c3f2c,BenchmarkLoadGlobalConfig-8,4483.00,1056.00,29.00
+34c3f2c,BenchmarkPadString-8,2.17,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        443.2n ± ∞ ¹    399.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       318.2n ± ∞ ¹    316.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.804µ ± ∞ ¹    4.497µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.290n ± ∞ ¹    1.980n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.042n ± ∞ ¹    7.628n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.717n ± ∞ ¹    1.731n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3649n ± ∞ ¹   0.3542n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                26.34n          24.48n        -7.04%
+CrushOriginal-8                        399.6n ± ∞ ¹    422.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       316.8n ± ∞ ¹    290.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.497µ ± ∞ ¹    4.897µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.980n ± ∞ ¹    2.060n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.628n ± ∞ ¹    8.632n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.731n ± ∞ ¹    1.729n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3542n ± ∞ ¹   0.3585n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.48n          25.29n        +3.30%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.63 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 316.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 399.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.63 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 290.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 422.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 1.73 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4497.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4897.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed]
-    line "CheckMetricsAndSwap" [9,8,9,10,9,7,8,8,9,8]
-    line "CrushOptimized" [340,351,332,337,356,316,320,315,318,317]
-    line "CrushOriginal" [429,480,425,474,434,388,406,408,443,400]
+    x-axis [c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7]
+    line "CheckMetricsAndSwap" [8,9,10,9,7,8,8,9,8,9]
+    line "CrushOptimized" [351,332,337,356,316,320,315,318,317,290]
+    line "CrushOriginal" [480,425,474,434,388,406,408,443,400,422]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [4721,5222,4592,4595,4739,4281,4517,4463,4804,4497]
+    line "LoadGlobalConfig" [5222,4592,4595,4739,4281,4517,4463,4804,4497,4897]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed]
+    x-axis [c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed]
+    x-axis [c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        408.1n ± ∞ ¹    443.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       314.6n ± ∞ ¹    318.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.463µ ± ∞ ¹    4.804µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.988n ± ∞ ¹    2.290n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.750n ± ∞ ¹    9.042n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.532n ± ∞ ¹    1.717n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3321n ± ∞ ¹   0.3649n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                23.93n          26.34n        +10.07%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        443.2n ± ∞ ¹    399.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       318.2n ± ∞ ¹    316.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.804µ ± ∞ ¹    4.497µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.290n ± ∞ ¹    1.980n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.042n ± ∞ ¹    7.628n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.717n ± ∞ ¹    1.731n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3649n ± ∞ ¹   0.3542n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                26.34n          24.48n        -7.04%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.04 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 318.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 443.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4804.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.63 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 316.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 399.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.73 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4497.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc]
-    line "CheckMetricsAndSwap" [9,9,8,9,10,9,7,8,8,9]
-    line "CrushOptimized" [303,340,351,332,337,356,316,320,315,318]
-    line "CrushOriginal" [434,429,480,425,474,434,388,406,408,443]
+    x-axis [7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed]
+    line "CheckMetricsAndSwap" [9,8,9,10,9,7,8,8,9,8]
+    line "CrushOptimized" [340,351,332,337,356,316,320,315,318,317]
+    line "CrushOriginal" [429,480,425,474,434,388,406,408,443,400]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5014,4721,5222,4592,4595,4739,4281,4517,4463,4804]
+    line "LoadGlobalConfig" [4721,5222,4592,4595,4739,4281,4517,4463,4804,4497]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc]
+    x-axis [7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ecdfb47,7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc]
+    x-axis [7763f59,c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        399.6n ± ∞ ¹    422.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       316.8n ± ∞ ¹    290.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.497µ ± ∞ ¹    4.897µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.980n ± ∞ ¹    2.060n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.628n ± ∞ ¹    8.632n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.731n ± ∞ ¹    1.729n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3542n ± ∞ ¹   0.3585n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.48n          25.29n        +3.30%
+CrushOriginal-8                        422.1n ± ∞ ¹    401.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       290.4n ± ∞ ¹    300.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.897µ ± ∞ ¹    4.483µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.060n ± ∞ ¹    2.172n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.632n ± ∞ ¹    9.369n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.729n ± ∞ ¹    1.607n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3585n ± ∞ ¹   0.3207n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                25.29n          24.75n        -2.15%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.63 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 290.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 422.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.73 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4897.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 300.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 401.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4483.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.17 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7]
-    line "CheckMetricsAndSwap" [8,9,10,9,7,8,8,9,8,9]
-    line "CrushOptimized" [351,332,337,356,316,320,315,318,317,290]
-    line "CrushOriginal" [480,425,474,434,388,406,408,443,400,422]
+    x-axis [eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c]
+    line "CheckMetricsAndSwap" [9,10,9,7,8,8,9,8,9,9]
+    line "CrushOptimized" [332,337,356,316,320,315,318,317,290,301]
+    line "CrushOriginal" [425,474,434,388,406,408,443,400,422,402]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5222,4592,4595,4739,4281,4517,4463,4804,4497,4897]
+    line "LoadGlobalConfig" [4592,4595,4739,4281,4517,4463,4804,4497,4897,4483]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7]
+    x-axis [eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c3ff670,eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7]
+    x-axis [eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/quic_net_conn.go
+++ b/src/transport/quic_net_conn.go
@@ -39,3 +39,9 @@ func (c *QUICNetConn) SetReadDeadline(t time.Time) error {
 func (c *QUICNetConn) SetWriteDeadline(t time.Time) error {
 	return c.Stream.SetWriteDeadline(t)
 }
+
+func (c *QUICNetConn) Close() error {
+	err := c.Stream.Close()
+	c.conn.CloseWithError(0, "")
+	return err
+}

--- a/src/transport/quic_net_conn.go
+++ b/src/transport/quic_net_conn.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -40,8 +41,13 @@ func (c *QUICNetConn) SetWriteDeadline(t time.Time) error {
 	return c.Stream.SetWriteDeadline(t)
 }
 
-func (c *QUICNetConn) Close() error {
-	err := c.Stream.Close()
+func (c *QUICNetConn) Close() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in QUICNetConn.Close: %v", r)
+		}
+	}()
+	err = c.Stream.Close()
 	c.conn.CloseWithError(0, "")
 	return err
 }

--- a/src/transport/quic_net_conn.go
+++ b/src/transport/quic_net_conn.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"fmt"
 	"net"
+	"syscall"
 	"time"
 
 	"github.com/quic-go/quic-go"
@@ -44,7 +45,7 @@ func (c *QUICNetConn) SetWriteDeadline(t time.Time) error {
 func (c *QUICNetConn) Close() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic in QUICNetConn.Close: %v", r)
+			err = fmt.Errorf("panic in QUICNetConn.Close: %v: %w", r, syscall.EIO)
 		}
 	}()
 	err = c.Stream.Close()


### PR DESCRIPTION
Resolves #581

## Problem
`QUICNetConn` embedded `*quic.Stream` and stored `conn *quic.Conn`, but never overrode `Close()`. When `Close()` was called, only `quic.Stream.Close()` was invoked via the embedded type — the `quic.Conn` was never closed, leaking every S3-over-QUIC connection.

## Fix
Added an explicit `Close()` method that closes both the stream and the connection:
```go
func (c *QUICNetConn) Close() error {
    err := c.Stream.Close()
    c.conn.CloseWithError(0, "")
    return err
}
```