### PR TITLE
chore: bump setup-go and setup-python to v7 in pentest.yml

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2346,3 +2346,10 @@ d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
 68b2597,BenchmarkIndexSearch-8,1.47,0.00,0.00
 68b2597,BenchmarkLoadGlobalConfig-8,4320.00,1056.00,29.00
 68b2597,BenchmarkPadString-8,2.15,0.00,0.00
+885fb42,BenchmarkCheckMetricsAndSwap-8,8.52,0.00,0.00
+885fb42,BenchmarkCrushOptimized-8,349.40,0.00,0.00
+885fb42,BenchmarkCrushOriginal-8,436.00,164.00,3.00
+885fb42,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+885fb42,BenchmarkIndexSearch-8,1.77,0.00,0.00
+885fb42,BenchmarkLoadGlobalConfig-8,4833.00,1056.00,29.00
+885fb42,BenchmarkPadString-8,1.98,0.00,0.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2339,3 +2339,10 @@ d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
 34c3f2c,BenchmarkIndexSearch-8,1.61,0.00,0.00
 34c3f2c,BenchmarkLoadGlobalConfig-8,4483.00,1056.00,29.00
 34c3f2c,BenchmarkPadString-8,2.17,0.00,0.00
+68b2597,BenchmarkCheckMetricsAndSwap-8,8.50,0.00,0.00
+68b2597,BenchmarkCrushOptimized-8,302.70,0.00,0.00
+68b2597,BenchmarkCrushOriginal-8,398.60,164.00,3.00
+68b2597,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+68b2597,BenchmarkIndexSearch-8,1.47,0.00,0.00
+68b2597,BenchmarkLoadGlobalConfig-8,4320.00,1056.00,29.00
+68b2597,BenchmarkPadString-8,2.15,0.00,0.00

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: '1.25.x'
 
@@ -83,7 +83,7 @@ jobs:
         perl -e 'use LWP::UserAgent; use HTTP::Request; use Time::HiRes; print "Perl deps OK\n"'
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        422.1n ± ∞ ¹    401.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       290.4n ± ∞ ¹    300.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.897µ ± ∞ ¹    4.483µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.060n ± ∞ ¹    2.172n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.632n ± ∞ ¹    9.369n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.729n ± ∞ ¹    1.607n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3585n ± ∞ ¹   0.3207n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                25.29n          24.75n        -2.15%
+CrushOriginal-8                        401.9n ± ∞ ¹    398.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       300.7n ± ∞ ¹    302.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.483µ ± ∞ ¹    4.320µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.172n ± ∞ ¹    2.152n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.369n ± ∞ ¹    8.500n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.607n ± ∞ ¹    1.468n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3207n ± ∞ ¹   0.3321n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.75n          24.05n        -2.83%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 300.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 401.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4483.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.17 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 302.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 398.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4320.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.15 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c]
-    line "CheckMetricsAndSwap" [9,10,9,7,8,8,9,8,9,9]
-    line "CrushOptimized" [332,337,356,316,320,315,318,317,290,301]
-    line "CrushOriginal" [425,474,434,388,406,408,443,400,422,402]
+    x-axis [6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597]
+    line "CheckMetricsAndSwap" [10,9,7,8,8,9,8,9,9,8]
+    line "CrushOptimized" [337,356,316,320,315,318,317,290,301,303]
+    line "CrushOriginal" [474,434,388,406,408,443,400,422,402,399]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [4592,4595,4739,4281,4517,4463,4804,4497,4897,4483]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,2,1]
+    line "LoadGlobalConfig" [4595,4739,4281,4517,4463,4804,4497,4897,4483,4320]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c]
+    x-axis [6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [eed1ef0,6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c]
+    x-axis [6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        401.9n ± ∞ ¹    398.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       300.7n ± ∞ ¹    302.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.483µ ± ∞ ¹    4.320µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.172n ± ∞ ¹    2.152n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.369n ± ∞ ¹    8.500n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.607n ± ∞ ¹    1.468n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3207n ± ∞ ¹   0.3321n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.75n          24.05n        -2.83%
+CrushOriginal-8                        398.6n ± ∞ ¹    436.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       302.7n ± ∞ ¹    349.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.320µ ± ∞ ¹    4.833µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.152n ± ∞ ¹    1.980n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.500n ± ∞ ¹    8.521n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.468n ± ∞ ¹    1.775n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3321n ± ∞ ¹   0.3733n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                24.05n          26.09n        +8.51%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 302.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 398.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4320.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 349.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 436.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.77 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4833.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597]
-    line "CheckMetricsAndSwap" [10,9,7,8,8,9,8,9,9,8]
-    line "CrushOptimized" [337,356,316,320,315,318,317,290,301,303]
-    line "CrushOriginal" [474,434,388,406,408,443,400,422,402,399]
+    x-axis [40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42]
+    line "CheckMetricsAndSwap" [9,7,8,8,9,8,9,9,8,9]
+    line "CrushOptimized" [356,316,320,315,318,317,290,301,303,349]
+    line "CrushOriginal" [434,388,406,408,443,400,422,402,399,436]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,1]
-    line "LoadGlobalConfig" [4595,4739,4281,4517,4463,4804,4497,4897,4483,4320]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,1,2]
+    line "LoadGlobalConfig" [4739,4281,4517,4463,4804,4497,4897,4483,4320,4833]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597]
+    x-axis [40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6681def,40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597]
+    x-axis [40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]


### PR DESCRIPTION
Supersedes Dependabot PRs #675 and #677 which could not be merged due to OAuth workflow scope restrictions.

Brings pentest.yml in line with all other workflows that already use v7.