### PR TITLE
fix: S3 PutBlob detects oversized blobs instead of silent truncation (#580)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2353,3 +2353,10 @@ d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
 885fb42,BenchmarkIndexSearch-8,1.77,0.00,0.00
 885fb42,BenchmarkLoadGlobalConfig-8,4833.00,1056.00,29.00
 885fb42,BenchmarkPadString-8,1.98,0.00,0.00
+9c8cba3,BenchmarkCheckMetricsAndSwap-8,9.08,0.00,0.00
+9c8cba3,BenchmarkCrushOptimized-8,330.50,0.00,0.00
+9c8cba3,BenchmarkCrushOriginal-8,442.30,164.00,3.00
+9c8cba3,BenchmarkIndexDirectTracking-8,0.40,0.00,0.00
+9c8cba3,BenchmarkIndexSearch-8,1.69,0.00,0.00
+9c8cba3,BenchmarkLoadGlobalConfig-8,4983.00,1056.00,29.00
+9c8cba3,BenchmarkPadString-8,2.18,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        398.6n ± ∞ ¹    436.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       302.7n ± ∞ ¹    349.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.320µ ± ∞ ¹    4.833µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.152n ± ∞ ¹    1.980n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.500n ± ∞ ¹    8.521n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.468n ± ∞ ¹    1.775n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3321n ± ∞ ¹   0.3733n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                24.05n          26.09n        +8.51%
+CrushOriginal-8                        436.0n ± ∞ ¹    442.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       349.4n ± ∞ ¹    330.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.833µ ± ∞ ¹    4.983µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            1.980n ± ∞ ¹    2.177n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.521n ± ∞ ¹    9.079n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.775n ± ∞ ¹    1.686n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3733n ± ∞ ¹   0.3998n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                26.09n          26.71n        +2.38%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 349.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 436.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.77 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4833.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 1.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.08 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 330.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 442.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4983.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.18 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42]
-    line "CheckMetricsAndSwap" [9,7,8,8,9,8,9,9,8,9]
-    line "CrushOptimized" [356,316,320,315,318,317,290,301,303,349]
-    line "CrushOriginal" [434,388,406,408,443,400,422,402,399,436]
+    x-axis [762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3]
+    line "CheckMetricsAndSwap" [7,8,8,9,8,9,9,8,9,9]
+    line "CrushOptimized" [316,320,315,318,317,290,301,303,349,330]
+    line "CrushOriginal" [388,406,408,443,400,422,402,399,436,442]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,1,2]
-    line "LoadGlobalConfig" [4739,4281,4517,4463,4804,4497,4897,4483,4320,4833]
+    line "IndexSearch" [2,2,2,2,2,2,2,1,2,2]
+    line "LoadGlobalConfig" [4281,4517,4463,4804,4497,4897,4483,4320,4833,4983]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42]
+    x-axis [762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [40545d2,762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42]
+    x-axis [762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/s3_blobstore.go
+++ b/src/storage/s3_blobstore.go
@@ -85,7 +85,8 @@ func (s *S3BlobStore) PutBlob(hash string, content io.Reader) (err error) {
 		}
 	}()
 
-	boundedContent := io.LimitReader(content, common.MaxFileSize)
+	cr := &countingReader{r: content}
+	boundedContent := io.LimitReader(cr, common.MaxFileSize+1)
 
 	req, err := s.newRequest("PUT", hash, boundedContent, "UNSIGNED-PAYLOAD")
 	if err != nil {
@@ -102,7 +103,24 @@ func (s *S3BlobStore) PutBlob(hash string, content io.Reader) (err error) {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("s3: PUT failed with status %d: %w", resp.StatusCode, syscall.EIO)
 	}
+
+	if cr.n > common.MaxFileSize {
+		_ = s.DeleteBlob(hash)
+		return fmt.Errorf("s3: blob exceeds MaxFileSize (%d bytes): %w", common.MaxFileSize, syscall.EFBIG)
+	}
+
 	return nil
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.n += int64(n)
+	return n, err
 }
 
 // GetBlob downloads a blob from S3 using HTTP GET with SigV4 authentication.


### PR DESCRIPTION
Resolves #580

## Problem

`S3BlobStore.PutBlob` used `io.LimitReader(content, common.MaxFileSize)` which silently truncates content exceeding MaxFileSize (1 GiB) without returning an error. A 2 GiB upload would store only the first 1 GiB under the hash of the full 2 GiB content — silent data corruption.

## Fix

- Added a `countingReader` wrapper that tracks total bytes read
- Changed limit to `MaxFileSize+1` (matching `raw_blobstore.go:145`)
- After the PUT completes, if `count > MaxFileSize`, delete the oversized blob from S3 and return `syscall.EFBIG`
- This mirrors the overflow detection pattern in `raw_blobstore.go:170-172`

## Changelog

- `src/storage/s3_blobstore.go`: Added `countingReader` type, overflow detection in `PutBlob`