### PR TITLE
fix: eliminate double wg.Done() on panic in replication forwarders (#582)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2360,3 +2360,10 @@ d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
 9c8cba3,BenchmarkIndexSearch-8,1.69,0.00,0.00
 9c8cba3,BenchmarkLoadGlobalConfig-8,4983.00,1056.00,29.00
 9c8cba3,BenchmarkPadString-8,2.18,0.00,0.00
+04e1511,BenchmarkCheckMetricsAndSwap-8,8.31,0.00,0.00
+04e1511,BenchmarkCrushOptimized-8,330.80,0.00,0.00
+04e1511,BenchmarkCrushOriginal-8,422.60,164.00,3.00
+04e1511,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+04e1511,BenchmarkIndexSearch-8,1.55,0.00,0.00
+04e1511,BenchmarkLoadGlobalConfig-8,4838.00,1056.00,29.00
+04e1511,BenchmarkPadString-8,2.05,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -8,14 +8,14 @@ This section is automatically updated by our GitHub Actions workflow.
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        436.0n ± ∞ ¹    442.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       349.4n ± ∞ ¹    330.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.833µ ± ∞ ¹    4.983µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            1.980n ± ∞ ¹    2.177n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.521n ± ∞ ¹    9.079n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.775n ± ∞ ¹    1.686n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3733n ± ∞ ¹   0.3998n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                26.09n          26.71n        +2.38%
+CrushOriginal-8                        442.3n ± ∞ ¹    422.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       330.5n ± ∞ ¹    330.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.983µ ± ∞ ¹    4.838µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.177n ± ∞ ¹    2.050n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.079n ± ∞ ¹    8.310n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.686n ± ∞ ¹    1.548n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3998n ± ∞ ¹   0.3217n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                26.71n          24.78n        -7.23%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.08 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 330.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 442.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4983.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.18 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 330.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 422.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4838.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.05 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3]
-    line "CheckMetricsAndSwap" [7,8,8,9,8,9,9,8,9,9]
-    line "CrushOptimized" [316,320,315,318,317,290,301,303,349,330]
-    line "CrushOriginal" [388,406,408,443,400,422,402,399,436,442]
+    x-axis [ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511]
+    line "CheckMetricsAndSwap" [8,8,9,8,9,9,8,9,9,8]
+    line "CrushOptimized" [320,315,318,317,290,301,303,349,330,331]
+    line "CrushOriginal" [406,408,443,400,422,402,399,436,442,423]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,1,2,2]
-    line "LoadGlobalConfig" [4281,4517,4463,4804,4497,4897,4483,4320,4833,4983]
+    line "IndexSearch" [2,2,2,2,2,2,1,2,2,2]
+    line "LoadGlobalConfig" [4517,4463,4804,4497,4897,4483,4320,4833,4983,4838]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3]
+    x-axis [ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [762b445,ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3]
+    x-axis [ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -274,8 +274,7 @@ func sendFile(wg *sync.WaitGroup, comm transport.Communicator, filePath string, 
 // from an io.Reader with pre-computed metadata. This is used by the server
 // for replication forwarding when the blob may not be on the local filesystem
 // (e.g., S3 or raw device backends).
-func ConnectStream(wg *sync.WaitGroup, cfg common.Configuration, content io.Reader, name string, hash string, size int64, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
-	defer wg.Done()
+func ConnectStream(cfg common.Configuration, content io.Reader, name string, hash string, size int64, remotePath string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
 	daemons := cfg.Daemons
 	if serverId < 0 || serverId >= len(daemons) {
 		log.Printf("Server ID %d is out of range", serverId)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -174,8 +174,8 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			// Inject scatter-gather and lease capabilities if P2P is enabled
 			if scatterGather != nil {
 				if glComm, ok := comm.(interface{ SetGlobalLister(transport.GlobalLister) }); ok {
-				glComm.SetGlobalLister(NewScatterGatherLister(scatterGather, store,
-					time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
+					glComm.SetGlobalLister(NewScatterGatherLister(scatterGather, store,
+						time.Duration(cfg.P2P.ScatterGatherTimeout)*time.Second))
 				}
 				if dpComm, ok := comm.(interface {
 					SetDeletePropagator(transport.DeletePropagator)
@@ -441,23 +441,21 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 
 					// 🛡️ Zero-Crash: Wrap Chain forwarding in a goroutine with recovery for consistency and safety.
 					go func(id int) {
+						defer wg.Done()
 						defer func() {
 							if r := recover(); r != nil {
 								log.Printf("CRITICAL: Panic recovered in Chain forwarder to node %d: %v", id, r)
-								wg.Done()
 								metricsCollector.IncErrors()
 							}
 						}()
 						reader, _, err := store.Get(storageKey)
 						if err != nil {
 							log.Printf("AUDIT: Failed to get blob for chain forwarding: %v", common.SanitizeLog(err.Error()))
-							wg.Done()
 							metricsCollector.IncErrors()
 							return
 						}
 						defer reader.Close()
-						// ⚡ Bolt: connectToPeerStream (client.ConnectStream) handles wg.Done() internally via defer.
-						connectToPeerStream(&wg, cfg, reader, storageKey, metadata.Hash, metadata.Size, "", id, finalTs, replicationMode, factor)
+						connectToPeerStream(cfg, reader, storageKey, metadata.Hash, metadata.Size, "", id, finalTs, replicationMode, factor)
 						metricsCollector.IncReplication()
 					}(nextHop.ID)
 				} else {
@@ -492,23 +490,21 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 					for i := 1; i < len(placement); i++ {
 						targetId := placement[i].ID
 						go func(id int) {
-							// ⚡ Bolt: connectToPeerStream (client.ConnectStream) handles wg.Done() internally via defer.
+							defer wg.Done()
 							defer func() {
 								if r := recover(); r != nil {
 									log.Printf("CRITICAL: Panic recovered in Splay forwarder to node %d: %v", id, r)
-									wg.Done()
 									metricsCollector.IncErrors()
 								}
 							}()
 							reader, _, err := store.Get(storageKey)
 							if err != nil {
 								log.Printf("AUDIT: Failed to get blob for splay forwarding: %v", common.SanitizeLog(err.Error()))
-								wg.Done()
 								metricsCollector.IncErrors()
 								return
 							}
 							defer reader.Close()
-							connectToPeerStream(&wg, cfg, reader, storageKey, metadata.Hash, metadata.Size, "", id, finalTs, replicationMode, factor)
+							connectToPeerStream(cfg, reader, storageKey, metadata.Hash, metadata.Size, "", id, finalTs, replicationMode, factor)
 							metricsCollector.IncReplication()
 						}(targetId)
 					}


### PR DESCRIPTION
Resolves #582

## Problem

`ConnectStream` had `defer wg.Done()` as its first statement. The Chain and Splay forwarding goroutines in `server.go` had recover handlers that *also* called `wg.Done()`. If `ConnectStream` panicked, its deferred `wg.Done()` ran during unwinding, then the recover handler called `wg.Done()` again — driving the WaitGroup counter negative and triggering an unrecoverable `sync: negative WaitGroup counter` panic that crashes the entire process.

## Fix

- Removed `wg *sync.WaitGroup` parameter and `defer wg.Done()` from `ConnectStream` — it no longer manages the WaitGroup
- Added `defer wg.Done()` at the top of each calling goroutine in `server.go` (Chain forwarder, Splay forwarder) — this runs exactly once regardless of how the goroutine exits (normal return, error return, or panic)
- Removed all explicit `wg.Done()` calls from error paths and recover handlers inside the forwarding goroutines — the goroutine-level defer handles all cases
- Parent-scope `wg.Done()` calls (before goroutines are spawned) remain unchanged — they handle the case where the forwarding goroutine is never created

## Changelog

- `src/client/client.go`: Removed `wg` parameter from `ConnectStream`
- `src/server/server.go`: Updated both call sites, added `defer wg.Done()` to forwarding goroutines, removed redundant `wg.Done()` calls