### PR TITLE
fix: ConnectStream uses derived peer token for replication forwarding (#583)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2367,3 +2367,10 @@ d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
 04e1511,BenchmarkIndexSearch-8,1.55,0.00,0.00
 04e1511,BenchmarkLoadGlobalConfig-8,4838.00,1056.00,29.00
 04e1511,BenchmarkPadString-8,2.05,0.00,0.00
+1ef40c1,BenchmarkCheckMetricsAndSwap-8,11.65,0.00,0.00
+1ef40c1,BenchmarkCrushOptimized-8,379.60,0.00,0.00
+1ef40c1,BenchmarkCrushOriginal-8,449.40,164.00,3.00
+1ef40c1,BenchmarkIndexDirectTracking-8,0.41,0.00,0.00
+1ef40c1,BenchmarkIndexSearch-8,1.96,0.00,0.00
+1ef40c1,BenchmarkLoadGlobalConfig-8,4948.00,1056.00,29.00
+1ef40c1,BenchmarkPadString-8,2.41,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        442.3n ± ∞ ¹    422.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       330.5n ± ∞ ¹    330.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.983µ ± ∞ ¹    4.838µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.177n ± ∞ ¹    2.050n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.079n ± ∞ ¹    8.310n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.686n ± ∞ ¹    1.548n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3998n ± ∞ ¹   0.3217n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                26.71n          24.78n        -7.23%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        422.6n ± ∞ ¹    449.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       330.8n ± ∞ ¹    379.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.838µ ± ∞ ¹    4.948µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.050n ± ∞ ¹    2.407n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.310n ± ∞ ¹   11.650n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.548n ± ∞ ¹    1.964n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3217n ± ∞ ¹   0.4082n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                24.78n          29.40n        +18.63%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 330.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 422.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4838.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.05 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 379.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 449.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 4948.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 2.41 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511]
-    line "CheckMetricsAndSwap" [8,8,9,8,9,9,8,9,9,8]
-    line "CrushOptimized" [320,315,318,317,290,301,303,349,330,331]
-    line "CrushOriginal" [406,408,443,400,422,402,399,436,442,423]
+    x-axis [6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1]
+    line "CheckMetricsAndSwap" [8,9,8,9,9,8,9,9,8,12]
+    line "CrushOptimized" [315,318,317,290,301,303,349,330,331,380]
+    line "CrushOriginal" [408,443,400,422,402,399,436,442,423,449]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,1,2,2,2]
-    line "LoadGlobalConfig" [4517,4463,4804,4497,4897,4483,4320,4833,4983,4838]
+    line "IndexSearch" [2,2,2,2,2,1,2,2,2,2]
+    line "LoadGlobalConfig" [4463,4804,4497,4897,4483,4320,4833,4983,4838,4948]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511]
+    x-axis [6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ee5caeb,6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511]
+    x-axis [6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -281,6 +281,7 @@ func ConnectStream(cfg common.Configuration, content io.Reader, name string, has
 		return
 	}
 	authToken := cfg.Global.AuthToken
+	peerToken := common.DerivePeerTokenString(authToken)
 	factory := transport.NewProtocolFactory(cfg)
 
 	comm, err := factory.Dial(daemons[serverId].Host)
@@ -290,7 +291,7 @@ func ConnectStream(cfg common.Configuration, content io.Reader, name string, has
 	}
 	defer comm.Close()
 
-	_, err = comm.HandshakeClient(authToken, timestamp, requestedMode)
+	_, err = comm.HandshakeClient(peerToken, timestamp, requestedMode)
 	if err != nil {
 		log.Printf("Handshake failed with %s: %v", daemons[serverId].Host, common.SanitizeLog(err.Error()))
 		return


### PR DESCRIPTION
Resolves #583

## Problem

`ConnectStream` called `comm.HandshakeClient(authToken, ...)` with the raw client auth token instead of the derived peer token. The transport layer sets `IsPeer()` to true only when the peer token is presented. As a result, the receiving server treated forwarded connections as regular client connections, bypassing CVE-007 peer authentication.

## Fix

Derive the peer token using `common.DerivePeerTokenString(authToken)` before calling `HandshakeClient`, matching the pattern in `replication.go:251`.

## Changelog

- `src/client/client.go`: Use `peerToken` instead of `authToken` in `ConnectStream`'s `HandshakeClient` call