### PR TITLE
fix: wait for in-flight handler goroutines before closing store (#584)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2374,3 +2374,10 @@ d21c9c7,BenchmarkPadString-8,2.06,0.00,0.00
 1ef40c1,BenchmarkIndexSearch-8,1.96,0.00,0.00
 1ef40c1,BenchmarkLoadGlobalConfig-8,4948.00,1056.00,29.00
 1ef40c1,BenchmarkPadString-8,2.41,0.00,0.00
+f69cd12,BenchmarkCheckMetricsAndSwap-8,9.17,0.00,0.00
+f69cd12,BenchmarkCrushOptimized-8,309.70,0.00,0.00
+f69cd12,BenchmarkCrushOriginal-8,455.90,164.00,3.00
+f69cd12,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+f69cd12,BenchmarkIndexSearch-8,1.94,0.00,0.00
+f69cd12,BenchmarkLoadGlobalConfig-8,5045.00,1056.00,29.00
+f69cd12,BenchmarkPadString-8,1.95,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,16 +6,16 @@ This section is automatically updated by our GitHub Actions workflow.
 ### Comparison with previous commit
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        422.6n ± ∞ ¹    449.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       330.8n ± ∞ ¹    379.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     4.838µ ± ∞ ¹    4.948µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.050n ± ∞ ¹    2.407n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.310n ± ∞ ¹   11.650n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.548n ± ∞ ¹    1.964n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3217n ± ∞ ¹   0.4082n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                24.78n          29.40n        +18.63%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        449.4n ± ∞ ¹    455.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       379.6n ± ∞ ¹    309.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     4.948µ ± ∞ ¹    5.045µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.407n ± ∞ ¹    1.953n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 11.650n ± ∞ ¹    9.168n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.964n ± ∞ ¹    1.940n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4082n ± ∞ ¹   0.3698n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                29.40n          26.49n        -9.90%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -53,13 +53,13 @@ geomean                                           ³                +0.00%      
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 379.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 449.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.96 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 4948.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
-| BenchmarkPadString-8 | 2.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.17 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 309.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 455.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5045.00 ns/op | 1056.00 B/op | 29.00 allocs/op |
+| BenchmarkPadString-8 | 1.95 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -82,13 +82,13 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1]
-    line "CheckMetricsAndSwap" [8,9,8,9,9,8,9,9,8,12]
-    line "CrushOptimized" [315,318,317,290,301,303,349,330,331,380]
-    line "CrushOriginal" [408,443,400,422,402,399,436,442,423,449]
+    x-axis [81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1,f69cd12]
+    line "CheckMetricsAndSwap" [9,8,9,9,8,9,9,8,12,9]
+    line "CrushOptimized" [318,317,290,301,303,349,330,331,380,310]
+    line "CrushOriginal" [443,400,422,402,399,436,442,423,449,456]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,1,2,2,2,2]
-    line "LoadGlobalConfig" [4463,4804,4497,4897,4483,4320,4833,4983,4838,4948]
+    line "IndexSearch" [2,2,2,2,1,2,2,2,2,2]
+    line "LoadGlobalConfig" [4804,4497,4897,4483,4320,4833,4983,4838,4948,5045]
     line "PadString" [2,2,2,2,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
@@ -99,7 +99,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1]
+    x-axis [81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1,f69cd12]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -116,7 +116,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6acd872,81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1]
+    x-axis [81fe5bc,a847fed,d21c9c7,34c3f2c,68b2597,885fb42,9c8cba3,04e1511,1ef40c1,f69cd12]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -74,6 +74,9 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 	closeServer := func() { closeOnce.Do(func() { server.Close() }) }
 	defer closeServer()
 
+	var handlersWG sync.WaitGroup
+	defer handlersWG.Wait()
+
 	// Handle graceful shutdown via context
 	go func() {
 		defer func() {
@@ -141,7 +144,9 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 		case <-ctx.Done():
 			return nil
 		}
+		handlersWG.Add(1)
 		go func(comm transport.Communicator) {
+			defer handlersWG.Done()
 			defer func() { <-sem }()
 			// 🛡️ Zero-Crash Hardening: Recover from any unexpected panics in the connection handler
 			// to ensure the daemon remains stable and available for other clients.


### PR DESCRIPTION
Resolves #584

## Problem

When `ctx` is canceled, `Daemon` returns immediately after the accept loop exits. `defer store.Close()` runs while up to 1000 in-flight connection handler goroutines may still be actively using `store` (`store.Get`, `store.Put`, `store.Has`). This is a use-after-close race that can cause panics, data corruption, or undefined behavior.

## Fix

- Added `handlersWG sync.WaitGroup` to track in-flight connection handler goroutines
- Added `defer handlersWG.Wait()` after `defer closeServer()` — defers are LIFO, so `handlersWG.Wait()` runs first, then `closeServer()`, then `store.Close()`
- In the accept loop: `handlersWG.Add(1)` before spinning up each goroutine
- Inside the goroutine: `defer handlersWG.Done()` as the first defer, ensuring it always runs

## Changelog

- `src/server/server.go`: Added `handlersWG` WaitGroup, `defer handlersWG.Wait()`, `handlersWG.Add(1)`/`defer handlersWG.Done()` in accept loop