### PR TITLE
fix: preserve io.EOF in IdleTimeoutConn.Read instead of wrapping (#591)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2535,3 +2535,10 @@ c359418,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
 c359418,BenchmarkIndexSearch-8,2.80,0.00,0.00
 c359418,BenchmarkLoadGlobalConfig-8,5790.00,1312.00,37.00
 c359418,BenchmarkPadString-8,2.05,0.00,0.00
+7692163,BenchmarkCheckMetricsAndSwap-8,8.93,0.00,0.00
+7692163,BenchmarkCrushOptimized-8,332.30,0.00,0.00
+7692163,BenchmarkCrushOriginal-8,441.70,164.00,3.00
+7692163,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+7692163,BenchmarkIndexSearch-8,2.78,0.00,0.00
+7692163,BenchmarkLoadGlobalConfig-8,6366.00,1312.00,37.00
+7692163,BenchmarkPadString-8,2.03,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,14 +39,14 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        426.4n ± ∞ ¹    592.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       315.0n ± ∞ ¹    308.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.771µ ± ∞ ¹    5.790µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.229n ± ∞ ¹    2.053n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.056n ± ∞ ¹    8.139n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.992n ± ∞ ¹    2.800n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3349n ± ∞ ¹   0.3736n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                28.13n          29.29n        +4.12%
+CrushOriginal-8                        592.8n ± ∞ ¹    441.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       308.4n ± ∞ ¹    332.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.790µ ± ∞ ¹    6.366µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.053n ± ∞ ¹    2.033n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.139n ± ∞ ¹    8.930n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.800n ± ∞ ¹    2.784n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3736n ± ∞ ¹   0.3511n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                29.29n          28.84n        -1.55%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -87,13 +87,13 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.14 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 308.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 592.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5790.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.05 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 332.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 441.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.78 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6366.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.03 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -122,14 +122,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [30f3f68,54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418]
-    line "CheckMetricsAndSwap" [8,9,9,8,10,9,8,9,8,8]
-    line "CrushOptimized" [325,299,354,319,351,357,386,313,315,308]
-    line "CrushOriginal" [505,436,427,453,491,441,433,459,426,593]
+    x-axis [54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163]
+    line "CheckMetricsAndSwap" [9,9,8,10,9,8,9,8,8,9]
+    line "CrushOptimized" [299,354,319,351,357,386,313,315,308,332]
+    line "CrushOriginal" [436,427,453,491,441,433,459,426,593,442]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [6294,6114,6368,6141,6534,6713,7976,6301,5771,5790]
-    line "PadString" [3,2,2,2,2,3,2,2,2,2]
+    line "LoadGlobalConfig" [6114,6368,6141,6534,6713,7976,6301,5771,5790,6366]
+    line "PadString" [2,2,2,2,3,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -144,7 +144,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [30f3f68,54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418]
+    x-axis [54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -166,7 +166,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [30f3f68,54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418]
+    x-axis [54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/net.go
+++ b/src/common/net.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -113,7 +114,7 @@ func (c *IdleTimeoutConn) Read(b []byte) (n int, err error) {
 
 	c.applyDeadlines(true)
 	n, err = c.Conn.Read(b)
-	if err != nil {
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 		if isTimeout(err) {
 			err = fmt.Errorf("%w: %w", err, syscall.ETIMEDOUT)
 		} else {

--- a/src/common/net_test.go
+++ b/src/common/net_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"io"
 	"net"
 	"sync"
 	"syscall"
@@ -134,6 +135,28 @@ func TestIdleTimeoutConn_ReadError(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("Expected n to be 0, got %d", n)
+	}
+}
+
+func TestIdleTimeoutConn_ReadPreservesEOF(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "io.EOF", err: io.EOF},
+		{name: "io.ErrUnexpectedEOF", err: io.ErrUnexpectedEOF},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := &mockConn{readError: tc.err}
+			idleConn := NewIdleTimeoutConn(mc, 30*time.Second)
+
+			_, err := idleConn.Read([]byte("test"))
+			if err != tc.err {
+				t.Fatalf("Expected err to be identity-equal to %v (direct == check), got %v", tc.err, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Resolves #591

## Problem
`IdleTimeoutConn.Read` (src/common/net.go) wrapped **all** non-nil errors with `syscall.ECONNABORTED`, including `io.EOF`:

```go
n, err = c.Conn.Read(b)
if err != nil {
    if isTimeout(err) {
        err = fmt.Errorf("%w: %w", err, syscall.ETIMEDOUT)
    } else {
        err = fmt.Errorf("%w: %w", err, syscall.ECONNABORTED)  // io.EOF gets wrapped here
    }
}
```

This broke **direct equality** checks (`err == io.EOF`) used throughout the codebase:
- `crypto/streaming.go:50,53,57,120` — EncryptStream/DecryptStream chunk framing
- `storage/raw_blobstore.go:166` — PutBlob streaming read loop

End-to-end: `client.go:528` decrypts a network stream via `DecryptStream(io.LimitReader(comm, size), dst)` where `comm` embeds `IdleTimeoutConn`. At the stream boundary, the wrapped `ECONNABORTED` error caused `io.ReadFull` to return `io.ErrUnexpectedEOF` instead of `io.EOF`, changing stream-termination semantics.

## Fix
Guard the EOF sentinels before wrapping (per the issue suggestion):
```go
if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
    if isTimeout(err) {
        err = fmt.Errorf("%w: %w", err, syscall.ETIMEDOUT)
    } else {
        err = fmt.Errorf("%w: %w", err, syscall.ECONNABORTED)
    }
}
```

Authentic EOF is passed through unmodified (identity-equal), so `err == io.EOF` and `err == io.ErrUnexpectedEOF` work again. Genuine connection errors (e.g. `net.ErrClosed`) still wrap `ECONNABORTED`; timeouts still wrap `ETIMEDOUT`.

## Changelog
- `fix: preserve io.EOF in IdleTimeoutConn.Read instead of wrapping (#591)`
  - Add `io` import to `src/common/net.go`.
  - Pass `io.EOF` / `io.ErrUnexpectedEOF` through `Read` without wrapping.
  - Add `TestIdleTimeoutConn_ReadPreservesEOF` (identity-equality regression test for both sentinels).
  - Regenerated benchmark docs / history via pre-commit hook.