### PR TITLE
fix: set read deadline on S3 http.ReadRequest to prevent slowloris DoS (#592)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2542,3 +2542,10 @@ c359418,BenchmarkPadString-8,2.05,0.00,0.00
 7692163,BenchmarkIndexSearch-8,2.78,0.00,0.00
 7692163,BenchmarkLoadGlobalConfig-8,6366.00,1312.00,37.00
 7692163,BenchmarkPadString-8,2.03,0.00,0.00
+33f292e,BenchmarkCheckMetricsAndSwap-8,12.87,0.00,0.00
+33f292e,BenchmarkCrushOptimized-8,438.20,0.00,0.00
+33f292e,BenchmarkCrushOriginal-8,634.70,164.00,3.00
+33f292e,BenchmarkIndexDirectTracking-8,0.40,0.00,0.00
+33f292e,BenchmarkIndexSearch-8,3.17,0.00,0.00
+33f292e,BenchmarkLoadGlobalConfig-8,7966.00,1312.00,37.00
+33f292e,BenchmarkPadString-8,2.39,0.00,0.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,16 +37,16 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        592.8n ± ∞ ¹    441.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       308.4n ± ∞ ¹    332.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.790µ ± ∞ ¹    6.366µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.053n ± ∞ ¹    2.033n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.139n ± ∞ ¹    8.930n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.800n ± ∞ ¹    2.784n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3736n ± ∞ ¹   0.3511n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                29.29n          28.84n        -1.55%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        441.7n ± ∞ ¹    634.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       332.3n ± ∞ ¹    438.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.366µ ± ∞ ¹    7.966µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.033n ± ∞ ¹    2.390n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.930n ± ∞ ¹   12.870n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.784n ± ∞ ¹    3.171n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3511n ± ∞ ¹   0.4022n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                28.84n          36.54n        +26.70%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -87,13 +87,13 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.93 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 332.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 441.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.78 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6366.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.03 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 438.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 634.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.17 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7966.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.39 ns/op | 0.00 B/op | 0.00 allocs/op |
 
 
 ### Performance History
@@ -122,14 +122,14 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163]
-    line "CheckMetricsAndSwap" [9,9,8,10,9,8,9,8,8,9]
-    line "CrushOptimized" [299,354,319,351,357,386,313,315,308,332]
-    line "CrushOriginal" [436,427,453,491,441,433,459,426,593,442]
+    x-axis [8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e]
+    line "CheckMetricsAndSwap" [9,8,10,9,8,9,8,8,9,13]
+    line "CrushOptimized" [354,319,351,357,386,313,315,308,332,438]
+    line "CrushOriginal" [427,453,491,441,433,459,426,593,442,635]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [6114,6368,6141,6534,6713,7976,6301,5771,5790,6366]
-    line "PadString" [2,2,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [6368,6141,6534,6713,7976,6301,5771,5790,6366,7966]
+    line "PadString" [2,2,2,3,2,2,2,2,2,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
 ```
@@ -144,7 +144,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163]
+    x-axis [8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -166,7 +166,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [54b321b,8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163]
+    x-axis [8ad88c4,495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -21,6 +21,11 @@ import (
 	"github.com/alsotoes/momo/src/storage"
 )
 
+// s3ReadHeaderTimeout is the maximum time to read an HTTP request header on
+// the S3 gateway. It prevents slowloris attacks where a client sends headers
+// one byte at a time to keep the connection alive indefinitely (issue #592).
+var s3ReadHeaderTimeout = 10 * time.Second
+
 type LimitedConnReader struct {
 	r     net.Conn
 	limit int64
@@ -246,8 +251,10 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		}
 	}()
 
-	m.connReader.SetLimit(65536) // 🛡️ Bounded Network Loop/Read (Rule 24)
+	m.connReader.SetLimit(65536)                                // 🛡️ Bounded Network Loop/Read (Rule 24)
+	m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout)) // 🛡️ Slowloris mitigation (issue #592)
 	req, err := http.ReadRequest(m.reader)
+	m.conn.SetReadDeadline(time.Time{})
 	m.connReader.ClearLimit()
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to read handshake request: %v: %w", err, syscall.EBADMSG)
@@ -658,8 +665,10 @@ func (m *S3Communicator) ReceiveMetadata() (meta common.FileMetadata, err error)
 	// is the NEXT HTTP request on the same connection!
 	// Let's read the next request if we haven't got metadata yet.
 	if m.meta.Name == "" {
-		m.connReader.SetLimit(65536) // 🛡️ Bounded Network Loop/Read (Rule 24)
+		m.connReader.SetLimit(65536)                                // 🛡️ Bounded Network Loop/Read (Rule 24)
+		m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout)) // 🛡️ Slowloris mitigation (issue #592)
 		req, err := http.ReadRequest(m.reader)
+		m.conn.SetReadDeadline(time.Time{})
 		m.connReader.ClearLimit()
 		if err != nil {
 			return common.FileMetadata{}, fmt.Errorf("ReceiveMetadata ReadRequest failed: %v: %w", err, syscall.EBADMSG)

--- a/src/transport/s3_communicator_extra_test.go
+++ b/src/transport/s3_communicator_extra_test.go
@@ -133,3 +133,53 @@ func TestS3Communicator_Methods(t *testing.T) {
 		t.Errorf("SetAbsoluteDeadline failed: %v", err)
 	}
 }
+
+func TestS3Communicator_SlowlorisMitigation(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	originalTimeout := s3ReadHeaderTimeout
+	s3ReadHeaderTimeout = 150 * time.Millisecond
+	defer func() { s3ReadHeaderTimeout = originalTimeout }()
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	defer l.Close()
+
+	errChan := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer conn.Close()
+		comm := NewS3Communicator(conn)
+		_, _, err = comm.HandshakeServer(expectedAuthToken)
+		errChan <- err
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	partialHeader := "PUT /test.txt HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+	if _, err := conn.Write([]byte(partialHeader)); err != nil {
+		t.Fatalf("Failed to write partial header: %v", err)
+	}
+
+	select {
+	case serverErr := <-errChan:
+		if serverErr == nil {
+			t.Fatal("Expected HandshakeServer to fail on slowloris, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandshakeServer did not time out within 2s — slowloris mitigation not working")
+	}
+}


### PR DESCRIPTION
Resolves #592

## Problem

`S3Communicator` wraps a raw `net.Conn` with no read deadline before `http.ReadRequest`. The `LimitedConnReader.SetLimit(65536)` bounds total bytes but sets **no time deadline**. A malicious client can send headers one byte at a time, keeping the connection alive indefinitely (classic **slowloris attack**).

## Fix

Set a read deadline (`s3ReadHeaderTimeout = 10s`) before each `http.ReadRequest` call in both `HandshakeServer` and `ReceiveMetadata`, then clear it immediately after:

```go
m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout))
req, err := http.ReadRequest(m.reader)
m.conn.SetReadDeadline(time.Time{})
```

The deadline is cleared after `http.ReadRequest` returns so subsequent body reads and writes are not constrained by the header-reading deadline.

## Test

`TestS3Communicator_SlowlorisMitigation` — overrides `s3ReadHeaderTimeout` to 150ms, writes partial HTTP headers (no terminating blank line) over a real TCP connection, and verifies `HandshakeServer` returns an error within 2s instead of blocking forever.

## Changelog

- `src/transport/s3_communicator.go`: Added `s3ReadHeaderTimeout` (10s default). Set/clear read deadline around `http.ReadRequest` in `HandshakeServer` and `ReceiveMetadata`.
- `src/transport/s3_communicator_extra_test.go`: Added `TestS3Communicator_SlowlorisMitigation`.