### PR TITLE
fix: optimize SanitizeLog with single-pass strings.Builder and fast-path (#718)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2556,3 +2556,12 @@ c359418,BenchmarkPadString-8,2.05,0.00,0.00
 867b924,BenchmarkIndexSearch-8,4.08,0.00,0.00
 867b924,BenchmarkLoadGlobalConfig-8,9009.00,1312.00,37.00
 867b924,BenchmarkPadString-8,2.56,0.00,0.00
+ed3f77f,BenchmarkCheckMetricsAndSwap-8,7.84,0.00,0.00
+ed3f77f,BenchmarkCrushOptimized-8,326.20,0.00,0.00
+ed3f77f,BenchmarkCrushOriginal-8,416.30,164.00,3.00
+ed3f77f,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+ed3f77f,BenchmarkIndexSearch-8,1.61,0.00,0.00
+ed3f77f,BenchmarkLoadGlobalConfig-8,5754.00,1312.00,37.00
+ed3f77f,BenchmarkPadString-8,1.99,0.00,0.00
+ed3f77f,BenchmarkSanitizeLog/Safe-8,509.90,0.00,0.00
+ed3f77f,BenchmarkSanitizeLog/Unsafe-8,1574.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,14 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        634.7n ± ∞ ¹    517.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       438.2n ± ∞ ¹    366.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.966µ ± ∞ ¹    9.009µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.390n ± ∞ ¹    2.565n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  12.87n ± ∞ ¹    13.08n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.171n ± ∞ ¹    4.085n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4022n ± ∞ ¹   0.7530n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                36.54n          40.43n        +10.65%
+CrushOriginal-8                        517.9n ± ∞ ¹    416.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       366.6n ± ∞ ¹    326.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.009µ ± ∞ ¹    5.754µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.565n ± ∞ ¹    1.991n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 13.080n ± ∞ ¹    7.838n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          4.085n ± ∞ ¹    1.614n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.7530n ± ∞ ¹   0.3766n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                                     509.9n ± ∞ ¹
+SanitizeLog/Unsafe-8                                   1.574µ ± ∞ ¹
+geomean                                40.43n          56.59n        -36.42%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -59,6 +61,8 @@ PadString-8                             0.000 ± ∞ ¹     0.000 ± ∞ ¹     
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                                      0.000 ± ∞ ¹
+SanitizeLog/Unsafe-8                                    704.0 ± ∞ ¹
 geomean                                           ³                  +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
@@ -73,6 +77,8 @@ PadString-8                             0.000 ± ∞ ¹   0.000 ± ∞ ¹       
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                                    0.000 ± ∞ ¹
+SanitizeLog/Unsafe-8                                  1.000 ± ∞ ¹
 geomean                                           ³                +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
@@ -87,13 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 13.08 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 366.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 517.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 4.08 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9009.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.56 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 326.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 416.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5754.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 509.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1574.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -122,16 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924]
-    line "CheckMetricsAndSwap" [8,10,9,8,9,8,8,9,13,13]
-    line "CrushOptimized" [319,351,357,386,313,315,308,332,438,367]
-    line "CrushOriginal" [453,491,441,433,459,426,593,442,635,518]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,3,4]
-    line "LoadGlobalConfig" [6141,6534,6713,7976,6301,5771,5790,6366,7966,9009]
-    line "PadString" [2,2,3,2,2,2,2,2,2,3]
+    x-axis [6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f]
+    line "CheckMetricsAndSwap" [10,9,8,9,8,8,9,13,13,8]
+    line "CrushOptimized" [351,357,386,313,315,308,332,438,367,326]
+    line "CrushOriginal" [491,441,433,459,426,593,442,635,518,416]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,4,2]
+    line "LoadGlobalConfig" [6534,6713,7976,6301,5771,5790,6366,7966,9009,5754]
+    line "PadString" [2,3,2,2,2,2,2,2,3,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
+    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,510]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,0,1574]
 ```
 
 #### Memory per Operation (B/op)
@@ -144,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924]
+    x-axis [6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -154,6 +164,8 @@ xychart-beta
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
+    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,0,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -166,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [495c14a,6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924]
+    x-axis [6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -176,6 +188,8 @@ xychart-beta
     line "PadString" [0,0,0,0,0,0,0,0,0,0]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
+    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,0,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/src/common/log.go
+++ b/src/common/log.go
@@ -19,7 +19,18 @@ func LogStdOut(logApp bool) {
 
 // SanitizeLog removes CRLF characters from a string to prevent log injection.
 func SanitizeLog(input string) string {
-	s := strings.ReplaceAll(input, "\n", "_")
-	s = strings.ReplaceAll(s, "\r", "_")
-	return s
+	if !strings.ContainsAny(input, "\n\r") {
+		return input
+	}
+	var b strings.Builder
+	b.Grow(len(input))
+	for i := 0; i < len(input); i++ {
+		c := input[i]
+		if c == '\n' || c == '\r' {
+			b.WriteByte('_')
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
 }

--- a/src/common/string_test.go
+++ b/src/common/string_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -170,4 +171,19 @@ func TestTrimNullBytesString_BufferReuse(t *testing.T) {
 	if result != "hello" {
 		t.Fatalf("result changed after buffer reuse: got %q, expected 'hello'", result)
 	}
+}
+
+func BenchmarkSanitizeLog(b *testing.B) {
+	safe := strings.Repeat("hello world ", 50)
+	unsafe := strings.Repeat("hello\r\nworld\n", 50)
+	b.Run("Safe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SanitizeLog(safe)
+		}
+	})
+	b.Run("Unsafe", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SanitizeLog(unsafe)
+		}
+	})
 }


### PR DESCRIPTION
Resolves #718

## Problem

`SanitizeLog` used double `strings.ReplaceAll`, traversing the string twice and creating up to 2 intermediate heap allocations. Called on hot paths for audit logging.

## Fix

Single-pass `strings.Builder` with `strings.ContainsAny` fast-path:
- **Safe strings** (no CRLF): zero allocations, returns original string
- **Unsafe strings** (with CRLF): single allocation via `strings.Builder`, single traversal

No `unsafe` usage — pure safe Go.

## Benchmark

```
BenchmarkSanitizeLog/Safe-8     0 allocs/op   ~500 ns/op
BenchmarkSanitizeLog/Unsafe-8   1 alloc/op   ~1600 ns/op  (was 2 allocs/op)
```

## Changelog

- `src/common/log.go`: Replaced double `strings.ReplaceAll` with single-pass `strings.Builder` + fast-path `strings.ContainsAny`
- `src/common/string_test.go`: Added `BenchmarkSanitizeLog` (Safe + Unsafe sub-benchmarks)