### PR TITLE
fix: add SigV4 timestamp freshness check to prevent replay attacks (#595)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2565,3 +2565,12 @@ ed3f77f,BenchmarkLoadGlobalConfig-8,5754.00,1312.00,37.00
 ed3f77f,BenchmarkPadString-8,1.99,0.00,0.00
 ed3f77f,BenchmarkSanitizeLog/Safe-8,509.90,0.00,0.00
 ed3f77f,BenchmarkSanitizeLog/Unsafe-8,1574.00,704.00,1.00
+596cec9,BenchmarkCheckMetricsAndSwap-8,9.49,0.00,0.00
+596cec9,BenchmarkCrushOptimized-8,382.20,0.00,0.00
+596cec9,BenchmarkCrushOriginal-8,464.00,164.00,3.00
+596cec9,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+596cec9,BenchmarkIndexSearch-8,1.69,0.00,0.00
+596cec9,BenchmarkLoadGlobalConfig-8,6420.00,1312.00,37.00
+596cec9,BenchmarkPadString-8,2.58,0.00,0.00
+596cec9,BenchmarkSanitizeLog/Safe-8,563.50,0.00,0.00
+596cec9,BenchmarkSanitizeLog/Unsafe-8,1680.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2592,3 +2592,12 @@ d2963d1,BenchmarkLoadGlobalConfig-8,16092.00,1312.00,37.00
 d2963d1,BenchmarkPadString-8,3.67,0.00,0.00
 d2963d1,BenchmarkSanitizeLog/Safe-8,932.20,0.00,0.00
 d2963d1,BenchmarkSanitizeLog/Unsafe-8,3581.00,704.00,1.00
+cc2b3a0,BenchmarkCheckMetricsAndSwap-8,12.55,0.00,0.00
+cc2b3a0,BenchmarkCrushOptimized-8,411.00,0.00,0.00
+cc2b3a0,BenchmarkCrushOriginal-8,573.80,164.00,3.00
+cc2b3a0,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+cc2b3a0,BenchmarkIndexSearch-8,2.29,0.00,0.00
+cc2b3a0,BenchmarkLoadGlobalConfig-8,8480.00,1312.00,37.00
+cc2b3a0,BenchmarkPadString-8,2.77,0.00,0.00
+cc2b3a0,BenchmarkSanitizeLog/Safe-8,758.90,0.00,0.00
+cc2b3a0,BenchmarkSanitizeLog/Unsafe-8,2269.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2583,3 +2583,12 @@ ed3f77f,BenchmarkSanitizeLog/Unsafe-8,1574.00,704.00,1.00
 126e08e,BenchmarkPadString-8,4.36,0.00,0.00
 126e08e,BenchmarkSanitizeLog/Safe-8,1086.00,0.00,0.00
 126e08e,BenchmarkSanitizeLog/Unsafe-8,2855.00,704.00,1.00
+d2963d1,BenchmarkCheckMetricsAndSwap-8,16.94,0.00,0.00
+d2963d1,BenchmarkCrushOptimized-8,611.00,0.00,0.00
+d2963d1,BenchmarkCrushOriginal-8,1014.00,164.00,3.00
+d2963d1,BenchmarkIndexDirectTracking-8,0.69,0.00,0.00
+d2963d1,BenchmarkIndexSearch-8,3.08,0.00,0.00
+d2963d1,BenchmarkLoadGlobalConfig-8,16092.00,1312.00,37.00
+d2963d1,BenchmarkPadString-8,3.67,0.00,0.00
+d2963d1,BenchmarkSanitizeLog/Safe-8,932.20,0.00,0.00
+d2963d1,BenchmarkSanitizeLog/Unsafe-8,3581.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2574,3 +2574,12 @@ ed3f77f,BenchmarkSanitizeLog/Unsafe-8,1574.00,704.00,1.00
 596cec9,BenchmarkPadString-8,2.58,0.00,0.00
 596cec9,BenchmarkSanitizeLog/Safe-8,563.50,0.00,0.00
 596cec9,BenchmarkSanitizeLog/Unsafe-8,1680.00,704.00,1.00
+126e08e,BenchmarkCheckMetricsAndSwap-8,21.99,0.00,0.00
+126e08e,BenchmarkCrushOptimized-8,508.40,0.00,0.00
+126e08e,BenchmarkCrushOriginal-8,564.40,164.00,3.00
+126e08e,BenchmarkIndexDirectTracking-8,1.13,0.00,0.00
+126e08e,BenchmarkIndexSearch-8,2.42,0.00,0.00
+126e08e,BenchmarkLoadGlobalConfig-8,12850.00,1312.00,37.00
+126e08e,BenchmarkPadString-8,4.36,0.00,0.00
+126e08e,BenchmarkSanitizeLog/Safe-8,1086.00,0.00,0.00
+126e08e,BenchmarkSanitizeLog/Unsafe-8,2855.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2601,3 +2601,12 @@ cc2b3a0,BenchmarkLoadGlobalConfig-8,8480.00,1312.00,37.00
 cc2b3a0,BenchmarkPadString-8,2.77,0.00,0.00
 cc2b3a0,BenchmarkSanitizeLog/Safe-8,758.90,0.00,0.00
 cc2b3a0,BenchmarkSanitizeLog/Unsafe-8,2269.00,704.00,1.00
+411f802,BenchmarkCheckMetricsAndSwap-8,10.91,0.00,0.00
+411f802,BenchmarkCrushOptimized-8,349.40,0.00,0.00
+411f802,BenchmarkCrushOriginal-8,546.00,164.00,3.00
+411f802,BenchmarkIndexDirectTracking-8,0.39,0.00,0.00
+411f802,BenchmarkIndexSearch-8,1.89,0.00,0.00
+411f802,BenchmarkLoadGlobalConfig-8,7218.00,1312.00,37.00
+411f802,BenchmarkPadString-8,2.46,0.00,0.00
+411f802,BenchmarkSanitizeLog/Safe-8,535.00,0.00,0.00
+411f802,BenchmarkSanitizeLog/Unsafe-8,1896.00,704.00,1.00

--- a/.github/scripts/test-external-client.sh
+++ b/.github/scripts/test-external-client.sh
@@ -77,8 +77,8 @@ FILE_SIZE=$(wc -c < $E2E_DIR/test_external.txt)
 
 # Compute real SigV4 signature for the PUT request
 TOKEN="a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"  # notsecret
-AMZ_DATE="20260727T120000Z"
-DATE_STAMP="20260727"
+AMZ_DATE=$(date -u +"%Y%m%dT%H%M%SZ")
+DATE_STAMP=$(date -u +"%Y%m%d")
 REGION="us-east-1"
 SIGNED_HEADERS="host;x-amz-content-sha256;x-amz-date"
 SIGNATURE=$(python3 -c "

--- a/docs/PENTESTING.md
+++ b/docs/PENTESTING.md
@@ -21,6 +21,7 @@ The pentest pipeline (`.github/workflows/pentest.yml`) runs 6 phases:
 | CVE | Vulnerability | Severity | Issue | Status |
 |---|---|---|---|---|
 | CVE-008 | S3 SigV4 signature bypass | Critical | #539 | ✅ Fixed (PR #549) |
+| CVE-010 | SigV4 replay attack (no timestamp freshness) | High | #595 | ✅ Fixed (PR #722) |
 | CVE-005 | Deduplication confusion attack | High | #540 | ✅ Fixed (PR #552) |
 | CVE-007 | Peer impersonation | High | #541 | ✅ Fixed (PR #553) |
 | CVE-002 | Arbitrary file download (GET) | High | #542 | ✅ Fixed (PR #554) |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        517.9n ± ∞ ¹    416.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       366.6n ± ∞ ¹    326.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     9.009µ ± ∞ ¹    5.754µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.565n ± ∞ ¹    1.991n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 13.080n ± ∞ ¹    7.838n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          4.085n ± ∞ ¹    1.614n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.7530n ± ∞ ¹   0.3766n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                                     509.9n ± ∞ ¹
-SanitizeLog/Unsafe-8                                   1.574µ ± ∞ ¹
-geomean                                40.43n          56.59n        -36.42%
+CrushOriginal-8                        416.3n ± ∞ ¹    464.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       326.2n ± ∞ ¹    382.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.754µ ± ∞ ¹    6.420µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            1.991n ± ∞ ¹    2.576n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     509.9n ± ∞ ¹    563.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.574µ ± ∞ ¹    1.680µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.838n ± ∞ ¹    9.486n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.614n ± ∞ ¹    1.690n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3766n ± ∞ ¹   0.4985n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                56.59n          65.50n        +15.75%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -58,11 +58,11 @@ CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹     
 CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 LoadGlobalConfig-8                    1.281Ki ± ∞ ¹   1.281Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
 PadString-8                             0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                                      0.000 ± ∞ ¹
-SanitizeLog/Unsafe-8                                    704.0 ± ∞ ¹
 geomean                                           ³                  +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
@@ -74,11 +74,11 @@ CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       
 CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 LoadGlobalConfig-8                      37.00 ± ∞ ¹   37.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 PadString-8                             0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                                    0.000 ± ∞ ¹
-SanitizeLog/Unsafe-8                                  1.000 ± ∞ ¹
 geomean                                           ³                +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 326.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 416.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5754.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 1.99 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 509.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1574.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 382.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 464.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6420.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.58 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 563.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1680.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f]
-    line "CheckMetricsAndSwap" [10,9,8,9,8,8,9,13,13,8]
-    line "CrushOptimized" [351,357,386,313,315,308,332,438,367,326]
-    line "CrushOriginal" [491,441,433,459,426,593,442,635,518,416]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,4,2]
-    line "LoadGlobalConfig" [6534,6713,7976,6301,5771,5790,6366,7966,9009,5754]
-    line "PadString" [2,3,2,2,2,2,2,2,3,2]
+    x-axis [327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9]
+    line "CheckMetricsAndSwap" [9,8,9,8,8,9,13,13,8,9]
+    line "CrushOptimized" [357,386,313,315,308,332,438,367,326,382]
+    line "CrushOriginal" [441,433,459,426,593,442,635,518,416,464]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,0]
+    line "IndexSearch" [3,3,3,3,3,3,3,4,2,2]
+    line "LoadGlobalConfig" [6713,7976,6301,5771,5790,6366,7966,9009,5754,6420]
+    line "PadString" [3,2,2,2,2,2,2,3,2,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,510]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,0,1574]
+    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,510,564]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,1574,1680]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f]
+    x-axis [327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,0,704]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6e77176,327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f]
+    x-axis [327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,0,1]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        416.3n ± ∞ ¹    464.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       326.2n ± ∞ ¹    382.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.754µ ± ∞ ¹    6.420µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            1.991n ± ∞ ¹    2.576n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     509.9n ± ∞ ¹    563.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.574µ ± ∞ ¹    1.680µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.838n ± ∞ ¹    9.486n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.614n ± ∞ ¹    1.690n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3766n ± ∞ ¹   0.4985n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                56.59n          65.50n        +15.75%
+CrushOriginal-8                        464.0n ± ∞ ¹    564.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       382.2n ± ∞ ¹    508.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.420µ ± ∞ ¹   12.850µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.576n ± ∞ ¹    4.356n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     563.5n ± ∞ ¹   1086.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.680µ ± ∞ ¹    2.855µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.486n ± ∞ ¹   21.990n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.690n ± ∞ ¹    2.418n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4985n ± ∞ ¹   1.1330n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                65.50n          113.0n        +72.50%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.49 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 382.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 464.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6420.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.58 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 563.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1680.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 21.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 508.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 564.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 1.13 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 12850.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 4.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 1086.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 2855.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9]
-    line "CheckMetricsAndSwap" [9,8,9,8,8,9,13,13,8,9]
-    line "CrushOptimized" [357,386,313,315,308,332,438,367,326,382]
-    line "CrushOriginal" [441,433,459,426,593,442,635,518,416,464]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,4,2,2]
-    line "LoadGlobalConfig" [6713,7976,6301,5771,5790,6366,7966,9009,5754,6420]
-    line "PadString" [3,2,2,2,2,2,2,3,2,3]
+    x-axis [32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e]
+    line "CheckMetricsAndSwap" [8,9,8,8,9,13,13,8,9,22]
+    line "CrushOptimized" [386,313,315,308,332,438,367,326,382,508]
+    line "CrushOriginal" [433,459,426,593,442,635,518,416,464,564]
+    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,1]
+    line "IndexSearch" [3,3,3,3,3,3,4,2,2,2]
+    line "LoadGlobalConfig" [7976,6301,5771,5790,6366,7966,9009,5754,6420,12850]
+    line "PadString" [2,2,2,2,2,2,3,2,3,4]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,510,564]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,1574,1680]
+    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,510,564,1086]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,1574,1680,2855]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9]
+    x-axis [32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,704,704]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [327b442,32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9]
+    x-axis [32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,0,1,1]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        564.4n ± ∞ ¹   1014.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       508.4n ± ∞ ¹    611.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     12.85µ ± ∞ ¹    16.09µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            4.356n ± ∞ ¹    3.675n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                    1086.0n ± ∞ ¹    932.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   2.855µ ± ∞ ¹    3.581µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  21.99n ± ∞ ¹    16.94n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.418n ± ∞ ¹    3.079n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 1.1330n ± ∞ ¹   0.6851n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                113.0n          117.8n        +4.27%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                       1014.0n ± ∞ ¹    573.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       611.0n ± ∞ ¹    411.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    16.092µ ± ∞ ¹    8.480µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            3.675n ± ∞ ¹    2.766n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     932.2n ± ∞ ¹    758.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   3.581µ ± ∞ ¹    2.269µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  16.94n ± ∞ ¹    12.55n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.079n ± ∞ ¹    2.285n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.6851n ± ∞ ¹   0.4993n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                117.8n          80.14n        -31.97%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 16.94 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 611.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 1014.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.08 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 16092.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 3.67 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 932.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 3581.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 411.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 573.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8480.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.77 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 758.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 2269.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1]
-    line "CheckMetricsAndSwap" [9,8,8,9,13,13,8,9,22,17]
-    line "CrushOptimized" [313,315,308,332,438,367,326,382,508,611]
-    line "CrushOriginal" [459,426,593,442,635,518,416,464,564,1014]
-    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,1,1]
-    line "IndexSearch" [3,3,3,3,3,4,2,2,2,3]
-    line "LoadGlobalConfig" [6301,5771,5790,6366,7966,9009,5754,6420,12850,16092]
-    line "PadString" [2,2,2,2,2,3,2,3,4,4]
+    x-axis [c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0]
+    line "CheckMetricsAndSwap" [8,8,9,13,13,8,9,22,17,13]
+    line "CrushOptimized" [315,308,332,438,367,326,382,508,611,411]
+    line "CrushOriginal" [426,593,442,635,518,416,464,564,1014,574]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,1,1,0]
+    line "IndexSearch" [3,3,3,3,4,2,2,2,3,2]
+    line "LoadGlobalConfig" [5771,5790,6366,7966,9009,5754,6420,12850,16092,8480]
+    line "PadString" [2,2,2,2,3,2,3,4,4,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,0,0,0,510,564,1086,932]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,1574,1680,2855,3581]
+    line "SanitizeLog/Safe" [0,0,0,0,0,510,564,1086,932,759]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,1574,1680,2855,3581,2269]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1]
+    x-axis [c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,704,704,704,704]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,704,704,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1]
+    x-axis [c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,1,1,1,1]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,1,1,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        464.0n ± ∞ ¹    564.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       382.2n ± ∞ ¹    508.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     6.420µ ± ∞ ¹   12.850µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.576n ± ∞ ¹    4.356n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     563.5n ± ∞ ¹   1086.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.680µ ± ∞ ¹    2.855µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.486n ± ∞ ¹   21.990n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.690n ± ∞ ¹    2.418n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4985n ± ∞ ¹   1.1330n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                65.50n          113.0n        +72.50%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        564.4n ± ∞ ¹   1014.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       508.4n ± ∞ ¹    611.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     12.85µ ± ∞ ¹    16.09µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            4.356n ± ∞ ¹    3.675n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                    1086.0n ± ∞ ¹    932.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   2.855µ ± ∞ ¹    3.581µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  21.99n ± ∞ ¹    16.94n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.418n ± ∞ ¹    3.079n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 1.1330n ± ∞ ¹   0.6851n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                113.0n          117.8n        +4.27%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 21.99 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 508.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 564.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 1.13 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.42 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 12850.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 4.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 1086.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 2855.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 16.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 611.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 1014.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.08 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 16092.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 3.67 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 932.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 3581.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e]
-    line "CheckMetricsAndSwap" [8,9,8,8,9,13,13,8,9,22]
-    line "CrushOptimized" [386,313,315,308,332,438,367,326,382,508]
-    line "CrushOriginal" [433,459,426,593,442,635,518,416,464,564]
-    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,1]
-    line "IndexSearch" [3,3,3,3,3,3,4,2,2,2]
-    line "LoadGlobalConfig" [7976,6301,5771,5790,6366,7966,9009,5754,6420,12850]
-    line "PadString" [2,2,2,2,2,2,3,2,3,4]
+    x-axis [9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1]
+    line "CheckMetricsAndSwap" [9,8,8,9,13,13,8,9,22,17]
+    line "CrushOptimized" [313,315,308,332,438,367,326,382,508,611]
+    line "CrushOriginal" [459,426,593,442,635,518,416,464,564,1014]
+    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,1,1]
+    line "IndexSearch" [3,3,3,3,3,4,2,2,2,3]
+    line "LoadGlobalConfig" [6301,5771,5790,6366,7966,9009,5754,6420,12850,16092]
+    line "PadString" [2,2,2,2,2,3,2,3,4,4]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,0,0,0,0,510,564,1086]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,1574,1680,2855]
+    line "SanitizeLog/Safe" [0,0,0,0,0,0,510,564,1086,932]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,1574,1680,2855,3581]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e]
+    x-axis [9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,704,704,704]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,704,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [32e1320,9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e]
+    x-axis [9ace83c,c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,0,1,1,1]
+    line "SanitizeLog/Unsafe" [0,0,0,0,0,0,1,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                       1014.0n ± ∞ ¹    573.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       611.0n ± ∞ ¹    411.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    16.092µ ± ∞ ¹    8.480µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            3.675n ± ∞ ¹    2.766n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     932.2n ± ∞ ¹    758.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   3.581µ ± ∞ ¹    2.269µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  16.94n ± ∞ ¹    12.55n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.079n ± ∞ ¹    2.285n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.6851n ± ∞ ¹   0.4993n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                117.8n          80.14n        -31.97%
+CrushOriginal-8                        573.8n ± ∞ ¹    546.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       411.0n ± ∞ ¹    349.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     8.480µ ± ∞ ¹    7.218µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.766n ± ∞ ¹    2.465n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     758.9n ± ∞ ¹    535.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   2.269µ ± ∞ ¹    1.896µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  12.55n ± ∞ ¹    10.91n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.285n ± ∞ ¹    1.886n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4993n ± ∞ ¹   0.3920n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                80.14n          67.15n        -16.21%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 12.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 411.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 573.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.29 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8480.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.77 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 758.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 2269.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 349.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 546.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7218.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 535.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1896.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0]
-    line "CheckMetricsAndSwap" [8,8,9,13,13,8,9,22,17,13]
-    line "CrushOptimized" [315,308,332,438,367,326,382,508,611,411]
-    line "CrushOriginal" [426,593,442,635,518,416,464,564,1014,574]
-    line "IndexDirectTracking" [0,0,0,0,1,0,0,1,1,0]
-    line "IndexSearch" [3,3,3,3,4,2,2,2,3,2]
-    line "LoadGlobalConfig" [5771,5790,6366,7966,9009,5754,6420,12850,16092,8480]
-    line "PadString" [2,2,2,2,3,2,3,4,4,3]
+    x-axis [c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802]
+    line "CheckMetricsAndSwap" [8,9,13,13,8,9,22,17,13,11]
+    line "CrushOptimized" [308,332,438,367,326,382,508,611,411,349]
+    line "CrushOriginal" [593,442,635,518,416,464,564,1014,574,546]
+    line "IndexDirectTracking" [0,0,0,1,0,0,1,1,0,0]
+    line "IndexSearch" [3,3,3,4,2,2,2,3,2,2]
+    line "LoadGlobalConfig" [5790,6366,7966,9009,5754,6420,12850,16092,8480,7218]
+    line "PadString" [2,2,2,3,2,3,4,4,3,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,0,0,510,564,1086,932,759]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,1574,1680,2855,3581,2269]
+    line "SanitizeLog/Safe" [0,0,0,0,510,564,1086,932,759,535]
+    line "SanitizeLog/Unsafe" [0,0,0,0,1574,1680,2855,3581,2269,1896]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0]
+    x-axis [c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,704,704,704,704,704]
+    line "SanitizeLog/Unsafe" [0,0,0,0,704,704,704,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c416bc5,c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0]
+    x-axis [c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,0,1,1,1,1,1]
+    line "SanitizeLog/Unsafe" [0,0,0,0,1,1,1,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -294,6 +294,7 @@ Security gates **only fail on `workflow_dispatch`** (manual trigger), not on PR/
 | CVE | Vulnerability | Severity | Issue | Status |
 |---|---|---|---|---|
 | CVE-008 | S3 SigV4 signature bypass | Critical | #539 | ✅ Fixed (PR #549) |
+| CVE-010 | SigV4 replay attack (no timestamp freshness) | High | #595 | ✅ Fixed (PR #722) |
 | CVE-005 | Deduplication confusion attack | High | #540 | ✅ Fixed (PR #552) |
 | CVE-007 | Peer impersonation | High | #541 | ✅ Fixed (PR #553) |
 | CVE-002 | Arbitrary file download (GET) | High | #542 | ✅ Fixed (PR #554) |

--- a/src/transport/external_client_test.go
+++ b/src/transport/external_client_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	"go.uber.org/goleak"
@@ -15,8 +16,9 @@ func TestS3Communicator_ExternalClientDetection(t *testing.T) {
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
 	t.Run("aws-cli without X-Momo-Requested-Mode is external", func(t *testing.T) {
-		amzDate := "20260604T120000Z"
-		dateStamp := "20260604"
+		now := time.Now().UTC()
+		amzDate := now.Format("20060102T150405Z")
+		dateStamp := now.Format("20060102")
 		region := "us-east-1"
 		payloadHash := "dummyhash"
 		signedHeaders := "host;x-amz-date"

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -89,8 +89,9 @@ func TestS3Communicator_AWSV4Auth(t *testing.T) {
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 
-	amzDate := "20260604T120000Z"
-	dateStamp := "20260604"
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
 	region := "us-east-1"
 	payloadHash := "dummyhash"
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"

--- a/src/transport/sigv4.go
+++ b/src/transport/sigv4.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 )
 
 type sigV4Components struct {
@@ -222,6 +223,26 @@ func hexHMAC(key []byte, data string) string {
 
 var emptyStringSHA256 = hexSHA256(nil)
 
+var sigV4MaxSkew = 15 * time.Minute
+
+func verifySigV4Timestamp(amzDate string) bool {
+	parsedTime, err := time.Parse("20060102T150405Z", amzDate)
+	if err != nil {
+		log.Printf("AUDIT: SigV4 rejected unparseable X-Amz-Date %q: %v", amzDate, err)
+		return false
+	}
+	now := time.Now().UTC()
+	skew := now.Sub(parsedTime)
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > sigV4MaxSkew {
+		log.Printf("AUDIT: SigV4 rejected stale/future X-Amz-Date %q (skew %v > %v)", amzDate, skew, sigV4MaxSkew)
+		return false
+	}
+	return true
+}
+
 func verifySigV4Signature(req *http.Request, authHeader, secretKey string) bool {
 	components, ok := parseSigV4AuthHeader(authHeader)
 	if !ok {
@@ -231,6 +252,10 @@ func verifySigV4Signature(req *http.Request, authHeader, secretKey string) bool 
 	amzDate := req.Header.Get("X-Amz-Date")
 	if amzDate == "" {
 		amzDate = components.AmzDate
+	}
+
+	if !verifySigV4Timestamp(amzDate) {
+		return false
 	}
 
 	payloadHash := req.Header.Get("X-Amz-Content-Sha256")

--- a/src/transport/sigv4.go
+++ b/src/transport/sigv4.go
@@ -223,7 +223,7 @@ func hexHMAC(key []byte, data string) string {
 
 var emptyStringSHA256 = hexSHA256(nil)
 
-var sigV4MaxSkew = 15 * time.Minute
+var sigV4MaxSkew = 15 * time.Minute // max allowed clock skew for X-Amz-Date (replay attack prevention)
 
 func verifySigV4Timestamp(amzDate string) bool {
 	parsedTime, err := time.Parse("20060102T150405Z", amzDate)

--- a/src/transport/sigv4.go
+++ b/src/transport/sigv4.go
@@ -225,7 +225,14 @@ var emptyStringSHA256 = hexSHA256(nil)
 
 var sigV4MaxSkew = 15 * time.Minute // max allowed clock skew for X-Amz-Date (replay attack prevention)
 
-func verifySigV4Timestamp(amzDate string) bool {
+func verifySigV4Timestamp(amzDate string) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Recovered from panic in verifySigV4Timestamp: %v", r)
+			ok = false
+		}
+	}()
+
 	parsedTime, err := time.Parse("20060102T150405Z", amzDate)
 	if err != nil {
 		log.Printf("AUDIT: SigV4 rejected unparseable X-Amz-Date %q: %v", amzDate, err)
@@ -243,6 +250,9 @@ func verifySigV4Timestamp(amzDate string) bool {
 	return true
 }
 
+// verifySigV4Signature validates the SigV4 signature and timestamp freshness.
+// Returns bool (consistent with hmac.Equal); the caller in HandshakeServer
+// maps false → syscall.EACCES per Rule 10 (POSIX Error Mapping).
 func verifySigV4Signature(req *http.Request, authHeader, secretKey string) bool {
 	components, ok := parseSigV4AuthHeader(authHeader)
 	if !ok {

--- a/src/transport/sigv4_test.go
+++ b/src/transport/sigv4_test.go
@@ -1,0 +1,104 @@
+package transport
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func buildSigV4Request(t *testing.T, amzDate, dateStamp, region, secretKey string) (*http.Request, string) {
+	t.Helper()
+	payloadHash := "dummyhash"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := "PUT\n/test-file.txt\n\nhost:127.0.0.1:4440\nx-amz-content-sha256:" + payloadHash + "\nx-amz-date:" + amzDate + "\n\n" + signedHeaders + "\n" + payloadHash
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+	signingKey := deriveSigningKey(secretKey, dateStamp, region)
+	signature := computeSignature(signingKey, stringToSign)
+
+	authHeader := "AWS4-HMAC-SHA256 Credential=" + secretKey + "/" + dateStamp + "/" + region + "/s3/aws4_request, SignedHeaders=" + signedHeaders + ", Signature=" + signature
+
+	req := &http.Request{
+		Method: "PUT",
+		Host:   "127.0.0.1:4440",
+		Header: http.Header{},
+		URL:    &url.URL{Path: "/test-file.txt"},
+	}
+	req.Header.Set("Authorization", authHeader)
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	return req, authHeader
+}
+
+func TestVerifySigV4Timestamp_Fresh(t *testing.T) {
+	amzDate := time.Now().UTC().Format("20060102T150405Z")
+	if !verifySigV4Timestamp(amzDate) {
+		t.Fatal("fresh timestamp should be accepted")
+	}
+}
+
+func TestVerifySigV4Timestamp_Stale(t *testing.T) {
+	amzDate := time.Now().UTC().Add(-30 * time.Minute).Format("20060102T150405Z")
+	if verifySigV4Timestamp(amzDate) {
+		t.Fatal("stale timestamp (30m old) should be rejected")
+	}
+}
+
+func TestVerifySigV4Timestamp_Future(t *testing.T) {
+	amzDate := time.Now().UTC().Add(30 * time.Minute).Format("20060102T150405Z")
+	if verifySigV4Timestamp(amzDate) {
+		t.Fatal("future timestamp (30m ahead) should be rejected")
+	}
+}
+
+func TestVerifySigV4Timestamp_Malformed(t *testing.T) {
+	if verifySigV4Timestamp("not-a-date") {
+		t.Fatal("malformed timestamp should be rejected")
+	}
+}
+
+func TestVerifySigV4Timestamp_Boundary(t *testing.T) {
+	original := sigV4MaxSkew
+	defer func() { sigV4MaxSkew = original }()
+	sigV4MaxSkew = 5 * time.Minute
+
+	amzDate := time.Now().UTC().Add(-4 * time.Minute).Format("20060102T150405Z")
+	if !verifySigV4Timestamp(amzDate) {
+		t.Fatal("timestamp within skew boundary should be accepted")
+	}
+
+	amzDate = time.Now().UTC().Add(-6 * time.Minute).Format("20060102T150405Z")
+	if verifySigV4Timestamp(amzDate) {
+		t.Fatal("timestamp beyond skew boundary should be rejected")
+	}
+}
+
+func TestVerifySigV4Signature_ReplayAttack(t *testing.T) {
+	secretKey := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	staleTime := time.Now().UTC().Add(-1 * time.Hour)
+	amzDate := staleTime.Format("20060102T150405Z")
+	dateStamp := staleTime.Format("20060102")
+	region := "us-east-1"
+
+	req, authHeader := buildSigV4Request(t, amzDate, dateStamp, region, secretKey)
+	if verifySigV4Signature(req, authHeader, secretKey) {
+		t.Fatal("replay attack: stale signed request should be rejected")
+	}
+}
+
+func TestVerifySigV4Signature_FreshRequest(t *testing.T) {
+	secretKey := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	region := "us-east-1"
+
+	req, authHeader := buildSigV4Request(t, amzDate, dateStamp, region, secretKey)
+	if !verifySigV4Signature(req, authHeader, secretKey) {
+		t.Fatal("fresh signed request should be accepted")
+	}
+}


### PR DESCRIPTION
Resolves #595

## Bug Description
`verifySigV4Signature` validated the cryptographic signature but never checked whether `X-Amz-Date` is within an acceptable time window (AWS recommends ±15 minutes). An attacker who captures a valid signed request can replay it indefinitely.

## Fix
Added `verifySigV4Timestamp` function that parses `X-Amz-Date` and rejects requests where the timestamp skew exceeds `sigV4MaxSkew` (15 minutes default). The check runs **before** the expensive signature computation, so stale requests are rejected early.

- Added package-level `sigV4MaxSkew` var (15m default) for testability
- Added `time` import to `sigv4.go`
- Updated existing tests (`TestS3Communicator_AWSV4Auth`, `TestS3Communicator_ExternalClientDetection`) to use dynamic timestamps instead of hardcoded stale dates

## Tests
New file `src/transport/sigv4_test.go` with 6 tests:
- `TestVerifySigV4Timestamp_Fresh` — current timestamp accepted
- `TestVerifySigV4Timestamp_Stale` — 30m-old timestamp rejected
- `TestVerifySigV4Timestamp_Future` — 30m-future timestamp rejected
- `TestVerifySigV4Timestamp_Malformed` — unparseable date rejected
- `TestVerifySigV4Timestamp_Boundary` — configurable skew boundary (4m ok, 6m rejected with 5m skew)
- `TestVerifySigV4Signature_ReplayAttack` — valid signature with 1h-old timestamp rejected
- `TestVerifySigV4Signature_FreshRequest` — valid signature with current timestamp accepted

## Changelog
- `126e08e`: Added SigV4 timestamp freshness check (`verifySigV4Timestamp`), `sigV4MaxSkew` var, 6 new tests, updated 2 existing tests to use dynamic timestamps

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `go work vendor` — no diff ✅