### PR TITLE
fix: guard wg.Add with closed check in Dial and acceptLoop (#597)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2610,3 +2610,12 @@ cc2b3a0,BenchmarkSanitizeLog/Unsafe-8,2269.00,704.00,1.00
 411f802,BenchmarkPadString-8,2.46,0.00,0.00
 411f802,BenchmarkSanitizeLog/Safe-8,535.00,0.00,0.00
 411f802,BenchmarkSanitizeLog/Unsafe-8,1896.00,704.00,1.00
+b6d6f22,BenchmarkCheckMetricsAndSwap-8,11.36,0.00,0.00
+b6d6f22,BenchmarkCrushOptimized-8,375.10,0.00,0.00
+b6d6f22,BenchmarkCrushOriginal-8,560.20,164.00,3.00
+b6d6f22,BenchmarkIndexDirectTracking-8,0.47,0.00,0.00
+b6d6f22,BenchmarkIndexSearch-8,1.91,0.00,0.00
+b6d6f22,BenchmarkLoadGlobalConfig-8,8185.00,1312.00,37.00
+b6d6f22,BenchmarkPadString-8,2.98,0.00,0.00
+b6d6f22,BenchmarkSanitizeLog/Safe-8,625.80,0.00,0.00
+b6d6f22,BenchmarkSanitizeLog/Unsafe-8,2138.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        573.8n ± ∞ ¹    546.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       411.0n ± ∞ ¹    349.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.480µ ± ∞ ¹    7.218µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.766n ± ∞ ¹    2.465n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     758.9n ± ∞ ¹    535.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   2.269µ ± ∞ ¹    1.896µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  12.55n ± ∞ ¹    10.91n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.285n ± ∞ ¹    1.886n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4993n ± ∞ ¹   0.3920n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                80.14n          67.15n        -16.21%
+CrushOriginal-8                        546.0n ± ∞ ¹    560.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       349.4n ± ∞ ¹    375.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.218µ ± ∞ ¹    8.185µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.465n ± ∞ ¹    2.982n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     535.0n ± ∞ ¹    625.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.896µ ± ∞ ¹    2.138µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  10.91n ± ∞ ¹    11.36n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.886n ± ∞ ¹    1.907n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3920n ± ∞ ¹   0.4736n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                67.15n          74.47n        +10.89%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 349.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 546.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.89 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7218.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 535.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1896.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 375.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 560.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8185.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.98 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 625.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 2138.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802]
-    line "CheckMetricsAndSwap" [8,9,13,13,8,9,22,17,13,11]
-    line "CrushOptimized" [308,332,438,367,326,382,508,611,411,349]
-    line "CrushOriginal" [593,442,635,518,416,464,564,1014,574,546]
-    line "IndexDirectTracking" [0,0,0,1,0,0,1,1,0,0]
-    line "IndexSearch" [3,3,3,4,2,2,2,3,2,2]
-    line "LoadGlobalConfig" [5790,6366,7966,9009,5754,6420,12850,16092,8480,7218]
-    line "PadString" [2,2,2,3,2,3,4,4,3,2]
+    x-axis [7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22]
+    line "CheckMetricsAndSwap" [9,13,13,8,9,22,17,13,11,11]
+    line "CrushOptimized" [332,438,367,326,382,508,611,411,349,375]
+    line "CrushOriginal" [442,635,518,416,464,564,1014,574,546,560]
+    line "IndexDirectTracking" [0,0,1,0,0,1,1,0,0,0]
+    line "IndexSearch" [3,3,4,2,2,2,3,2,2,2]
+    line "LoadGlobalConfig" [6366,7966,9009,5754,6420,12850,16092,8480,7218,8185]
+    line "PadString" [2,2,3,2,3,4,4,3,2,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,0,510,564,1086,932,759,535]
-    line "SanitizeLog/Unsafe" [0,0,0,0,1574,1680,2855,3581,2269,1896]
+    line "SanitizeLog/Safe" [0,0,0,510,564,1086,932,759,535,626]
+    line "SanitizeLog/Unsafe" [0,0,0,1574,1680,2855,3581,2269,1896,2138]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802]
+    x-axis [7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,704,704,704,704,704,704]
+    line "SanitizeLog/Unsafe" [0,0,0,704,704,704,704,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c359418,7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802]
+    x-axis [7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,0,1,1,1,1,1,1]
+    line "SanitizeLog/Unsafe" [0,0,0,1,1,1,1,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -89,10 +89,15 @@ func (t *TCPTransport) acceptLoop() {
 		}
 
 		t.mu.Lock()
+		if t.closed {
+			t.mu.Unlock()
+			conn.Close()
+			continue
+		}
 		t.conns[conn] = struct{}{}
+		t.wg.Add(1)
 		t.mu.Unlock()
 
-		t.wg.Add(1)
 		go t.handleConn(conn)
 	}
 }
@@ -172,14 +177,19 @@ func (t *TCPTransport) Dial(id int32, addr string) (*Peer, error) {
 	}
 
 	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		conn.Close()
+		return nil, fmt.Errorf("transport closed: %w", syscall.ECONNREFUSED)
+	}
 	t.conns[conn] = struct{}{}
+	t.wg.Add(1)
 	t.mu.Unlock()
 
 	peer := NewPeer(id, addr)
 	peer.SetConn(conn)
 	t.peerMap.Add(peer)
 
-	t.wg.Add(1)
 	go t.readLoop(id, conn)
 
 	log.Printf("P2P dialed peer %d at %s", id, addr)

--- a/src/p2p/tcp_transport_test.go
+++ b/src/p2p/tcp_transport_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"math/big"
 	"net"
+	"sync"
 	"testing"
 	"time"
 )
@@ -229,6 +230,56 @@ func TestTCPTransport_TLS(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for TLS RPC")
+	}
+}
+
+func TestTCPTransport_DialAfterClose(t *testing.T) {
+	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := ln.Addr().String()
+	ln.Close()
+
+	if err := tr.Listen(addr); err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	_, err := tr.Dial(2, addr)
+	if err == nil {
+		t.Fatal("expected error when Dialing after Close")
+	}
+}
+
+func TestTCPTransport_ConcurrentDialClose(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+
+		ln, _ := net.Listen("tcp", "127.0.0.1:0")
+		addr := ln.Addr().String()
+		ln.Close()
+
+		if err := tr.Listen(addr); err != nil {
+			t.Fatalf("Listen failed: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			tr.Dial(2, addr)
+		}()
+
+		go func() {
+			defer wg.Done()
+			tr.Close()
+		}()
+
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
Resolves #597

## Problem

`TCPTransport.Dial` calls `t.wg.Add(1)` without checking if `Close` has been called. If `Close` runs concurrently, `t.wg.Wait()` may return before the `readLoop` goroutine finishes, or the `Add` may race with `Wait` — undefined behavior per `sync.WaitGroup` docs.

The same race exists in `acceptLoop`: `t.wg.Add(1)` was outside the mutex lock with no `closed` check.

## Fix

**Dial** (`src/p2p/tcp_transport.go:179-187`):
- Move `t.wg.Add(1)` inside `t.mu.Lock()` block
- Check `t.closed` before adding to conns/wg; if closed, close the conn and return error

**acceptLoop** (`src/p2p/tcp_transport.go:91-99`):
- Move `t.wg.Add(1)` inside `t.mu.Lock()` block
- Check `t.closed` before adding; if closed, close the conn and continue

## Tests

- `TestTCPTransport_DialAfterClose`: verifies Dial returns error after Close
- `TestTCPTransport_ConcurrentDialClose`: 100 iterations of concurrent Dial+Close with race detector

## Changelog

- Fixed: `wg.Add` race condition in `TCPTransport.Dial` and `acceptLoop` when `Close` runs concurrently (#597)