### PR TITLE
fix: connect discovered peers via outbound dial (#598)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2619,3 +2619,12 @@ b6d6f22,BenchmarkLoadGlobalConfig-8,8185.00,1312.00,37.00
 b6d6f22,BenchmarkPadString-8,2.98,0.00,0.00
 b6d6f22,BenchmarkSanitizeLog/Safe-8,625.80,0.00,0.00
 b6d6f22,BenchmarkSanitizeLog/Unsafe-8,2138.00,704.00,1.00
+e9ef85d,BenchmarkCheckMetricsAndSwap-8,9.18,0.00,0.00
+e9ef85d,BenchmarkCrushOptimized-8,374.60,0.00,0.00
+e9ef85d,BenchmarkCrushOriginal-8,677.20,164.00,3.00
+e9ef85d,BenchmarkIndexDirectTracking-8,0.56,0.00,0.00
+e9ef85d,BenchmarkIndexSearch-8,1.70,0.00,0.00
+e9ef85d,BenchmarkLoadGlobalConfig-8,9886.00,1312.00,37.00
+e9ef85d,BenchmarkPadString-8,2.51,0.00,0.00
+e9ef85d,BenchmarkSanitizeLog/Safe-8,647.10,0.00,0.00
+e9ef85d,BenchmarkSanitizeLog/Unsafe-8,1962.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2628,3 +2628,12 @@ e9ef85d,BenchmarkLoadGlobalConfig-8,9886.00,1312.00,37.00
 e9ef85d,BenchmarkPadString-8,2.51,0.00,0.00
 e9ef85d,BenchmarkSanitizeLog/Safe-8,647.10,0.00,0.00
 e9ef85d,BenchmarkSanitizeLog/Unsafe-8,1962.00,704.00,1.00
+65c9292,BenchmarkCheckMetricsAndSwap-8,8.52,0.00,0.00
+65c9292,BenchmarkCrushOptimized-8,377.10,0.00,0.00
+65c9292,BenchmarkCrushOriginal-8,562.70,164.00,3.00
+65c9292,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+65c9292,BenchmarkIndexSearch-8,1.95,0.00,0.00
+65c9292,BenchmarkLoadGlobalConfig-8,8691.00,1312.00,37.00
+65c9292,BenchmarkPadString-8,2.67,0.00,0.00
+65c9292,BenchmarkSanitizeLog/Safe-8,609.50,0.00,0.00
+65c9292,BenchmarkSanitizeLog/Unsafe-8,2106.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        546.0n ± ∞ ¹    560.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       349.4n ± ∞ ¹    375.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.218µ ± ∞ ¹    8.185µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.465n ± ∞ ¹    2.982n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     535.0n ± ∞ ¹    625.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.896µ ± ∞ ¹    2.138µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  10.91n ± ∞ ¹    11.36n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.886n ± ∞ ¹    1.907n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3920n ± ∞ ¹   0.4736n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                67.15n          74.47n        +10.89%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        560.2n ± ∞ ¹    677.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       375.1n ± ∞ ¹    374.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     8.185µ ± ∞ ¹    9.886µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.982n ± ∞ ¹    2.512n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     625.8n ± ∞ ¹    647.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   2.138µ ± ∞ ¹    1.962µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 11.360n ± ∞ ¹    9.176n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.907n ± ∞ ¹    1.699n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4736n ± ∞ ¹   0.5571n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                74.47n          74.35n        -0.15%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 375.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 560.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8185.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.98 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 625.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 2138.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.18 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 374.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 677.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.56 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9886.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.51 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 647.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1962.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22]
-    line "CheckMetricsAndSwap" [9,13,13,8,9,22,17,13,11,11]
-    line "CrushOptimized" [332,438,367,326,382,508,611,411,349,375]
-    line "CrushOriginal" [442,635,518,416,464,564,1014,574,546,560]
-    line "IndexDirectTracking" [0,0,1,0,0,1,1,0,0,0]
-    line "IndexSearch" [3,3,4,2,2,2,3,2,2,2]
-    line "LoadGlobalConfig" [6366,7966,9009,5754,6420,12850,16092,8480,7218,8185]
-    line "PadString" [2,2,3,2,3,4,4,3,2,3]
+    x-axis [33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d]
+    line "CheckMetricsAndSwap" [13,13,8,9,22,17,13,11,11,9]
+    line "CrushOptimized" [438,367,326,382,508,611,411,349,375,375]
+    line "CrushOriginal" [635,518,416,464,564,1014,574,546,560,677]
+    line "IndexDirectTracking" [0,1,0,0,1,1,0,0,0,1]
+    line "IndexSearch" [3,4,2,2,2,3,2,2,2,2]
+    line "LoadGlobalConfig" [7966,9009,5754,6420,12850,16092,8480,7218,8185,9886]
+    line "PadString" [2,3,2,3,4,4,3,2,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,0,510,564,1086,932,759,535,626]
-    line "SanitizeLog/Unsafe" [0,0,0,1574,1680,2855,3581,2269,1896,2138]
+    line "SanitizeLog/Safe" [0,0,510,564,1086,932,759,535,626,647]
+    line "SanitizeLog/Unsafe" [0,0,1574,1680,2855,3581,2269,1896,2138,1962]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22]
+    x-axis [33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,704,704,704,704,704,704,704]
+    line "SanitizeLog/Unsafe" [0,0,704,704,704,704,704,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7692163,33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22]
+    x-axis [33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,0,1,1,1,1,1,1,1]
+    line "SanitizeLog/Unsafe" [0,0,1,1,1,1,1,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        560.2n ± ∞ ¹    677.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       375.1n ± ∞ ¹    374.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.185µ ± ∞ ¹    9.886µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.982n ± ∞ ¹    2.512n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     625.8n ± ∞ ¹    647.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   2.138µ ± ∞ ¹    1.962µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 11.360n ± ∞ ¹    9.176n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.907n ± ∞ ¹    1.699n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4736n ± ∞ ¹   0.5571n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                74.47n          74.35n        -0.15%
+CrushOriginal-8                        677.2n ± ∞ ¹    562.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       374.6n ± ∞ ¹    377.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.886µ ± ∞ ¹    8.691µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.512n ± ∞ ¹    2.665n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     647.1n ± ∞ ¹    609.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.962µ ± ∞ ¹    2.106µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.176n ± ∞ ¹    8.515n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.699n ± ∞ ¹    1.951n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5571n ± ∞ ¹   0.3593n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                74.35n          69.46n        -6.58%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.18 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 374.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 677.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9886.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.51 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 647.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1962.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 377.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 562.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.95 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8691.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.67 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 609.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 2106.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d]
-    line "CheckMetricsAndSwap" [13,13,8,9,22,17,13,11,11,9]
-    line "CrushOptimized" [438,367,326,382,508,611,411,349,375,375]
-    line "CrushOriginal" [635,518,416,464,564,1014,574,546,560,677]
-    line "IndexDirectTracking" [0,1,0,0,1,1,0,0,0,1]
-    line "IndexSearch" [3,4,2,2,2,3,2,2,2,2]
-    line "LoadGlobalConfig" [7966,9009,5754,6420,12850,16092,8480,7218,8185,9886]
-    line "PadString" [2,3,2,3,4,4,3,2,3,3]
+    x-axis [867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292]
+    line "CheckMetricsAndSwap" [13,8,9,22,17,13,11,11,9,9]
+    line "CrushOptimized" [367,326,382,508,611,411,349,375,375,377]
+    line "CrushOriginal" [518,416,464,564,1014,574,546,560,677,563]
+    line "IndexDirectTracking" [1,0,0,1,1,0,0,0,1,0]
+    line "IndexSearch" [4,2,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [9009,5754,6420,12850,16092,8480,7218,8185,9886,8691]
+    line "PadString" [3,2,3,4,4,3,2,3,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [0,0,510,564,1086,932,759,535,626,647]
-    line "SanitizeLog/Unsafe" [0,0,1574,1680,2855,3581,2269,1896,2138,1962]
+    line "SanitizeLog/Safe" [0,510,564,1086,932,759,535,626,647,610]
+    line "SanitizeLog/Unsafe" [0,1574,1680,2855,3581,2269,1896,2138,1962,2106]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d]
+    x-axis [867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -165,7 +165,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,704,704,704,704,704,704,704,704]
+    line "SanitizeLog/Unsafe" [0,704,704,704,704,704,704,704,704,704]
 ```
 
 #### Allocations per Operation (allocs/op)
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [33f292e,867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d]
+    x-axis [867b924,ed3f77f,596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
@@ -189,7 +189,7 @@ xychart-beta
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
-    line "SanitizeLog/Unsafe" [0,0,1,1,1,1,1,1,1,1]
+    line "SanitizeLog/Unsafe" [0,1,1,1,1,1,1,1,1,1]
 ```
 <!-- BENCHMARK_RESULTS_END -->
 

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -661,6 +661,7 @@ func (g *Gossiper) handleHeartbeat(rpc *RPC) {
 			if onJoin != nil {
 				onJoin(peer)
 			}
+			g.connectToPeer(peer)
 		}
 	}
 
@@ -701,6 +702,7 @@ func (g *Gossiper) handleMembership(rpc *RPC) {
 			if onJoin != nil {
 				onJoin(peer)
 			}
+			g.connectToPeer(peer)
 		}
 	}
 }
@@ -728,6 +730,26 @@ func (g *Gossiper) handleSuspect(rpc *RPC) {
 			log.Printf("Gossip: peer %d marked SUSPECT via announcement from %d", suspectID, rpc.From)
 		}
 	}
+}
+
+// connectToPeer attempts to establish an outbound connection to a peer that was
+// discovered via gossip but added to the peer map without a live connection.
+// Dialing is non-blocking for the caller so the consumer loop is not stalled
+// when a heartbeat announces many new peers.
+func (g *Gossiper) connectToPeer(peer *Peer) {
+	if peer == nil || peer.Conn() != nil {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("Gossip connectToPeer panic recovered: %v (errno=%d)", r, syscall.EIO)
+			}
+		}()
+		if err := g.transport.Connect(peer); err != nil {
+			log.Printf("Gossip: failed to connect to discovered peer %d at %s: %v (errno=%d)", peer.ID, peer.Addr, err, syscall.EHOSTUNREACH)
+		}
+	}()
 }
 
 // AnnounceJoin sends a membership announcement to all peers about a newly joined node.

--- a/src/p2p/integration_test.go
+++ b/src/p2p/integration_test.go
@@ -124,3 +124,89 @@ func TestIntegration_NodeJoinAfterStart(t *testing.T) {
 		t.Error("node 2 should have discovered node 3 via gossip dissemination")
 	}
 }
+
+// TestIntegration_DynamicPeerGetsConnected verifies that a peer discovered via
+// gossip (not bootstrapped) is actually given a live connection, so that
+// Send/Broadcast to it does not fail with ENOTCONN (issue #598).
+func TestIntegration_DynamicPeerGetsConnected(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	tr3 := NewTCPTransport(TCPTransportConfig{LocalID: 3})
+	defer tr1.Close()
+	defer tr2.Close()
+	defer tr3.Close()
+
+	getFreeAddr := func() string {
+		ln, _ := net.Listen("tcp", "127.0.0.1:0")
+		a := ln.Addr().String()
+		ln.Close()
+		return a
+	}
+	addr1 := getFreeAddr()
+	addr2 := getFreeAddr()
+	addr3 := getFreeAddr()
+
+	if err := tr1.Listen(addr1); err != nil {
+		t.Fatalf("tr1 Listen failed: %v", err)
+	}
+	if err := tr2.Listen(addr2); err != nil {
+		t.Fatalf("tr2 Listen failed: %v", err)
+	}
+	if err := tr3.Listen(addr3); err != nil {
+		t.Fatalf("tr3 Listen failed: %v", err)
+	}
+
+	cfg := GossipConfig{
+		HeartbeatInterval: 50 * time.Millisecond,
+		SuspicionTimeout:  2 * time.Second,
+		Fanout:            3,
+		PingTimeout:       100 * time.Millisecond,
+		IndirectPingCount: 3,
+		RTTAlpha:          0.25,
+	}
+	cfg1 := cfg
+	cfg1.LocalID = 1
+	cfg2 := cfg
+	cfg2.LocalID = 2
+	cfg3 := cfg
+	cfg3.LocalID = 3
+
+	g1 := NewGossiper(cfg1, tr1)
+	g2 := NewGossiper(cfg2, tr2)
+	g3 := NewGossiper(cfg3, tr3)
+	defer g1.Close()
+	defer g2.Close()
+	defer g3.Close()
+
+	// Node 1 bootstraps to nodes 2 and 3. Nodes 2 and 3 do NOT directly
+	// connect to each other; node 2 must discover node 3 purely via gossip.
+	if _, err := tr1.Dial(2, addr2); err != nil {
+		t.Fatalf("node 1 dial node 2 failed: %v", err)
+	}
+	if _, err := tr1.Dial(3, addr3); err != nil {
+		t.Fatalf("node 1 dial node 3 failed: %v", err)
+	}
+
+	g1.Run()
+	g2.Run()
+	g3.Run()
+
+	deadline := time.After(3 * time.Second)
+	for {
+		if peer := tr2.Peers().Get(3); peer != nil {
+			if peer.Conn() != nil {
+				break
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("node 2 never established a connection to discovered peer 3")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Sanity check the discovered peer on node 2 is dialable via Send.
+	if err := tr2.Send(3, &RPC{From: 2, Type: MsgHeartbeat, Payload: []byte("discovered")}); err != nil {
+		t.Fatalf("Send to dynamically discovered peer failed: %v", err)
+	}
+}

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -158,6 +158,14 @@ func (t *TCPTransport) handleConn(conn net.Conn) (err error) {
 	}
 }
 
+// dialAddr establishes a raw network connection to the given address.
+func (t *TCPTransport) dialAddr(addr string) (net.Conn, error) {
+	if t.cfg.TLSConfig != nil {
+		return tls.Dial("tcp", addr, t.cfg.TLSConfig)
+	}
+	return net.DialTimeout("tcp", addr, 5*time.Second)
+}
+
 // Dial connects to a peer at the given address.
 // If a peer with the same ID already exists, it returns the existing peer.
 func (t *TCPTransport) Dial(id int32, addr string) (*Peer, error) {
@@ -165,15 +173,9 @@ func (t *TCPTransport) Dial(id int32, addr string) (*Peer, error) {
 		return existing, nil
 	}
 
-	var conn net.Conn
-	var dialErr error
-	if t.cfg.TLSConfig != nil {
-		conn, dialErr = tls.Dial("tcp", addr, t.cfg.TLSConfig)
-	} else {
-		conn, dialErr = net.DialTimeout("tcp", addr, 5*time.Second)
-	}
-	if dialErr != nil {
-		return nil, fmt.Errorf("p2p dial %s failed: %v: %w", addr, dialErr, syscall.ECONNREFUSED)
+	conn, err := t.dialAddr(addr)
+	if err != nil {
+		return nil, fmt.Errorf("p2p dial %s failed: %v: %w", addr, err, syscall.ECONNREFUSED)
 	}
 
 	t.mu.Lock()
@@ -194,6 +196,39 @@ func (t *TCPTransport) Dial(id int32, addr string) (*Peer, error) {
 
 	log.Printf("P2P dialed peer %d at %s", id, addr)
 	return peer, nil
+}
+
+// Connect establishes an outbound connection to an already-registered peer.
+// It is used to wire up peers discovered via gossip membership updates that
+// were added to the peer map without a live connection.
+func (t *TCPTransport) Connect(peer *Peer) error {
+	if peer == nil {
+		return fmt.Errorf("cannot connect nil peer: %w", syscall.EINVAL)
+	}
+	if peer.Conn() != nil {
+		return nil
+	}
+
+	conn, err := t.dialAddr(peer.Addr)
+	if err != nil {
+		return fmt.Errorf("p2p dial %s failed: %v: %w", peer.Addr, err, syscall.ECONNREFUSED)
+	}
+
+	t.mu.Lock()
+	if t.closed {
+		t.mu.Unlock()
+		conn.Close()
+		return fmt.Errorf("transport closed: %w", syscall.ECONNREFUSED)
+	}
+	t.conns[conn] = struct{}{}
+	t.wg.Add(1)
+	t.mu.Unlock()
+
+	peer.SetConn(conn)
+	go t.readLoop(peer.ID, conn)
+
+	log.Printf("P2P connected to discovered peer %d at %s", peer.ID, peer.Addr)
+	return nil
 }
 
 // readLoop reads RPCs from a dialed connection.

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -201,7 +201,14 @@ func (t *TCPTransport) Dial(id int32, addr string) (*Peer, error) {
 // Connect establishes an outbound connection to an already-registered peer.
 // It is used to wire up peers discovered via gossip membership updates that
 // were added to the peer map without a live connection.
-func (t *TCPTransport) Connect(peer *Peer) error {
+func (t *TCPTransport) Connect(peer *Peer) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in Connect to peer %d: %v: %w", peer.ID, r, syscall.EIO)
+			log.Printf("CRITICAL: %v", err)
+		}
+	}()
+
 	if peer == nil {
 		return fmt.Errorf("cannot connect nil peer: %w", syscall.EINVAL)
 	}
@@ -214,10 +221,18 @@ func (t *TCPTransport) Connect(peer *Peer) error {
 		return fmt.Errorf("p2p dial %s failed: %v: %w", peer.Addr, err, syscall.ECONNREFUSED)
 	}
 
+	// Ownership of conn transfers to the readLoop once started. Until then,
+	// ensure the socket is closed on any error or panic to avoid a zombie conn.
+	transferred := false
+	defer func() {
+		if !transferred {
+			conn.Close()
+		}
+	}()
+
 	t.mu.Lock()
 	if t.closed {
 		t.mu.Unlock()
-		conn.Close()
 		return fmt.Errorf("transport closed: %w", syscall.ECONNREFUSED)
 	}
 	t.conns[conn] = struct{}{}
@@ -226,6 +241,7 @@ func (t *TCPTransport) Connect(peer *Peer) error {
 
 	peer.SetConn(conn)
 	go t.readLoop(peer.ID, conn)
+	transferred = true
 
 	log.Printf("P2P connected to discovered peer %d at %s", peer.ID, peer.Addr)
 	return nil

--- a/src/p2p/tcp_transport_test.go
+++ b/src/p2p/tcp_transport_test.go
@@ -139,6 +139,73 @@ func TestTCPTransport_Broadcast(t *testing.T) {
 	}
 }
 
+func TestTCPTransport_Connect(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	defer tr1.Close()
+	defer tr2.Close()
+
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr2 := ln.Addr().String()
+	ln.Close()
+
+	if err := tr2.Listen(addr2); err != nil {
+		t.Fatalf("tr2 Listen failed: %v", err)
+	}
+
+	peer := NewPeer(2, addr2)
+	if peer.Conn() != nil {
+		t.Fatal("expected new peer to have no connection")
+	}
+	tr1.Peers().Add(peer)
+
+	if err := tr1.Connect(peer); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	if peer.Conn() == nil {
+		t.Fatal("expected peer to have a connection after Connect")
+	}
+
+	rpc := &RPC{
+		From:    1,
+		Type:    MsgHeartbeat,
+		Payload: []byte("connected"),
+	}
+	if err := tr1.Send(2, rpc); err != nil {
+		t.Fatalf("Send after Connect failed: %v", err)
+	}
+
+	select {
+	case received := <-tr2.Consume():
+		if received.From != 1 {
+			t.Errorf("expected From=1, got %d", received.From)
+		}
+		if string(received.Payload) != "connected" {
+			t.Errorf("expected payload 'connected', got %q", received.Payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for RPC after Connect")
+	}
+}
+
+func TestTCPTransport_ConnectFailsOnUnreachable(t *testing.T) {
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr1.Close()
+
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	unreachable := ln.Addr().String()
+	ln.Close()
+
+	peer := NewPeer(9, unreachable)
+	tr1.Peers().Add(peer)
+	if err := tr1.Connect(peer); err == nil {
+		t.Fatal("expected Connect to fail for unreachable address")
+	}
+	if peer.Conn() != nil {
+		t.Error("expected peer to remain unconnected after failed Connect")
+	}
+}
+
 func generateTestTLSConfig(t *testing.T) *tls.Config {
 	t.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)

--- a/src/p2p/transport.go
+++ b/src/p2p/transport.go
@@ -14,6 +14,9 @@ type Transport interface {
 	// Dial connects to a peer at the given address and returns the peer.
 	Dial(id int32, addr string) (*Peer, error)
 
+	// Connect establishes an outbound connection to an already-registered peer.
+	Connect(peer *Peer) error
+
 	// Consume returns the channel of incoming RPCs from all peers.
 	Consume() <-chan RPC
 


### PR DESCRIPTION
Resolves #598

## Problem
When a new peer is discovered via gossip heartbeat or membership update (gossip.go handleHeartbeat / handleMembership), a `Peer` was created and added to the `PeerMap` but no network connection was ever established. All subsequent `Send()`, `Broadcast()`, ping, and query operations to the discovered peer failed with `ENOTCONN` ("peer has no connection"). Only bootstrap peers fed through `TCPTransport.Dial` ever got connected, so dynamic membership discovery was effectively non-functional.

## Root cause
The discovery handler built a `Peer` from the announced address and registered it, but never invoked an outbound dial. `TCPTransport.Dial` could not be reused because it early-returns the existing peer (when the ID is already in the map) without opening a connection.

## Implementation
- `src/p2p/tcp_transport.go`: added a `Connect(peer *Peer) error` method that establishes an outbound connection to an already-registered peer and attaches it via `SetConn` (mirrors `Dial`'s TLS/`net.DialTimeout`, closed-guard, and WG-race-safe `t.wg.Add` under `t.mu`). Factored the shared dial logic into `dialAddr`. Panic-safe: the conn is closed if an error/panic occurs before ownership transfers to `readLoop` (Rule 43).
- `src/p2p/transport.go`: extended the `Transport` interface with `Connect`.
- `src/p2p/gossip.go`: added `connectToPeer`, called from both `handleHeartbeat` and `handleMembership` after a new peer is discovered. Dialing runs in a non-blocking goroutine so a heartbeat announcing many new peers does not stall the serialized consumer loop.

## Tests
- `tcp_transport_test.go`: `TestTCPTransport_Connect` (registers an unconnected peer, `Connect`, asserts a live `Conn` and successful Send/RPC) and `TestTCPTransport_ConnectNoopOnUnreachable` (failed dial leaves peer unconnected).
- `integration_test.go`: `TestIntegration_DynamicPeerGetsConnected` — node 2 must discover node 3 purely via gossip and actually obtain a live connection and be Send-able (the exact scenario that failed before).

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` (full workspace) — pass.
- `go test -race ./...` in p2p — pass.
- `go work vendor` — no diff (Rules 25, 65).
- `pre-commit` hook — `docs/PERFORMANCE.md` and benchmark history regenerated.

## Changelog
- fix: connect dynamically discovered peers via outbound dial (#598)
- fix: close conn on panic in transport Connect (#598)