### PR TITLE
fix: delete blob content immediately in ApplyTombstone on refcount zero

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2664,3 +2664,12 @@ aa25779,BenchmarkLoadGlobalConfig-8,9070.00,1312.00,37.00
 aa25779,BenchmarkPadString-8,2.88,0.00,0.00
 aa25779,BenchmarkSanitizeLog/Safe-8,1080.00,0.00,0.00
 aa25779,BenchmarkSanitizeLog/Unsafe-8,1679.00,704.00,1.00
+c6f3baa,BenchmarkCheckMetricsAndSwap-8,12.31,0.00,0.00
+c6f3baa,BenchmarkCrushOptimized-8,472.50,0.00,0.00
+c6f3baa,BenchmarkCrushOriginal-8,688.50,164.00,3.00
+c6f3baa,BenchmarkIndexDirectTracking-8,0.61,0.00,0.00
+c6f3baa,BenchmarkIndexSearch-8,3.69,0.00,0.00
+c6f3baa,BenchmarkLoadGlobalConfig-8,10649.00,1312.00,37.00
+c6f3baa,BenchmarkPadString-8,2.60,0.00,0.00
+c6f3baa,BenchmarkSanitizeLog/Safe-8,747.10,0.00,0.00
+c6f3baa,BenchmarkSanitizeLog/Unsafe-8,1432.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                       1141.0n ± ∞ ¹    771.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       635.1n ± ∞ ¹    480.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    14.541µ ± ∞ ¹    9.070µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            3.400n ± ∞ ¹    2.877n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     854.7n ± ∞ ¹   1080.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.691µ ± ∞ ¹    1.679µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  14.45n ± ∞ ¹    16.75n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          4.008n ± ∞ ¹    3.733n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.9348n ± ∞ ¹   0.4652n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                112.1n          92.80n        -17.24%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        771.4n ± ∞ ¹    688.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       480.7n ± ∞ ¹    472.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.070µ ± ∞ ¹   10.649µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.877n ± ∞ ¹    2.604n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                    1080.0n ± ∞ ¹    747.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.679µ ± ∞ ¹    1.432µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  16.75n ± ∞ ¹    12.31n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.733n ± ∞ ¹    3.689n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4652n ± ∞ ¹   0.6116n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                92.80n          86.39n        -6.91%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 16.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 480.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 771.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.73 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9070.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.88 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 1080.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1679.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 472.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 688.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 10649.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 747.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1432.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779]
-    line "CheckMetricsAndSwap" [22,17,13,11,11,9,9,14,13,17]
-    line "CrushOptimized" [508,611,411,349,375,375,377,635,462,481]
-    line "CrushOriginal" [564,1014,574,546,560,677,563,1141,538,771]
-    line "IndexDirectTracking" [1,1,0,0,0,1,0,1,1,0]
-    line "IndexSearch" [2,3,2,2,2,2,2,4,3,4]
-    line "LoadGlobalConfig" [12850,16092,8480,7218,8185,9886,8691,14541,8623,9070]
-    line "PadString" [4,4,3,2,3,3,3,3,3,3]
+    x-axis [126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa]
+    line "CheckMetricsAndSwap" [17,13,11,11,9,9,14,13,17,12]
+    line "CrushOptimized" [611,411,349,375,375,377,635,462,481,472]
+    line "CrushOriginal" [1014,574,546,560,677,563,1141,538,771,688]
+    line "IndexDirectTracking" [1,0,0,0,1,0,1,1,0,1]
+    line "IndexSearch" [3,2,2,2,2,2,4,3,4,4]
+    line "LoadGlobalConfig" [16092,8480,7218,8185,9886,8691,14541,8623,9070,10649]
+    line "PadString" [4,3,2,3,3,3,3,3,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [1086,932,759,535,626,647,610,855,645,1080]
-    line "SanitizeLog/Unsafe" [2855,3581,2269,1896,2138,1962,2106,1691,1147,1679]
+    line "SanitizeLog/Safe" [932,759,535,626,647,610,855,645,1080,747]
+    line "SanitizeLog/Unsafe" [3581,2269,1896,2138,1962,2106,1691,1147,1679,1432]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779]
+    x-axis [126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [596cec9,126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779]
+    x-axis [126e08e,d2963d1,cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -183,7 +183,8 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.db.Update(func(tx *bbolt.Tx) error {
+	var orphanedHash string
+	err = s.db.Update(func(tx *bbolt.Tx) error {
 		ts := tx.Bucket(bucketTombstones)
 		existing := ts.Get([]byte(name))
 		if existing != nil {
@@ -214,6 +215,10 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) (err error) {
 				if meta.RefCount <= 0 {
 					meta.RefCount = 0
 					meta.DeletedAt = deletedAt
+					// 🛡️ CVE-006: Mirror Delete's immediate-deletion intent. When
+					// refcount reaches 0 the blob is orphaned; record it so we can
+					// delete its content right after the transaction commits.
+					orphanedHash = hash
 				}
 				if err := obj.Put([]byte(hash), meta.encode()); err != nil {
 					return fmt.Errorf("metadata update error: %w", syscall.EIO)
@@ -228,4 +233,21 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) (err error) {
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// 🛡️ CVE-006: Immediately delete blob content when refcount reaches 0, same
+	// as CASStore.Delete. Performed outside the bbolt transaction to avoid
+	// blocking all db operations during potential network I/O (S3 backends).
+	if orphanedHash != "" {
+		if delErr := s.blobs.DeleteBlob(orphanedHash); delErr != nil {
+			log.Printf("AUDIT: Failed to delete orphaned blob %s: %v", orphanedHash, delErr)
+		} else if metaErr := s.db.Update(func(tx *bbolt.Tx) error {
+			return tx.Bucket(bucketObjects).Delete([]byte(orphanedHash))
+		}); metaErr != nil {
+			log.Printf("AUDIT: Failed to remove metadata for orphaned blob %s: %v", orphanedHash, metaErr)
+		}
+	}
+	return nil
 }

--- a/src/storage/gc_test.go
+++ b/src/storage/gc_test.go
@@ -327,6 +327,86 @@ func TestApplyTombstoneFromRemote(t *testing.T) {
 	}
 }
 
+func TestApplyTombstoneDeletesOrphanedBlobImmediately(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("immediate delete")
+	hash := "555000111222333444555666777888"
+	store.Put("immediate.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	blobPath := store.getBlobPath(hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatal("Blob file should exist before ApplyTombstone")
+	}
+
+	// Applying the only name's tombstone drops refcount to 0 → CVE-006 requires
+	// the blob content to be deleted immediately (not deferred to GC).
+	deletedAt := time.Now().UnixNano()
+	if err := store.ApplyTombstone("immediate.txt", deletedAt); err != nil {
+		t.Fatalf("ApplyTombstone failed: %v", err)
+	}
+
+	// Blob content must be gone immediately — no GC run needed.
+	if _, err := os.Stat(blobPath); !os.IsNotExist(err) {
+		t.Fatal("Blob file should be deleted immediately by ApplyTombstone (CVE-006)")
+	}
+
+	// Metadata entry should be removed too.
+	exists, _ := store.Has(hash)
+	if exists {
+		t.Fatal("Has should return false after ApplyTombstone orphaned the blob")
+	}
+}
+
+func TestApplyTombstoneKeepsBlobWhenShared(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("shared remote delete")
+	hash := "666111222333444555666777888999"
+	store.Put("shared_a.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+	store.Put("shared_b.txt", hash, int64(len(content)), "", bytes.NewReader(content))
+
+	// Apply tombstone to one name — refcount stays > 0 so blob must remain.
+	deletedAt := time.Now().UnixNano()
+	if err := store.ApplyTombstone("shared_a.txt", deletedAt); err != nil {
+		t.Fatalf("ApplyTombstone failed: %v", err)
+	}
+
+	blobPath := store.getBlobPath(hash)
+	if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+		t.Fatal("Blob file removed while refcount > 0")
+	}
+
+	// The remaining name should still resolve.
+	rc, _, err := store.Get("shared_b.txt")
+	if err != nil {
+		t.Fatalf("Get shared_b.txt failed after ApplyTombstone: %v", err)
+	}
+	rc.Close()
+}
+
 func TestGCBackgroundSweeper(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	tmpDir, err := os.MkdirTemp("", "momo-gc-test-*")


### PR DESCRIPTION
Resolves #604

### Issue
`CASStore.ApplyTombstone` only marked metadata (`RefCount=0, DeletedAt=...`) and relied on the GC sweeper to eventually delete blob content (default 5 min). This is inconsistent with `CASStore.Delete`'s immediate-deletion security intent (CVE-006): tombstoned content from P2P exchange lingers on disk until GC runs.

### Fix
`ApplyTombstone` now deletes blob content immediately when refcount reaches 0, matching `Delete`. The orphaned-hash blob deletion and metadata entry removal happen **outside** the bbolt transaction (same pattern as `Delete`/GC) to avoid blocking all db operations during potential network I/O (S3 backends).

```go
if orphanedHash != "" {
    if delErr := s.blobs.DeleteBlob(orphanedHash); delErr != nil {
        log.Printf("AUDIT: Failed to delete orphaned blob %s: %v", orphanedHash, delErr)
    } else if metaErr := s.db.Update(func(tx *bbolt.Tx) error {
        return tx.Bucket(bucketObjects).Delete([]byte(orphanedHash))
    }); metaErr != nil {
        log.Printf("AUDIT: Failed to remove metadata for orphaned blob %s: %v", orphanedHash, metaErr)
    }
}
```

### Changelog
- `src/storage/gc.go`: `ApplyTombstone` deletes blob content + metadata immediately when refcount reaches 0 (CVE-006 parity with `Delete`).
- `src/storage/gc_test.go`: add `TestApplyTombstoneDeletesOrphanedBlobImmediately` (blob + metadata gone without GC) and `TestApplyTombstoneKeepsBlobWhenShared` (blob retained while refcount > 0).