### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing empty hash check in Momo QUIC transport

### DIFF
--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -654,7 +654,7 @@ func (m *MomoQUICCommunicator) ReceiveMetadata() (meta common.FileMetadata, err 
 	// ⚡ Bolt: Use common.TrimNullBytesString to eliminate string allocation overhead
 	metadata.Hash = common.SanitizeLog(common.TrimNullBytesString(buffer[:hashLength]))
 	// 🛡️ Sentinel: Sanitize hash immediately to prevent path traversal in all downstream consumers.
-	if common.HasPathTraversalChars(metadata.Hash) {
+	if metadata.Hash == "" || common.HasPathTraversalChars(metadata.Hash) {
 		return common.FileMetadata{}, fmt.Errorf("invalid hash: %s: %w", metadata.Hash, syscall.EBADMSG)
 	}
 	// ⚡ Bolt: Use common.TrimNullBytesString to eliminate string allocation overhead


### PR DESCRIPTION
Resolves #733

🚨 **Severity:** HIGH
💡 **Vulnerability:** The Momo QUIC transport layer was missing a validation check to reject empty hashes when parsing received file metadata, unlike its TCP counterpart.
🎯 **Impact:** If an empty hash is accepted, downstream components might misinterpret the file location (e.g., trying to access a root or base directory rather than a specific file instance), which can cause logical errors or potentially be exploited in specific contexts.
🔧 **Fix:** Modified `ReceiveMetadata` in `src/transport/momo_quic.go` to explicitly check if `metadata.Hash` is an empty string (`metadata.Hash == ""`) before passing it downstream.
✅ **Verification:** Ran `make test` to ensure all tests pass and that the behavior matches the expected logic defined in the TCP transport equivalent.

---
*PR created automatically by Jules for task [10074318912763746315](https://jules.google.com/task/10074318912763746315) started by @alsotoes*
