### PR TITLE
fix: add stream integrity footer to crypto streams (#600)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2691,3 +2691,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 6f3c2bd,BenchmarkPadString-8,2.79,0.00,0.00
 6f3c2bd,BenchmarkSanitizeLog/Safe-8,673.30,0.00,0.00
 6f3c2bd,BenchmarkSanitizeLog/Unsafe-8,1013.00,704.00,1.00
+52dc2d6,BenchmarkCheckMetricsAndSwap-8,10.12,0.00,0.00
+52dc2d6,BenchmarkCrushOptimized-8,390.40,0.00,0.00
+52dc2d6,BenchmarkCrushOriginal-8,484.70,164.00,3.00
+52dc2d6,BenchmarkIndexDirectTracking-8,0.40,0.00,0.00
+52dc2d6,BenchmarkIndexSearch-8,3.32,0.00,0.00
+52dc2d6,BenchmarkLoadGlobalConfig-8,7250.00,1312.00,37.00
+52dc2d6,BenchmarkPadString-8,2.67,0.00,0.00
+52dc2d6,BenchmarkSanitizeLog/Safe-8,708.10,0.00,0.00
+52dc2d6,BenchmarkSanitizeLog/Unsafe-8,989.80,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2718,3 +2718,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 66a6811,BenchmarkPadString-8,2.65,0.00,0.00
 66a6811,BenchmarkSanitizeLog/Safe-8,598.20,0.00,0.00
 66a6811,BenchmarkSanitizeLog/Unsafe-8,1078.00,704.00,1.00
+0c47d6e,BenchmarkCheckMetricsAndSwap-8,12.65,0.00,0.00
+0c47d6e,BenchmarkCrushOptimized-8,494.30,0.00,0.00
+0c47d6e,BenchmarkCrushOriginal-8,560.30,164.00,3.00
+0c47d6e,BenchmarkIndexDirectTracking-8,0.54,0.00,0.00
+0c47d6e,BenchmarkIndexSearch-8,3.51,0.00,0.00
+0c47d6e,BenchmarkLoadGlobalConfig-8,9861.00,1312.00,37.00
+0c47d6e,BenchmarkPadString-8,3.17,0.00,0.00
+0c47d6e,BenchmarkSanitizeLog/Safe-8,725.20,0.00,0.00
+0c47d6e,BenchmarkSanitizeLog/Unsafe-8,1279.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2700,3 +2700,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 52dc2d6,BenchmarkPadString-8,2.67,0.00,0.00
 52dc2d6,BenchmarkSanitizeLog/Safe-8,708.10,0.00,0.00
 52dc2d6,BenchmarkSanitizeLog/Unsafe-8,989.80,704.00,1.00
+43ccc3d,BenchmarkCheckMetricsAndSwap-8,11.00,0.00,0.00
+43ccc3d,BenchmarkCrushOptimized-8,389.70,0.00,0.00
+43ccc3d,BenchmarkCrushOriginal-8,594.70,164.00,3.00
+43ccc3d,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+43ccc3d,BenchmarkIndexSearch-8,3.31,0.00,0.00
+43ccc3d,BenchmarkLoadGlobalConfig-8,6847.00,1312.00,37.00
+43ccc3d,BenchmarkPadString-8,2.63,0.00,0.00
+43ccc3d,BenchmarkSanitizeLog/Safe-8,538.00,0.00,0.00
+43ccc3d,BenchmarkSanitizeLog/Unsafe-8,899.10,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2709,3 +2709,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 43ccc3d,BenchmarkPadString-8,2.63,0.00,0.00
 43ccc3d,BenchmarkSanitizeLog/Safe-8,538.00,0.00,0.00
 43ccc3d,BenchmarkSanitizeLog/Unsafe-8,899.10,704.00,1.00
+66a6811,BenchmarkCheckMetricsAndSwap-8,13.46,0.00,0.00
+66a6811,BenchmarkCrushOptimized-8,318.80,0.00,0.00
+66a6811,BenchmarkCrushOriginal-8,606.10,164.00,3.00
+66a6811,BenchmarkIndexDirectTracking-8,0.42,0.00,0.00
+66a6811,BenchmarkIndexSearch-8,3.15,0.00,0.00
+66a6811,BenchmarkLoadGlobalConfig-8,7422.00,1312.00,37.00
+66a6811,BenchmarkPadString-8,2.65,0.00,0.00
+66a6811,BenchmarkSanitizeLog/Safe-8,598.20,0.00,0.00
+66a6811,BenchmarkSanitizeLog/Unsafe-8,1078.00,704.00,1.00

--- a/.github/scripts/test-e2e-encryption.sh
+++ b/.github/scripts/test-e2e-encryption.sh
@@ -8,7 +8,7 @@ set -e
 #   2. Uploads a file via the client (content is encrypted client-side)
 #   3. Verifies plaintext is NOT on any node's disk (zero-knowledge)
 #   4. Verifies ciphertext IS on the primary node's disk (blob stored)
-#   5. Verifies blob format starts with stream version byte 0x02
+#   5. Verifies blob format starts with a valid stream version byte (0x02/0x03)
 # Note: Replication to all nodes is tested by test-e2e.sh (without encryption).
 # Chain placement depends on the ciphertext hash, so the primary may be the
 # last node in the chain and not forward — only the primary is checked for blobs.
@@ -124,13 +124,14 @@ if [ "$TOTAL_BLOBS" -eq 0 ]; then
   FAIL=1
 fi
 
-# 3. Blob content must start with stream version byte 0x02 (EncryptStream header)
+# 3. Blob content must start with a valid stream version byte (EncryptStream
+#    header): 0x02 (legacy v2) or 0x03 (current v3 with integrity footer).
 if [ -n "$PRIMARY_SERVER" ]; then
   FIRST_BLOB=$(find "$E2E_DIR/$PRIMARY_SERVER/blobs" -type f 2>/dev/null | head -1)
   if [ -n "$FIRST_BLOB" ]; then
     FIRST_BYTE=$(xxd -l 1 -p "$FIRST_BLOB" 2>/dev/null)
-    if [ "$FIRST_BYTE" != "02" ]; then
-        echo "FAIL: Blob on Server $PRIMARY_SERVER does not start with stream version 0x02 (got 0x$FIRST_BYTE)"
+    if [ "$FIRST_BYTE" != "02" ] && [ "$FIRST_BYTE" != "03" ]; then
+        echo "FAIL: Blob on Server $PRIMARY_SERVER has unexpected stream version byte (got 0x$FIRST_BYTE, want 0x02 or 0x03)"
         FAIL=1
     fi
   fi
@@ -158,5 +159,5 @@ fi
 echo "All encryption properties verified:"
 echo "  - Plaintext NOT on any node's disk (zero-knowledge)"
 echo "  - Ciphertext stored on primary node"
-echo "  - Blob format correct (stream version 0x02 header)"
+echo "  - Blob format correct (stream version 0x02/0x03 header)"
 echo "E2E Encryption Test Passed ($PROTOCOL)!"

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        637.4n ± ∞ ¹    484.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       494.7n ± ∞ ¹    390.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.444µ ± ∞ ¹    7.250µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.792n ± ∞ ¹    2.668n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     673.3n ± ∞ ¹    708.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                  1013.0n ± ∞ ¹    989.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.163n ± ∞ ¹   10.120n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.884n ± ∞ ¹    3.324n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4639n ± ∞ ¹   0.4035n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                73.44n          68.86n        -6.24%
+CrushOriginal-8                        484.7n ± ∞ ¹    594.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       390.4n ± ∞ ¹    389.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.250µ ± ∞ ¹    6.847µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.668n ± ∞ ¹    2.634n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     708.1n ± ∞ ¹    538.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   989.8n ± ∞ ¹    899.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  10.12n ± ∞ ¹    11.00n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.324n ± ∞ ¹    3.308n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4035n ± ∞ ¹   0.3350n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                68.86n          66.27n        -3.77%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.12 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 390.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 484.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7250.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.67 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 708.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 989.80 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 389.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 594.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6847.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.63 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 538.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 899.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6]
-    line "CheckMetricsAndSwap" [11,9,9,14,13,17,12,10,9,10]
-    line "CrushOptimized" [375,375,377,635,462,481,472,342,495,390]
-    line "CrushOriginal" [560,677,563,1141,538,771,688,503,637,485]
-    line "IndexDirectTracking" [0,1,0,1,1,0,1,0,0,0]
-    line "IndexSearch" [2,2,2,4,3,4,4,3,3,3]
-    line "LoadGlobalConfig" [8185,9886,8691,14541,8623,9070,10649,7011,8444,7250]
-    line "PadString" [3,3,3,3,3,3,3,2,3,3]
+    x-axis [b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d]
+    line "CheckMetricsAndSwap" [9,9,14,13,17,12,10,9,10,11]
+    line "CrushOptimized" [375,377,635,462,481,472,342,495,390,390]
+    line "CrushOriginal" [677,563,1141,538,771,688,503,637,485,595]
+    line "IndexDirectTracking" [1,0,1,1,0,1,0,0,0,0]
+    line "IndexSearch" [2,2,4,3,4,4,3,3,3,3]
+    line "LoadGlobalConfig" [9886,8691,14541,8623,9070,10649,7011,8444,7250,6847]
+    line "PadString" [3,3,3,3,3,3,2,3,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [626,647,610,855,645,1080,747,628,673,708]
-    line "SanitizeLog/Unsafe" [2138,1962,2106,1691,1147,1679,1432,841,1013,990]
+    line "SanitizeLog/Safe" [647,610,855,645,1080,747,628,673,708,538]
+    line "SanitizeLog/Unsafe" [1962,2106,1691,1147,1679,1432,841,1013,990,899]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6]
+    x-axis [b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6]
+    x-axis [b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        594.7n ± ∞ ¹    606.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       389.7n ± ∞ ¹    318.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     6.847µ ± ∞ ¹    7.422µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.634n ± ∞ ¹    2.654n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     538.0n ± ∞ ¹    598.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   899.1n ± ∞ ¹   1078.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  11.00n ± ∞ ¹    13.46n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.308n ± ∞ ¹    3.150n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3350n ± ∞ ¹   0.4230n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                66.27n          70.68n        +6.66%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        606.1n ± ∞ ¹    560.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       318.8n ± ∞ ¹    494.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.422µ ± ∞ ¹    9.861µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.654n ± ∞ ¹    3.173n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     598.2n ± ∞ ¹    725.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.078µ ± ∞ ¹    1.279µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  13.46n ± ∞ ¹    12.65n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.150n ± ∞ ¹    3.513n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4230n ± ∞ ¹   0.5392n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                70.68n          83.28n        +17.82%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 13.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 318.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 606.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.15 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7422.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 598.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1078.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 494.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 560.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.54 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.51 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9861.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 3.17 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 725.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1279.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811]
-    line "CheckMetricsAndSwap" [9,14,13,17,12,10,9,10,11,13]
-    line "CrushOptimized" [377,635,462,481,472,342,495,390,390,319]
-    line "CrushOriginal" [563,1141,538,771,688,503,637,485,595,606]
-    line "IndexDirectTracking" [0,1,1,0,1,0,0,0,0,0]
-    line "IndexSearch" [2,4,3,4,4,3,3,3,3,3]
-    line "LoadGlobalConfig" [8691,14541,8623,9070,10649,7011,8444,7250,6847,7422]
-    line "PadString" [3,3,3,3,3,2,3,3,3,3]
+    x-axis [65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e]
+    line "CheckMetricsAndSwap" [14,13,17,12,10,9,10,11,13,13]
+    line "CrushOptimized" [635,462,481,472,342,495,390,390,319,494]
+    line "CrushOriginal" [1141,538,771,688,503,637,485,595,606,560]
+    line "IndexDirectTracking" [1,1,0,1,0,0,0,0,0,1]
+    line "IndexSearch" [4,3,4,4,3,3,3,3,3,4]
+    line "LoadGlobalConfig" [14541,8623,9070,10649,7011,8444,7250,6847,7422,9861]
+    line "PadString" [3,3,3,3,2,3,3,3,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [610,855,645,1080,747,628,673,708,538,598]
-    line "SanitizeLog/Unsafe" [2106,1691,1147,1679,1432,841,1013,990,899,1078]
+    line "SanitizeLog/Safe" [855,645,1080,747,628,673,708,538,598,725]
+    line "SanitizeLog/Unsafe" [1691,1147,1679,1432,841,1013,990,899,1078,1279]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811]
+    x-axis [65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811]
+    x-axis [65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        484.7n ± ∞ ¹    594.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       390.4n ± ∞ ¹    389.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.250µ ± ∞ ¹    6.847µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.668n ± ∞ ¹    2.634n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     708.1n ± ∞ ¹    538.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   989.8n ± ∞ ¹    899.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  10.12n ± ∞ ¹    11.00n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.324n ± ∞ ¹    3.308n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4035n ± ∞ ¹   0.3350n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                68.86n          66.27n        -3.77%
+CrushOriginal-8                        594.7n ± ∞ ¹    606.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       389.7n ± ∞ ¹    318.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.847µ ± ∞ ¹    7.422µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.634n ± ∞ ¹    2.654n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     538.0n ± ∞ ¹    598.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   899.1n ± ∞ ¹   1078.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  11.00n ± ∞ ¹    13.46n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.308n ± ∞ ¹    3.150n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3350n ± ∞ ¹   0.4230n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                66.27n          70.68n        +6.66%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 389.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 594.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6847.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.63 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 538.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 899.10 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 13.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 318.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 606.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7422.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 598.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1078.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d]
-    line "CheckMetricsAndSwap" [9,9,14,13,17,12,10,9,10,11]
-    line "CrushOptimized" [375,377,635,462,481,472,342,495,390,390]
-    line "CrushOriginal" [677,563,1141,538,771,688,503,637,485,595]
-    line "IndexDirectTracking" [1,0,1,1,0,1,0,0,0,0]
-    line "IndexSearch" [2,2,4,3,4,4,3,3,3,3]
-    line "LoadGlobalConfig" [9886,8691,14541,8623,9070,10649,7011,8444,7250,6847]
-    line "PadString" [3,3,3,3,3,3,2,3,3,3]
+    x-axis [e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811]
+    line "CheckMetricsAndSwap" [9,14,13,17,12,10,9,10,11,13]
+    line "CrushOptimized" [377,635,462,481,472,342,495,390,390,319]
+    line "CrushOriginal" [563,1141,538,771,688,503,637,485,595,606]
+    line "IndexDirectTracking" [0,1,1,0,1,0,0,0,0,0]
+    line "IndexSearch" [2,4,3,4,4,3,3,3,3,3]
+    line "LoadGlobalConfig" [8691,14541,8623,9070,10649,7011,8444,7250,6847,7422]
+    line "PadString" [3,3,3,3,3,2,3,3,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [647,610,855,645,1080,747,628,673,708,538]
-    line "SanitizeLog/Unsafe" [1962,2106,1691,1147,1679,1432,841,1013,990,899]
+    line "SanitizeLog/Safe" [610,855,645,1080,747,628,673,708,538,598]
+    line "SanitizeLog/Unsafe" [2106,1691,1147,1679,1432,841,1013,990,899,1078]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d]
+    x-axis [e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d]
+    x-axis [e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        502.7n ± ∞ ¹    637.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       342.0n ± ∞ ¹    494.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.011µ ± ∞ ¹    8.444µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.420n ± ∞ ¹    2.792n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     627.8n ± ∞ ¹    673.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   840.9n ± ∞ ¹   1013.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.020n ± ∞ ¹    9.163n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.209n ± ∞ ¹    2.884n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3363n ± ∞ ¹   0.4639n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                63.44n          73.44n        +15.76%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        637.4n ± ∞ ¹    484.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       494.7n ± ∞ ¹    390.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     8.444µ ± ∞ ¹    7.250µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.792n ± ∞ ¹    2.668n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     673.3n ± ∞ ¹    708.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                  1013.0n ± ∞ ¹    989.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.163n ± ∞ ¹   10.120n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.884n ± ∞ ¹    3.324n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4639n ± ∞ ¹   0.4035n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                73.44n          68.86n        -6.24%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.16 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 494.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 637.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.88 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8444.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.79 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 673.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1013.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.12 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 390.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 484.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7250.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.67 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 708.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 989.80 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd]
-    line "CheckMetricsAndSwap" [11,11,9,9,14,13,17,12,10,9]
-    line "CrushOptimized" [349,375,375,377,635,462,481,472,342,495]
-    line "CrushOriginal" [546,560,677,563,1141,538,771,688,503,637]
-    line "IndexDirectTracking" [0,0,1,0,1,1,0,1,0,0]
-    line "IndexSearch" [2,2,2,2,4,3,4,4,3,3]
-    line "LoadGlobalConfig" [7218,8185,9886,8691,14541,8623,9070,10649,7011,8444]
-    line "PadString" [2,3,3,3,3,3,3,3,2,3]
+    x-axis [411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6]
+    line "CheckMetricsAndSwap" [11,9,9,14,13,17,12,10,9,10]
+    line "CrushOptimized" [375,375,377,635,462,481,472,342,495,390]
+    line "CrushOriginal" [560,677,563,1141,538,771,688,503,637,485]
+    line "IndexDirectTracking" [0,1,0,1,1,0,1,0,0,0]
+    line "IndexSearch" [2,2,2,4,3,4,4,3,3,3]
+    line "LoadGlobalConfig" [8185,9886,8691,14541,8623,9070,10649,7011,8444,7250]
+    line "PadString" [3,3,3,3,3,3,3,2,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [535,626,647,610,855,645,1080,747,628,673]
-    line "SanitizeLog/Unsafe" [1896,2138,1962,2106,1691,1147,1679,1432,841,1013]
+    line "SanitizeLog/Safe" [626,647,610,855,645,1080,747,628,673,708]
+    line "SanitizeLog/Unsafe" [2138,1962,2106,1691,1147,1679,1432,841,1013,990]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd]
+    x-axis [411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [cc2b3a0,411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd]
+    x-axis [411f802,b6d6f22,e9ef85d,65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -398,7 +398,7 @@ func TestSendFile_PanicRecovery(t *testing.T) {
 // client.Connect must stream encryption to a temp spool file (chunk-bounded
 // memory) rather than buffering the entire ciphertext in a bytes.Buffer.
 // It verifies that (1) the wire payload is ciphertext (starts with stream
-// version 0x02), (2) the plaintext never appears on the wire, and (3) the
+// version 0x02/0x03), (2) the plaintext never appears on the wire, and (3) the
 // temp spool is cleaned up after the upload.
 func TestConnect_EncryptionStreamsToSpool(t *testing.T) {
 	defer goleak.VerifyNone(t)
@@ -504,8 +504,8 @@ func TestConnect_EncryptionStreamsToSpool(t *testing.T) {
 		if len(payload) == 0 {
 			t.Fatal("Empty payload received")
 		}
-		if payload[0] != 0x02 {
-			t.Errorf("Expected payload to start with stream version 0x02, got 0x%02x", payload[0])
+		if payload[0] != 0x02 && payload[0] != 0x03 {
+			t.Errorf("Expected payload to start with stream version 0x02/0x03, got 0x%02x", payload[0])
 		}
 		if bytes.Contains(payload, []byte(plaintext)) {
 			t.Error("FAIL: Plaintext leaked to wire (not encrypted)")

--- a/src/crypto/crypto_test.go
+++ b/src/crypto/crypto_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"testing"
@@ -216,15 +217,109 @@ func TestEncryptStreamNonceNotReused(t *testing.T) {
 	}
 }
 
-func TestDecryptStreamRejectsLegacyVersion(t *testing.T) {
+func TestDecryptStreamRejectsUnsupportedVersion(t *testing.T) {
 	key, _ := GenerateKey()
 	c, _ := NewCipher(key)
 
-	// A v1 stream has no seed: header version 1 then chunk data.
+	// A v1 stream predates versioned formats; it must be rejected.
 	legacy := append([]byte{1}, bytes.Repeat([]byte{0xAA}, ChunkSize+NonceSize)...)
 	var decBuf bytes.Buffer
 	if err := c.DecryptStream(bytes.NewReader(legacy), &decBuf); !errors.Is(err, ErrStreamFormat) {
-		t.Fatalf("expected ErrStreamFormat for legacy stream, got: %v", err)
+		t.Fatalf("expected ErrStreamFormat for unsupported stream version, got: %v", err)
+	}
+}
+
+// TestDecryptStreamLegacyV2StillDecodes verifies that v2 blob fragments (which
+// predate the integrity footer) remain decryptable so pre-existing at-rest
+// blobs do not become unreadable after an upgrade.
+func TestDecryptStreamLegacyV2StillDecodes(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	// Craft a minimal valid v2 stream by hand: version byte 2, a fixed seed,
+	// then a single AEAD-sealed data chunk with nil AAD (no footer).
+	seed := bytes.Repeat([]byte{0x11}, streamSeedSize)
+	nonce := make([]byte, NonceSize)
+	copy(nonce[0:streamSeedSize], seed)
+	binary.BigEndian.PutUint32(nonce[streamSeedSize:], 0)
+
+	plaintext := []byte("legacy-blob-data")
+	sealed := c.aead.Seal(nil, nonce, plaintext, nil)
+
+	var stream bytes.Buffer
+	stream.WriteByte(StreamVersionLegacy2)
+	stream.Write(seed)
+	var lenBuf [ChunkHeader]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(sealed)))
+	stream.Write(lenBuf[:])
+	stream.Write(sealed)
+
+	var decBuf bytes.Buffer
+	if err := c.DecryptStream(&stream, &decBuf); err != nil {
+		t.Fatalf("DecryptStream rejected legacy v2 stream: %v", err)
+	}
+	if !bytes.Equal(decBuf.Bytes(), plaintext) {
+		t.Fatalf("v2 decode mismatch: got %q, want %q", decBuf.Bytes(), plaintext)
+	}
+}
+
+// TestDecryptStreamDetectsTruncation ensures a v3 stream whose trailing chunks
+// (including the integrity footer) are dropped is rejected instead of silently
+// returning partial plaintext.
+func TestDecryptStreamDetectsTruncation(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := bytes.Repeat([]byte("T"), 3*ChunkSize+100)
+	var encBuf, decBuf bytes.Buffer
+	if err := c.EncryptStream(bytes.NewReader(plaintext), &encBuf); err != nil {
+		t.Fatalf("EncryptStream failed: %v", err)
+	}
+
+	// Drop the trailing footer chunk (4-byte length + sealed count + tag) to
+	// simulate truncation. The stream must then end cleanly at a data-chunk
+	// boundary so DecryptStream hits EOF while expecting the footer.
+	footerBytes := ChunkHeader + 4 + TagSize
+	truncated := encBuf.Bytes()[:len(encBuf.Bytes())-footerBytes]
+
+	if err := c.DecryptStream(bytes.NewReader(truncated), &decBuf); !errors.Is(err, ErrStreamTruncated) {
+		t.Fatalf("expected ErrStreamTruncated, got: %v", err)
+	}
+}
+
+// TestDecryptStreamRejectsFooterChunkCountMismatch ensures a forged footer that
+// authenticates with the wrong chunk count is rejected.
+func TestDecryptStreamRejectsFooterChunkCountMismatch(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := bytes.Repeat([]byte("C"), 2*ChunkSize)
+	var encBuf, decBuf bytes.Buffer
+	if err := c.EncryptStream(bytes.NewReader(plaintext), &encBuf); err != nil {
+		t.Fatalf("EncryptStream failed: %v", err)
+	}
+
+	buf := encBuf.Bytes()
+
+	// Locate and re-seal the footer with an incorrect chunk count.
+	seed := buf[1 : 1+streamSeedSize]
+	nonce := make([]byte, NonceSize)
+	copy(nonce[0:streamSeedSize], seed)
+	binary.BigEndian.PutUint32(nonce[streamSeedSize:], footerNonceIndex)
+
+	var wrong [4]byte
+	binary.BigEndian.PutUint32(wrong[:], 12345)
+	badFooter := c.aead.Seal(nil, nonce, wrong[:], streamFooterAAD)
+
+	var forged bytes.Buffer
+	forged.Write(buf[:len(buf)-(ChunkHeader+4+TagSize)]) // drop original footer
+	var flen [ChunkHeader]byte
+	binary.BigEndian.PutUint32(flen[:], uint32(len(badFooter)))
+	forged.Write(flen[:])
+	forged.Write(badFooter)
+
+	if err := c.DecryptStream(&forged, &decBuf); !errors.Is(err, ErrStreamFormat) {
+		t.Fatalf("expected ErrStreamFormat for footer count mismatch, got: %v", err)
 	}
 }
 

--- a/src/crypto/crypto_test.go
+++ b/src/crypto/crypto_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"golang.org/x/sys/unix"
 	"testing"
 )
 
@@ -320,6 +321,39 @@ func TestDecryptStreamRejectsFooterChunkCountMismatch(t *testing.T) {
 
 	if err := c.DecryptStream(&forged, &decBuf); !errors.Is(err, ErrStreamFormat) {
 		t.Fatalf("expected ErrStreamFormat for footer count mismatch, got: %v", err)
+	}
+}
+
+// TestDecryptStreamErrorsMapToPOSIXConsts verifies that protocol errors surface
+// the POSIX constants required by Rule 10/42 via errors.Is, so the storage
+// layer can react to them.
+func TestDecryptStreamErrorsMapToPOSIXConsts(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	var decBuf bytes.Buffer
+	// Unsupported version -> ErrStreamFormat -> syscall.EBADMSG on Linux.
+	err := c.DecryptStream(bytes.NewReader([]byte{1, 0xAA}), &decBuf)
+	if !errors.Is(err, ErrStreamFormat) {
+		t.Fatalf("expected ErrStreamFormat, got: %v", err)
+	}
+	if !errors.Is(err, unix.EBADMSG) {
+		t.Fatalf("expected errors.Is(err, unix.EBADMSG), got: %v", err)
+	}
+
+	// Truncated stream -> ErrStreamTruncated -> syscall.EIO.
+	plaintext := bytes.Repeat([]byte("R"), 2*ChunkSize)
+	var encBuf bytes.Buffer
+	c.EncryptStream(bytes.NewReader(plaintext), &encBuf)
+	footerBytes := ChunkHeader + 4 + TagSize
+	truncated := encBuf.Bytes()[:len(encBuf.Bytes())-footerBytes]
+	decBuf.Reset()
+	truncErr := c.DecryptStream(bytes.NewReader(truncated), &decBuf)
+	if !errors.Is(truncErr, ErrStreamTruncated) {
+		t.Fatalf("expected ErrStreamTruncated, got: %v", truncErr)
+	}
+	if !errors.Is(truncErr, unix.EIO) {
+		t.Fatalf("expected errors.Is(err, unix.EIO), got: %v", truncErr)
 	}
 }
 

--- a/src/crypto/streaming.go
+++ b/src/crypto/streaming.go
@@ -143,19 +143,19 @@ func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) (err error) {
 	// the number of data chunks. DecryptStream requires it, so a stream that is
 	// truncated (trailing chunks removed) now fails instead of silently
 	// returning partial plaintext.
-	return writeStreamFooter(c, dst, seed, nonce, lenBuf, sealedBuf, chunkIndex)
+	return writeStreamFooter(c, dst, seed, nonce, lenBuf, sealedBuf, buf, chunkIndex)
 }
 
 // writeStreamFooter appends the authenticated footer chunk for a stream that
-// produced chunkCount data chunks.
-func writeStreamFooter(c *Cipher, dst io.Writer, seed, nonce, lenBuf, sealedBuf []byte, chunkCount uint32) error {
+// produced chunkCount data chunks. The plaintext container param is the
+// loop's 4KB chunk buffer, reused so the footer adds no heap allocation.
+func writeStreamFooter(c *Cipher, dst io.Writer, seed, nonce, lenBuf, sealedBuf, plainBuf []byte, chunkCount uint32) error {
 	copy(nonce[0:streamSeedSize], seed)
 	binary.BigEndian.PutUint32(nonce[streamSeedSize:], footerNonceIndex)
 
-	var countBuf [4]byte
-	binary.BigEndian.PutUint32(countBuf[:], chunkCount)
+	binary.BigEndian.PutUint32(plainBuf[0:4], chunkCount)
 
-	sealed := c.aead.Seal(sealedBuf[:0], nonce, countBuf[:], streamFooterAAD)
+	sealed := c.aead.Seal(sealedBuf[:0], nonce, plainBuf[0:4], streamFooterAAD)
 
 	binary.BigEndian.PutUint32(lenBuf, uint32(len(sealed)))
 

--- a/src/crypto/streaming.go
+++ b/src/crypto/streaming.go
@@ -6,6 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -32,16 +36,57 @@ const (
 var streamFooterAAD = []byte("momo:stream-footer:v1")
 
 var (
-	ErrStreamFormat    = errors.New("crypto: invalid stream format")
-	ErrStreamTruncated = errors.New("crypto: stream truncated (integrity footer missing)")
+	ErrStreamFormat    = &streamError{posix: unix.EBADMSG, domain: errors.New("crypto: invalid stream format")}
+	ErrStreamTruncated = &streamError{posix: unix.EIO, domain: errors.New("crypto: stream truncated (integrity footer missing)")}
 )
+
+// streamError is a domain error that also unwraps to a POSIX constant so the
+// storage layer can match on both the stream sentinel and the underlying
+// syscall via errors.Is (Rule 10/42).
+type streamError struct {
+	posix  error
+	domain error
+}
+
+func (e *streamError) Error() string {
+	return e.domain.Error()
+}
+
+func (e *streamError) Unwrap() []error {
+	return []error{e.posix, e.domain}
+}
+
+func (e *streamError) Is(target error) bool {
+	return target == e.posix || target == e.domain
+}
+
+// wrapStreamErr annotates a stream error with context while preserving
+// errors.Is matching against both the POSIX constant and the domain sentinel.
+func wrapStreamErr(e error, format string, args ...any) error {
+	if se, ok := e.(*streamError); ok {
+		return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), se)
+	}
+	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), e)
+}
+
+// recoverStreamErr is the unified panic-recovery helper for the streaming
+// cipher functions. It maps any panic to syscall.EIO so an unexpected runtime
+// panic cannot crash the daemon (Rule 37).
+func recoverStreamErr(err *error, op string) {
+	if r := recover(); r != nil {
+		log.Printf("CRITICAL: Panic recovered in %s: %v", op, r)
+		*err = fmt.Errorf("panic in %s: %v: %w", op, r, syscall.EIO)
+	}
+}
 
 // footerNonceIndex marks the AEAD nonce index used for the stream footer. It is
 // deliberately distinct from any data-chunk index so an attacker cannot forge
 // or reorder a footer as a regular chunk, and vice versa.
 const footerNonceIndex = 0xFFFFFFFF
 
-func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) error {
+func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) (err error) {
+	defer recoverStreamErr(&err, "EncryptStream")
+
 	header := []byte{StreamVersion}
 	if _, err := dst.Write(header); err != nil {
 		return fmt.Errorf("crypto: failed to write stream header: %w", err)
@@ -123,7 +168,9 @@ func writeStreamFooter(c *Cipher, dst io.Writer, seed, nonce, lenBuf, sealedBuf 
 	return nil
 }
 
-func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) error {
+func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) (err error) {
+	defer recoverStreamErr(&err, "DecryptStream")
+
 	versionBuf := make([]byte, 1)
 	if _, err := io.ReadFull(ciphertext, versionBuf); err != nil {
 		return fmt.Errorf("crypto: failed to read stream header: %w", err)
@@ -135,11 +182,13 @@ func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) error {
 	case StreamVersionLegacy2:
 		return c.decryptStreamLegacy(ciphertext, dst)
 	default:
-		return fmt.Errorf("%w: unsupported version %d", ErrStreamFormat, versionBuf[0])
+		return wrapStreamErr(ErrStreamFormat, "unsupported version %d", versionBuf[0])
 	}
 }
 
-func (c *Cipher) decryptStreamLegacy(ciphertext io.Reader, dst io.Writer) error {
+func (c *Cipher) decryptStreamLegacy(ciphertext io.Reader, dst io.Writer) (err error) {
+	defer recoverStreamErr(&err, "decryptStreamLegacy")
+
 	seed := make([]byte, streamSeedSize)
 	if _, err := io.ReadFull(ciphertext, seed); err != nil {
 		return fmt.Errorf("crypto: failed to read stream seed: %w", err)
@@ -163,7 +212,7 @@ func (c *Cipher) decryptStreamLegacy(ciphertext io.Reader, dst io.Writer) error 
 
 		sealedLen := binary.BigEndian.Uint32(lenBuf)
 		if sealedLen == 0 || sealedLen > uint32(MaxChunkSize) {
-			return fmt.Errorf("%w: invalid chunk size %d", ErrStreamFormat, sealedLen)
+			return wrapStreamErr(ErrStreamFormat, "invalid chunk size %d", sealedLen)
 		}
 
 		sealed := sealedBuf[:sealedLen]
@@ -189,7 +238,9 @@ func (c *Cipher) decryptStreamLegacy(ciphertext io.Reader, dst io.Writer) error 
 	return nil
 }
 
-func (c *Cipher) decryptStreamV3(ciphertext io.Reader, dst io.Writer) error {
+func (c *Cipher) decryptStreamV3(ciphertext io.Reader, dst io.Writer) (err error) {
+	defer recoverStreamErr(&err, "decryptStreamV3")
+
 	seed := make([]byte, streamSeedSize)
 	if _, err := io.ReadFull(ciphertext, seed); err != nil {
 		return fmt.Errorf("crypto: failed to read stream seed: %w", err)
@@ -205,17 +256,17 @@ func (c *Cipher) decryptStreamV3(ciphertext io.Reader, dst io.Writer) error {
 		sealedLen, err := readChunkLen(ciphertext, lenBuf)
 		if err == io.EOF {
 			// Encountered EOF before a footer: the stream was truncated.
-			return fmt.Errorf("%w: expected integrity footer after %d chunk(s)", ErrStreamTruncated, chunkIndex)
+			return wrapStreamErr(ErrStreamTruncated, "expected integrity footer after %d chunk(s)", chunkIndex)
 		}
 		if err != nil {
 			return err
 		}
 
 		if sealedLen > uint32(MaxChunkSize) {
-			return fmt.Errorf("%w: invalid chunk size %d", ErrStreamFormat, sealedLen)
+			return wrapStreamErr(ErrStreamFormat, "invalid chunk size %d", sealedLen)
 		}
 		if sealedLen == 0 {
-			return fmt.Errorf("%w: invalid zero-length chunk", ErrStreamFormat)
+			return wrapStreamErr(ErrStreamFormat, "invalid zero-length chunk")
 		}
 
 		sealed := sealedBuf[:sealedLen]
@@ -238,11 +289,11 @@ func (c *Cipher) decryptStreamV3(ciphertext io.Reader, dst io.Writer) error {
 			// It is the footer. Verify it encodes the exact number of data
 			// chunks seen, then end the stream.
 			if len(plaintext) != 4 {
-				return fmt.Errorf("%w: malformed stream footer", ErrStreamFormat)
+				return wrapStreamErr(ErrStreamFormat, "malformed stream footer")
 			}
 			footerCount := binary.BigEndian.Uint32(plaintext)
 			if footerCount != chunkIndex {
-				return fmt.Errorf("%w: footer chunk count %d != %d chunks decoded", ErrStreamFormat, footerCount, chunkIndex)
+				return wrapStreamErr(ErrStreamFormat, "footer chunk count %d != %d chunks decoded", footerCount, chunkIndex)
 			}
 			break
 		}

--- a/src/crypto/streaming.go
+++ b/src/crypto/streaming.go
@@ -12,17 +12,34 @@ const (
 	ChunkSize     = 4096
 	ChunkHeader   = 4
 	MaxChunkSize  = ChunkSize + ChunkHeader + NonceSize + TagSize
-	StreamVersion = 2
+	StreamVersion = 3
 
 	// streamSeedSize is the number of random bytes seeded per stream. It is
 	// XORed into the first part of the nonce so that a (key, nonce) pair is
 	// never reused across streams for the same key.
 	streamSeedSize = 8
+
+	// StreamVersionLegacy2 is the prior stream format that had no integrity
+	// footer. It is still decoded (insecure against truncation) for backward
+	// compatibility with blobs written before the footer was added.
+	StreamVersionLegacy2 = 2
 )
 
+// streamFooterAAD is the AEAD additional authenticated data bound to the
+// stream footer chunk. It is intentionally domain-separated from data chunks
+// (whose AAD is nil) so DecryptStream can distinguish the final footer from a
+// regular ciphertext chunk.
+var streamFooterAAD = []byte("momo:stream-footer:v1")
+
 var (
-	ErrStreamFormat = errors.New("crypto: invalid stream format")
+	ErrStreamFormat    = errors.New("crypto: invalid stream format")
+	ErrStreamTruncated = errors.New("crypto: stream truncated (integrity footer missing)")
 )
+
+// footerNonceIndex marks the AEAD nonce index used for the stream footer. It is
+// deliberately distinct from any data-chunk index so an attacker cannot forge
+// or reorder a footer as a regular chunk, and vice versa.
+const footerNonceIndex = 0xFFFFFFFF
 
 func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) error {
 	header := []byte{StreamVersion}
@@ -77,20 +94,32 @@ func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) error {
 		}
 	}
 
-	if chunkIndex == 0 {
-		copy(nonce[0:streamSeedSize], seed)
-		sealed := c.aead.Seal(sealedBuf[:0], nonce, nil, nil)
+	// 🛡️ Stream integrity footer: a final AEAD-authenticated chunk that binds
+	// the number of data chunks. DecryptStream requires it, so a stream that is
+	// truncated (trailing chunks removed) now fails instead of silently
+	// returning partial plaintext.
+	return writeStreamFooter(c, dst, seed, nonce, lenBuf, sealedBuf, chunkIndex)
+}
 
-		binary.BigEndian.PutUint32(lenBuf, uint32(len(sealed)))
+// writeStreamFooter appends the authenticated footer chunk for a stream that
+// produced chunkCount data chunks.
+func writeStreamFooter(c *Cipher, dst io.Writer, seed, nonce, lenBuf, sealedBuf []byte, chunkCount uint32) error {
+	copy(nonce[0:streamSeedSize], seed)
+	binary.BigEndian.PutUint32(nonce[streamSeedSize:], footerNonceIndex)
 
-		if _, err := dst.Write(lenBuf); err != nil {
-			return fmt.Errorf("crypto: failed to write empty chunk length: %w", err)
-		}
-		if _, err := dst.Write(sealed); err != nil {
-			return fmt.Errorf("crypto: failed to write empty chunk ciphertext: %w", err)
-		}
+	var countBuf [4]byte
+	binary.BigEndian.PutUint32(countBuf[:], chunkCount)
+
+	sealed := c.aead.Seal(sealedBuf[:0], nonce, countBuf[:], streamFooterAAD)
+
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(sealed)))
+
+	if _, err := dst.Write(lenBuf); err != nil {
+		return fmt.Errorf("crypto: failed to write stream footer length: %w", err)
 	}
-
+	if _, err := dst.Write(sealed); err != nil {
+		return fmt.Errorf("crypto: failed to write stream footer ciphertext: %w", err)
+	}
 	return nil
 }
 
@@ -100,10 +129,17 @@ func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) error {
 		return fmt.Errorf("crypto: failed to read stream header: %w", err)
 	}
 
-	if versionBuf[0] != StreamVersion {
+	switch versionBuf[0] {
+	case StreamVersion:
+		return c.decryptStreamV3(ciphertext, dst)
+	case StreamVersionLegacy2:
+		return c.decryptStreamLegacy(ciphertext, dst)
+	default:
 		return fmt.Errorf("%w: unsupported version %d", ErrStreamFormat, versionBuf[0])
 	}
+}
 
+func (c *Cipher) decryptStreamLegacy(ciphertext io.Reader, dst io.Writer) error {
 	seed := make([]byte, streamSeedSize)
 	if _, err := io.ReadFull(ciphertext, seed); err != nil {
 		return fmt.Errorf("crypto: failed to read stream seed: %w", err)
@@ -118,6 +154,7 @@ func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) error {
 	for {
 		_, err := io.ReadFull(ciphertext, lenBuf)
 		if err == io.EOF {
+			// Legacy format has no integrity footer — cannot detect truncation.
 			break
 		}
 		if err != nil {
@@ -150,4 +187,88 @@ func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) error {
 	}
 
 	return nil
+}
+
+func (c *Cipher) decryptStreamV3(ciphertext io.Reader, dst io.Writer) error {
+	seed := make([]byte, streamSeedSize)
+	if _, err := io.ReadFull(ciphertext, seed); err != nil {
+		return fmt.Errorf("crypto: failed to read stream seed: %w", err)
+	}
+
+	lenBuf := make([]byte, ChunkHeader)
+	nonce := make([]byte, NonceSize)
+	sealedBuf := make([]byte, MaxChunkSize)
+	plaintextBuf := make([]byte, 0, ChunkSize)
+	chunkIndex := uint32(0)
+
+	for {
+		sealedLen, err := readChunkLen(ciphertext, lenBuf)
+		if err == io.EOF {
+			// Encountered EOF before a footer: the stream was truncated.
+			return fmt.Errorf("%w: expected integrity footer after %d chunk(s)", ErrStreamTruncated, chunkIndex)
+		}
+		if err != nil {
+			return err
+		}
+
+		if sealedLen > uint32(MaxChunkSize) {
+			return fmt.Errorf("%w: invalid chunk size %d", ErrStreamFormat, sealedLen)
+		}
+		if sealedLen == 0 {
+			return fmt.Errorf("%w: invalid zero-length chunk", ErrStreamFormat)
+		}
+
+		sealed := sealedBuf[:sealedLen]
+		if _, err := io.ReadFull(ciphertext, sealed); err != nil {
+			return fmt.Errorf("crypto: failed to read chunk ciphertext: %w", err)
+		}
+
+		// Data chunk nonce.
+		copy(nonce[0:streamSeedSize], seed)
+		binary.BigEndian.PutUint32(nonce[streamSeedSize:], chunkIndex)
+
+		plaintext, err := c.aead.Open(plaintextBuf[:0], nonce, sealed, nil)
+		if err != nil {
+			// Data-AAD verification failed. It might be the stream footer —
+			// retry with the footer nonce/AAD before declaring tamper.
+			plaintext, err = c.aead.Open(plaintextBuf[:0], footerNonce(nonce, seed), sealed, streamFooterAAD)
+			if err != nil {
+				return ErrTampered
+			}
+			// It is the footer. Verify it encodes the exact number of data
+			// chunks seen, then end the stream.
+			if len(plaintext) != 4 {
+				return fmt.Errorf("%w: malformed stream footer", ErrStreamFormat)
+			}
+			footerCount := binary.BigEndian.Uint32(plaintext)
+			if footerCount != chunkIndex {
+				return fmt.Errorf("%w: footer chunk count %d != %d chunks decoded", ErrStreamFormat, footerCount, chunkIndex)
+			}
+			break
+		}
+
+		if _, err := dst.Write(plaintext); err != nil {
+			return fmt.Errorf("crypto: failed to write decrypted chunk: %w", err)
+		}
+
+		chunkIndex++
+	}
+
+	return nil
+}
+
+// readChunkLen reads a sealed chunk's length. It returns io.EOF when the stream
+// ends cleanly at an expectation of more data (used to detect truncation).
+func readChunkLen(r io.Reader, lenBuf []byte) (uint32, error) {
+	if _, err := io.ReadFull(r, lenBuf); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(lenBuf), nil
+}
+
+// footerNonce rebuilds the nonce for the stream footer inside the shared buffer.
+func footerNonce(nonce, seed []byte) []byte {
+	copy(nonce[0:streamSeedSize], seed)
+	binary.BigEndian.PutUint32(nonce[streamSeedSize:], footerNonceIndex)
+	return nonce
 }


### PR DESCRIPTION
Resolves #600

## Summary
Adds a stream integrity footer to the streaming crypto format to fix #600: a truncated (or tail-dropped) encrypted stream previously decrypted "successfully" with silently missing trailing data.

## Changes
- `EncryptStream` writes a final AEAD-authenticated footer chunk (format **v3**) binding the number of data chunks. The footer is domain-separated from data chunks by a dedicated nonce index (`0xFFFFFFFF`) and `streamFooterAAD` context, so it cannot be reordered as or replaced by a regular chunk.
- `DecryptStream` now requires the footer for v3: hitting EOF where the footer is expected returns `ErrStreamTruncated` instead of partial plaintext. A forged footer with the wrong chunk count is rejected (`ErrStreamFormat`).
- Backward compatibility: legacy **v2** streams (no footer, truncation-insecure) still decode so existing at-rest blobs remain readable.
- New tested `ErrStreamTruncated` sentinel error.

## Tests
- `TestEncryptStreamDecryptStreamRoundTrip` (unchanged, now exercises v3 incl. empty/1-chunk/multi-chunk)
- `TestDecryptStreamDetectsTruncation` — dropping the footer fails with `ErrStreamTruncated`
- `TestDecryptStreamRejectsFooterChunkCountMismatch` — forged footer rejected
- `TestDecryptStreamLegacyV2StillDecodes` — old-format blobs still read
- `TestDecryptStreamRejectsUnsupportedVersion`

All `src` tests pass (`go build`/`go vet`/`go test ./...`).