### PR TITLE
fix: drain s3 blobstore response bodies before close

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2736,3 +2736,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 24e5c28,BenchmarkPadString-8,2.62,0.00,0.00
 24e5c28,BenchmarkSanitizeLog/Safe-8,535.30,0.00,0.00
 24e5c28,BenchmarkSanitizeLog/Unsafe-8,925.90,704.00,1.00
+51102d9,BenchmarkCheckMetricsAndSwap-8,11.53,0.00,0.00
+51102d9,BenchmarkCrushOptimized-8,375.20,0.00,0.00
+51102d9,BenchmarkCrushOriginal-8,522.70,164.00,3.00
+51102d9,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+51102d9,BenchmarkIndexSearch-8,3.50,0.00,0.00
+51102d9,BenchmarkLoadGlobalConfig-8,7276.00,1312.00,37.00
+51102d9,BenchmarkPadString-8,2.26,0.00,0.00
+51102d9,BenchmarkSanitizeLog/Safe-8,662.90,0.00,0.00
+51102d9,BenchmarkSanitizeLog/Unsafe-8,1017.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2727,3 +2727,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 0c47d6e,BenchmarkPadString-8,3.17,0.00,0.00
 0c47d6e,BenchmarkSanitizeLog/Safe-8,725.20,0.00,0.00
 0c47d6e,BenchmarkSanitizeLog/Unsafe-8,1279.00,704.00,1.00
+24e5c28,BenchmarkCheckMetricsAndSwap-8,8.82,0.00,0.00
+24e5c28,BenchmarkCrushOptimized-8,305.90,0.00,0.00
+24e5c28,BenchmarkCrushOriginal-8,479.50,164.00,3.00
+24e5c28,BenchmarkIndexDirectTracking-8,0.41,0.00,0.00
+24e5c28,BenchmarkIndexSearch-8,2.90,0.00,0.00
+24e5c28,BenchmarkLoadGlobalConfig-8,6379.00,1312.00,37.00
+24e5c28,BenchmarkPadString-8,2.62,0.00,0.00
+24e5c28,BenchmarkSanitizeLog/Safe-8,535.30,0.00,0.00
+24e5c28,BenchmarkSanitizeLog/Unsafe-8,925.90,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        606.1n ± ∞ ¹    560.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       318.8n ± ∞ ¹    494.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.422µ ± ∞ ¹    9.861µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.654n ± ∞ ¹    3.173n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     598.2n ± ∞ ¹    725.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.078µ ± ∞ ¹    1.279µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  13.46n ± ∞ ¹    12.65n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.150n ± ∞ ¹    3.513n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4230n ± ∞ ¹   0.5392n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                70.68n          83.28n        +17.82%
+CrushOriginal-8                        560.3n ± ∞ ¹    479.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       494.3n ± ∞ ¹    305.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.861µ ± ∞ ¹    6.379µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            3.173n ± ∞ ¹    2.618n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     725.2n ± ∞ ¹    535.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                  1279.0n ± ∞ ¹    925.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 12.650n ± ∞ ¹    8.822n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.513n ± ∞ ¹    2.902n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5392n ± ∞ ¹   0.4127n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                83.28n          61.63n        -25.99%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 12.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 494.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 560.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.54 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.51 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9861.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 3.17 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 725.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1279.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.82 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 305.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 479.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6379.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.62 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 535.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 925.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e]
-    line "CheckMetricsAndSwap" [14,13,17,12,10,9,10,11,13,13]
-    line "CrushOptimized" [635,462,481,472,342,495,390,390,319,494]
-    line "CrushOriginal" [1141,538,771,688,503,637,485,595,606,560]
-    line "IndexDirectTracking" [1,1,0,1,0,0,0,0,0,1]
-    line "IndexSearch" [4,3,4,4,3,3,3,3,3,4]
-    line "LoadGlobalConfig" [14541,8623,9070,10649,7011,8444,7250,6847,7422,9861]
-    line "PadString" [3,3,3,3,2,3,3,3,3,3]
+    x-axis [381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28]
+    line "CheckMetricsAndSwap" [13,17,12,10,9,10,11,13,13,9]
+    line "CrushOptimized" [462,481,472,342,495,390,390,319,494,306]
+    line "CrushOriginal" [538,771,688,503,637,485,595,606,560,480]
+    line "IndexDirectTracking" [1,0,1,0,0,0,0,0,1,0]
+    line "IndexSearch" [3,4,4,3,3,3,3,3,4,3]
+    line "LoadGlobalConfig" [8623,9070,10649,7011,8444,7250,6847,7422,9861,6379]
+    line "PadString" [3,3,3,2,3,3,3,3,3,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [855,645,1080,747,628,673,708,538,598,725]
-    line "SanitizeLog/Unsafe" [1691,1147,1679,1432,841,1013,990,899,1078,1279]
+    line "SanitizeLog/Safe" [645,1080,747,628,673,708,538,598,725,535]
+    line "SanitizeLog/Unsafe" [1147,1679,1432,841,1013,990,899,1078,1279,926]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e]
+    x-axis [381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [65c9292,381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e]
+    x-axis [381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        560.3n ± ∞ ¹    479.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       494.3n ± ∞ ¹    305.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     9.861µ ± ∞ ¹    6.379µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            3.173n ± ∞ ¹    2.618n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     725.2n ± ∞ ¹    535.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                  1279.0n ± ∞ ¹    925.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 12.650n ± ∞ ¹    8.822n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.513n ± ∞ ¹    2.902n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.5392n ± ∞ ¹   0.4127n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                83.28n          61.63n        -25.99%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        479.5n ± ∞ ¹    522.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       305.9n ± ∞ ¹    375.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.379µ ± ∞ ¹    7.276µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            2.618n ± ∞ ¹    2.262n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     535.3n ± ∞ ¹    662.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   925.9n ± ∞ ¹   1017.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.822n ± ∞ ¹   11.530n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.902n ± ∞ ¹    3.504n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4127n ± ∞ ¹   0.3353n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                61.63n          67.60n        +9.69%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.82 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 305.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 479.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6379.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.62 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 535.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 925.90 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 375.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 522.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7276.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.26 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 662.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1017.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28]
-    line "CheckMetricsAndSwap" [13,17,12,10,9,10,11,13,13,9]
-    line "CrushOptimized" [462,481,472,342,495,390,390,319,494,306]
-    line "CrushOriginal" [538,771,688,503,637,485,595,606,560,480]
-    line "IndexDirectTracking" [1,0,1,0,0,0,0,0,1,0]
-    line "IndexSearch" [3,4,4,3,3,3,3,3,4,3]
-    line "LoadGlobalConfig" [8623,9070,10649,7011,8444,7250,6847,7422,9861,6379]
-    line "PadString" [3,3,3,2,3,3,3,3,3,3]
+    x-axis [aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9]
+    line "CheckMetricsAndSwap" [17,12,10,9,10,11,13,13,9,12]
+    line "CrushOptimized" [481,472,342,495,390,390,319,494,306,375]
+    line "CrushOriginal" [771,688,503,637,485,595,606,560,480,523]
+    line "IndexDirectTracking" [0,1,0,0,0,0,0,1,0,0]
+    line "IndexSearch" [4,4,3,3,3,3,3,4,3,4]
+    line "LoadGlobalConfig" [9070,10649,7011,8444,7250,6847,7422,9861,6379,7276]
+    line "PadString" [3,3,2,3,3,3,3,3,3,2]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [645,1080,747,628,673,708,538,598,725,535]
-    line "SanitizeLog/Unsafe" [1147,1679,1432,841,1013,990,899,1078,1279,926]
+    line "SanitizeLog/Safe" [1080,747,628,673,708,538,598,725,535,663]
+    line "SanitizeLog/Unsafe" [1679,1432,841,1013,990,899,1078,1279,926,1017]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28]
+    x-axis [aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [381b894,aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28]
+    x-axis [aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/s3_blobstore.go
+++ b/src/storage/s3_blobstore.go
@@ -172,9 +172,10 @@ func (s *S3BlobStore) DeleteBlob(hash string) error {
 // drainAndClose discards any remaining response body before closing it so the
 // underlying HTTP connection can be returned to the transport pool.
 // Necessary for reusing secure (TLS) connections for error responses -- AWS S3
-// may send a non-empty error body even for 4xx/5xx.
+// may send a non-empty error body even for 4xx/5xx. The body is bounded with
+// io.LimitReader to prevent unbounded memory consumption (Rule 4).
 func drainAndClose(body io.ReadCloser) {
-	_, _ = io.Copy(io.Discard, body)
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 4096))
 	_ = body.Close()
 }
 
@@ -182,11 +183,11 @@ func drainAndClose(body io.ReadCloser) {
 func (s *S3BlobStore) newRequest(method, key string, body io.Reader, payloadHash string) (req *http.Request, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("panic building new request: %v", r)
+			log.Printf("CRITICAL: Recovered from panic in S3BlobStore.newRequest: %v", r)
 			if closer, ok := body.(io.ReadCloser); ok {
 				closer.Close()
 			}
-			err = syscall.EIO
+			err = fmt.Errorf("panic in S3BlobStore.newRequest: %v: %w", r, syscall.EIO)
 		}
 	}()
 

--- a/src/storage/s3_blobstore.go
+++ b/src/storage/s3_blobstore.go
@@ -98,7 +98,7 @@ func (s *S3BlobStore) PutBlob(hash string, content io.Reader) (err error) {
 	if err != nil {
 		return fmt.Errorf("s3: PUT request failed: %w", syscall.ECONNREFUSED)
 	}
-	defer resp.Body.Close()
+	defer drainAndClose(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("s3: PUT failed with status %d: %w", resp.StatusCode, syscall.EIO)
@@ -136,11 +136,11 @@ func (s *S3BlobStore) GetBlob(hash string) (io.ReadCloser, error) {
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		resp.Body.Close()
+		drainAndClose(resp.Body)
 		return nil, syscall.ENOENT
 	}
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		drainAndClose(resp.Body)
 		return nil, fmt.Errorf("s3: GET failed with status %d: %w", resp.StatusCode, syscall.EIO)
 	}
 	return resp.Body, nil
@@ -158,7 +158,7 @@ func (s *S3BlobStore) DeleteBlob(hash string) error {
 	if err != nil {
 		return fmt.Errorf("s3: DELETE request failed: %w", syscall.ECONNREFUSED)
 	}
-	defer resp.Body.Close()
+	defer drainAndClose(resp.Body)
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil
@@ -167,6 +167,15 @@ func (s *S3BlobStore) DeleteBlob(hash string) error {
 		return fmt.Errorf("s3: DELETE failed with status %d: %w", resp.StatusCode, syscall.EIO)
 	}
 	return nil
+}
+
+// drainAndClose discards any remaining response body before closing it so the
+// underlying HTTP connection can be returned to the transport pool.
+// Necessary for reusing secure (TLS) connections for error responses -- AWS S3
+// may send a non-empty error body even for 4xx/5xx.
+func drainAndClose(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
 }
 
 // newRequest builds an HTTP request for the given method and object key.


### PR DESCRIPTION
Resolves #606


## Location
`src/storage/s3_blobstore.go:100, 143`

## Description
In `PutBlob` and `DeleteBlob`, `defer resp.Body.Close()` is used but the body is never drained. For error responses, the unread body prevents HTTP connection reuse.

## Impact
Connection is closed instead of returned to the pool. Performance/resource leak under error conditions.

## Suggested Fix
Drain the body before closing: `io.Copy(io.Discard, resp.Body)`.

## Changelog
- [51102d9] Add `drainAndClose` helper: drains response bodies (bounded to 4KB via `io.LimitReader`) before closing so HTTP connections return to the pool. Applied in `PutBlob`, `GetBlob` (404/non-200 paths), and `DeleteBlob`.
- [08d890d] Reviewer feedback: bound `drainAndClose` body with `io.LimitReader(body, 4096)`; align `newRequest` panic recovery with Rule 37 (Stderr log + `syscall.EIO` mapping).
