### PR TITLE
fix: replace S3 client overall timeout with transport timeouts

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2745,3 +2745,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 51102d9,BenchmarkPadString-8,2.26,0.00,0.00
 51102d9,BenchmarkSanitizeLog/Safe-8,662.90,0.00,0.00
 51102d9,BenchmarkSanitizeLog/Unsafe-8,1017.00,704.00,1.00
+355507e,BenchmarkCheckMetricsAndSwap-8,12.84,0.00,0.00
+355507e,BenchmarkCrushOptimized-8,422.00,0.00,0.00
+355507e,BenchmarkCrushOriginal-8,612.00,164.00,3.00
+355507e,BenchmarkIndexDirectTracking-8,0.60,0.00,0.00
+355507e,BenchmarkIndexSearch-8,3.12,0.00,0.00
+355507e,BenchmarkLoadGlobalConfig-8,8830.00,1312.00,37.00
+355507e,BenchmarkPadString-8,2.58,0.00,0.00
+355507e,BenchmarkSanitizeLog/Safe-8,723.60,0.00,0.00
+355507e,BenchmarkSanitizeLog/Unsafe-8,1209.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        479.5n ± ∞ ¹    522.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       305.9n ± ∞ ¹    375.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     6.379µ ± ∞ ¹    7.276µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            2.618n ± ∞ ¹    2.262n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     535.3n ± ∞ ¹    662.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   925.9n ± ∞ ¹   1017.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.822n ± ∞ ¹   11.530n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.902n ± ∞ ¹    3.504n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4127n ± ∞ ¹   0.3353n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                61.63n          67.60n        +9.69%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        522.7n ± ∞ ¹    612.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       375.2n ± ∞ ¹    422.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.276µ ± ∞ ¹    8.830µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.262n ± ∞ ¹    2.583n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     662.9n ± ∞ ¹    723.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.017µ ± ∞ ¹    1.209µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  11.53n ± ∞ ¹    12.84n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.504n ± ∞ ¹    3.119n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3353n ± ∞ ¹   0.6028n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                67.60n          79.33n        +17.35%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 375.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 522.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7276.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.26 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 662.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1017.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.84 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 422.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 612.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.12 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8830.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 2.58 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 723.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1209.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9]
-    line "CheckMetricsAndSwap" [17,12,10,9,10,11,13,13,9,12]
-    line "CrushOptimized" [481,472,342,495,390,390,319,494,306,375]
-    line "CrushOriginal" [771,688,503,637,485,595,606,560,480,523]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,1,0,0]
-    line "IndexSearch" [4,4,3,3,3,3,3,4,3,4]
-    line "LoadGlobalConfig" [9070,10649,7011,8444,7250,6847,7422,9861,6379,7276]
-    line "PadString" [3,3,2,3,3,3,3,3,3,2]
+    x-axis [c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e]
+    line "CheckMetricsAndSwap" [12,10,9,10,11,13,13,9,12,13]
+    line "CrushOptimized" [472,342,495,390,390,319,494,306,375,422]
+    line "CrushOriginal" [688,503,637,485,595,606,560,480,523,612]
+    line "IndexDirectTracking" [1,0,0,0,0,0,1,0,0,1]
+    line "IndexSearch" [4,3,3,3,3,3,4,3,4,3]
+    line "LoadGlobalConfig" [10649,7011,8444,7250,6847,7422,9861,6379,7276,8830]
+    line "PadString" [3,2,3,3,3,3,3,3,2,3]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [1080,747,628,673,708,538,598,725,535,663]
-    line "SanitizeLog/Unsafe" [1679,1432,841,1013,990,899,1078,1279,926,1017]
+    line "SanitizeLog/Safe" [747,628,673,708,538,598,725,535,663,724]
+    line "SanitizeLog/Unsafe" [1432,841,1013,990,899,1078,1279,926,1017,1209]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9]
+    x-axis [c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [aa25779,c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9]
+    x-axis [c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/s3_blobstore.go
+++ b/src/storage/s3_blobstore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -57,9 +58,22 @@ func NewS3BlobStore(cfg common.ConfigurationStorage) (*S3BlobStore, error) {
 		region = "us-east-1"
 	}
 
+	// Use a custom Transport with dial/response-header timeouts instead of an
+	// overall client timeout. http.Client.Timeout also covers the entire body
+	// read, which would abort large blob downloads (e.g. 1 GiB at 50 Mbit/s
+	// takes ~170s) even when the connection is healthy.
+	transport := &http.Transport{
+		DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		ResponseHeaderTimeout: 30 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+	}
+
 	return &S3BlobStore{
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			Transport: transport,
 		},
 		endpoint:  strings.TrimRight(cfg.S3Endpoint, "/"),
 		region:    region,
@@ -71,6 +85,9 @@ func NewS3BlobStore(cfg common.ConfigurationStorage) (*S3BlobStore, error) {
 }
 
 func (s *S3BlobStore) Close() error {
+	if transport, ok := s.client.Transport.(*http.Transport); ok {
+		transport.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/src/storage/s3_blobstore_test.go
+++ b/src/storage/s3_blobstore_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	"go.uber.org/goleak"
@@ -185,6 +186,86 @@ func TestS3BlobStore_ValidationErrors(t *testing.T) {
 				t.Errorf("Expected validation error")
 			}
 		})
+	}
+}
+
+func TestS3BlobStore_NoOverallClientTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	server, _ := mockS3Server(t)
+	defer server.Close()
+
+	cfg := common.ConfigurationStorage{
+		Backend:     "s3",
+		S3Endpoint:  server.URL,
+		S3Region:    "us-east-1",
+		S3Bucket:    "test-bucket",
+		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
+		S3SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // notsecret
+		S3PathStyle: true,
+	}
+
+	store, err := NewS3BlobStore(cfg)
+	if err != nil {
+		t.Fatalf("NewS3BlobStore failed: %v", err)
+	}
+	defer store.Close()
+
+	if store.client.Timeout != 0 {
+		t.Errorf("http.Client.Timeout must be zero (would abort slow large downloads); got %v", store.client.Timeout)
+	}
+	transport, ok := store.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", store.client.Transport)
+	}
+	if transport.DialContext == nil || transport.ResponseHeaderTimeout == 0 {
+		t.Errorf("expected dial and response-header timeouts to be configured, got DialContext=%v ResponseHeaderTimeout=%v",
+			transport.DialContext != nil, transport.ResponseHeaderTimeout)
+	}
+
+	// A slow-but-steady streamed download must succeed; previously the overall
+	// http.Client.Timeout covered the body read and would abort a slow transfer.
+	const totalBytes = 1024 * 1024
+	const segment = 16 * 1024
+	const segmentCount = totalBytes / segment
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < segmentCount; i++ {
+			time.Sleep(2 * time.Millisecond)
+			if _, err := w.Write(make([]byte, segment)); err != nil {
+				return
+			}
+		}
+	}))
+	defer server2.Close()
+
+	cfg2 := common.ConfigurationStorage{
+		Backend:     "s3",
+		S3Endpoint:  server2.URL,
+		S3Region:    "us-east-1",
+		S3Bucket:    "test-bucket",
+		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
+		S3SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // notsecret
+		S3PathStyle: true,
+	}
+	store2, err := NewS3BlobStore(cfg2)
+	if err != nil {
+		t.Fatalf("NewS3BlobStore failed: %v", err)
+	}
+	defer store2.Close()
+
+	reader, err := store2.GetBlob("slow-blob")
+	if err != nil {
+		t.Fatalf("GetBlob over slow connection failed: %v", err)
+	}
+	defer reader.Close()
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed reading slow blob: %v", err)
+	}
+	if len(got) != totalBytes {
+		t.Errorf("size mismatch: got %d, want %d", len(got), totalBytes)
 	}
 }
 


### PR DESCRIPTION
Resolves #607


## Location
`src/storage/s3_blobstore.go:62`

## Description
`http.Client.Timeout` includes "reading the entire response body." A 1 GiB blob on a slow connection (50 Mbit/s) takes ~170 seconds, far exceeding the 30-second timeout.

## Impact
Large blob downloads **fail with a timeout** even though the connection is healthy.

## Suggested Fix
Use a custom `http.Transport` with dial/response-header timeouts instead of an overall client timeout.