### PR TITLE
fix: make PadString fail loudly on overlong input

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2763,3 +2763,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 554181f,BenchmarkPadString-8,48.50,64.00,1.00
 554181f,BenchmarkSanitizeLog/Safe-8,642.30,0.00,0.00
 554181f,BenchmarkSanitizeLog/Unsafe-8,1232.00,704.00,1.00
+f578dce,BenchmarkCheckMetricsAndSwap-8,9.53,0.00,0.00
+f578dce,BenchmarkCrushOptimized-8,351.60,0.00,0.00
+f578dce,BenchmarkCrushOriginal-8,481.00,164.00,3.00
+f578dce,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+f578dce,BenchmarkIndexSearch-8,3.43,0.00,0.00
+f578dce,BenchmarkLoadGlobalConfig-8,6898.00,1312.00,37.00
+f578dce,BenchmarkPadString-8,46.73,64.00,1.00
+f578dce,BenchmarkSanitizeLog/Safe-8,658.10,0.00,0.00
+f578dce,BenchmarkSanitizeLog/Unsafe-8,802.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2754,3 +2754,12 @@ caca111,BenchmarkSanitizeLog/Unsafe-8,840.90,704.00,1.00
 355507e,BenchmarkPadString-8,2.58,0.00,0.00
 355507e,BenchmarkSanitizeLog/Safe-8,723.60,0.00,0.00
 355507e,BenchmarkSanitizeLog/Unsafe-8,1209.00,704.00,1.00
+554181f,BenchmarkCheckMetricsAndSwap-8,12.61,0.00,0.00
+554181f,BenchmarkCrushOptimized-8,435.00,0.00,0.00
+554181f,BenchmarkCrushOriginal-8,675.50,164.00,3.00
+554181f,BenchmarkIndexDirectTracking-8,0.61,0.00,0.00
+554181f,BenchmarkIndexSearch-8,3.61,0.00,0.00
+554181f,BenchmarkLoadGlobalConfig-8,7163.00,1312.00,37.00
+554181f,BenchmarkPadString-8,48.50,64.00,1.00
+554181f,BenchmarkSanitizeLog/Safe-8,642.30,0.00,0.00
+554181f,BenchmarkSanitizeLog/Unsafe-8,1232.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,52 +39,50 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        612.0n ± ∞ ¹    675.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       422.0n ± ∞ ¹    435.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.830µ ± ∞ ¹    7.163µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.583n ± ∞ ¹   48.500n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     723.6n ± ∞ ¹    642.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.209µ ± ∞ ¹    1.232µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  12.84n ± ∞ ¹    12.61n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.119n ± ∞ ¹    3.612n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.6028n ± ∞ ¹   0.6144n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                79.33n          109.5n        +38.02%
+CrushOriginal-8                        675.5n ± ∞ ¹    481.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       435.0n ± ∞ ¹    351.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.163µ ± ∞ ¹    6.898µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            48.50n ± ∞ ¹    46.73n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     642.3n ± ∞ ¹    658.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                  1232.0n ± ∞ ¹    802.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 12.610n ± ∞ ¹    9.532n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.612n ± ∞ ¹    3.434n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.6144n ± ∞ ¹   0.3633n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                109.5n          88.77n        -18.92%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
-                      │ /tmp/old_bench_filtered.txt │   /tmp/new_bench_filtered.txt    │
-                      │            B/op             │     B/op       vs base           │
-CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
-CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1.281Ki ± ∞ ¹   1.281Ki ± ∞ ¹  ~ (p=1.000 n=1) ²
-PadString-8                              0.00 ± ∞ ¹     64.00 ± ∞ ¹  ~ (p=1.000 n=1) ³
-SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-geomean                                           ⁴                  ?               ⁴
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │            B/op             │     B/op       vs base                │
+CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1.281Ki ± ∞ ¹   1.281Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                             64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                           ³                  +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 
-                      │ /tmp/old_bench_filtered.txt │  /tmp/new_bench_filtered.txt   │
-                      │          allocs/op          │  allocs/op   vs base           │
-CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      37.00 ± ∞ ¹   37.00 ± ∞ ¹  ~ (p=1.000 n=1) ²
-PadString-8                             0.000 ± ∞ ¹   1.000 ± ∞ ¹  ~ (p=1.000 n=1) ³
-SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
-geomean                                           ⁴                ?               ⁴
+                      │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
+                      │          allocs/op          │  allocs/op   vs base                │
+CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                      37.00 ± ∞ ¹   37.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                             1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                           ³                +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 ```
 
 ### Latest Benchmark Results
@@ -95,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 12.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 435.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 675.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7163.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 48.50 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 642.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1232.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.53 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 351.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 481.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.43 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6898.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 46.73 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 658.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 802.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -132,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f]
-    line "CheckMetricsAndSwap" [10,9,10,11,13,13,9,12,13,13]
-    line "CrushOptimized" [342,495,390,390,319,494,306,375,422,435]
-    line "CrushOriginal" [503,637,485,595,606,560,480,523,612,676]
-    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,1,1]
-    line "IndexSearch" [3,3,3,3,3,4,3,4,3,4]
-    line "LoadGlobalConfig" [7011,8444,7250,6847,7422,9861,6379,7276,8830,7163]
-    line "PadString" [2,3,3,3,3,3,3,2,3,48]
+    x-axis [6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce]
+    line "CheckMetricsAndSwap" [9,10,11,13,13,9,12,13,13,10]
+    line "CrushOptimized" [495,390,390,319,494,306,375,422,435,352]
+    line "CrushOriginal" [637,485,595,606,560,480,523,612,676,481]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,1,1,0]
+    line "IndexSearch" [3,3,3,3,4,3,4,3,4,3]
+    line "LoadGlobalConfig" [8444,7250,6847,7422,9861,6379,7276,8830,7163,6898]
+    line "PadString" [3,3,3,3,3,3,2,3,48,47]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [628,673,708,538,598,725,535,663,724,642]
-    line "SanitizeLog/Unsafe" [841,1013,990,899,1078,1279,926,1017,1209,1232]
+    line "SanitizeLog/Safe" [673,708,538,598,725,535,663,724,642,658]
+    line "SanitizeLog/Unsafe" [1013,990,899,1078,1279,926,1017,1209,1232,802]
 ```
 
 #### Memory per Operation (B/op)
@@ -156,14 +154,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f]
+    x-axis [6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
     line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1312,1312,1312]
-    line "PadString" [0,0,0,0,0,0,0,0,0,64]
+    line "PadString" [0,0,0,0,0,0,0,0,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -180,14 +178,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f]
+    x-axis [6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
     line "LoadGlobalConfig" [37,37,37,37,37,37,37,37,37,37]
-    line "PadString" [0,0,0,0,0,0,0,0,0,1]
+    line "PadString" [0,0,0,0,0,0,0,0,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,50 +39,52 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        522.7n ± ∞ ¹    612.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       375.2n ± ∞ ¹    422.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.276µ ± ∞ ¹    8.830µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            2.262n ± ∞ ¹    2.583n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     662.9n ± ∞ ¹    723.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   1.017µ ± ∞ ¹    1.209µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  11.53n ± ∞ ¹    12.84n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.504n ± ∞ ¹    3.119n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3353n ± ∞ ¹   0.6028n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                67.60n          79.33n        +17.35%
+CrushOriginal-8                        612.0n ± ∞ ¹    675.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       422.0n ± ∞ ¹    435.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     8.830µ ± ∞ ¹    7.163µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            2.583n ± ∞ ¹   48.500n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     723.6n ± ∞ ¹    642.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.209µ ± ∞ ¹    1.232µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  12.84n ± ∞ ¹    12.61n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.119n ± ∞ ¹    3.612n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.6028n ± ∞ ¹   0.6144n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                79.33n          109.5n        +38.02%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │            B/op             │     B/op       vs base                │
-CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1.281Ki ± ∞ ¹   1.281Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                             0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ³                  +0.00%               ³
+                      │ /tmp/old_bench_filtered.txt │   /tmp/new_bench_filtered.txt    │
+                      │            B/op             │     B/op       vs base           │
+CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
+CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1.281Ki ± ∞ ¹   1.281Ki ± ∞ ¹  ~ (p=1.000 n=1) ²
+PadString-8                              0.00 ± ∞ ¹     64.00 ± ∞ ¹  ~ (p=1.000 n=1) ³
+SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+geomean                                           ⁴                  ?               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ summaries must be >0 to compute geomean
+³ need >= 4 samples to detect a difference at alpha level 0.05
+⁴ summaries must be >0 to compute geomean
 
-                      │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
-                      │          allocs/op          │  allocs/op   vs base                │
-CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      37.00 ± ∞ ¹   37.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                             0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ³                +0.00%               ³
+                      │ /tmp/old_bench_filtered.txt │  /tmp/new_bench_filtered.txt   │
+                      │          allocs/op          │  allocs/op   vs base           │
+CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                      37.00 ± ∞ ¹   37.00 ± ∞ ¹  ~ (p=1.000 n=1) ²
+PadString-8                             0.000 ± ∞ ¹   1.000 ± ∞ ¹  ~ (p=1.000 n=1) ³
+SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
+geomean                                           ⁴                ?               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ summaries must be >0 to compute geomean
+³ need >= 4 samples to detect a difference at alpha level 0.05
+⁴ summaries must be >0 to compute geomean
 ```
 
 ### Latest Benchmark Results
@@ -93,15 +95,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 12.84 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 422.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 612.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.12 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8830.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 2.58 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 723.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1209.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 435.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 675.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7163.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 48.50 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 642.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1232.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +132,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e]
-    line "CheckMetricsAndSwap" [12,10,9,10,11,13,13,9,12,13]
-    line "CrushOptimized" [472,342,495,390,390,319,494,306,375,422]
-    line "CrushOriginal" [688,503,637,485,595,606,560,480,523,612]
-    line "IndexDirectTracking" [1,0,0,0,0,0,1,0,0,1]
-    line "IndexSearch" [4,3,3,3,3,3,4,3,4,3]
-    line "LoadGlobalConfig" [10649,7011,8444,7250,6847,7422,9861,6379,7276,8830]
-    line "PadString" [3,2,3,3,3,3,3,3,2,3]
+    x-axis [caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f]
+    line "CheckMetricsAndSwap" [10,9,10,11,13,13,9,12,13,13]
+    line "CrushOptimized" [342,495,390,390,319,494,306,375,422,435]
+    line "CrushOriginal" [503,637,485,595,606,560,480,523,612,676]
+    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,1,1]
+    line "IndexSearch" [3,3,3,3,3,4,3,4,3,4]
+    line "LoadGlobalConfig" [7011,8444,7250,6847,7422,9861,6379,7276,8830,7163]
+    line "PadString" [2,3,3,3,3,3,3,2,3,48]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [747,628,673,708,538,598,725,535,663,724]
-    line "SanitizeLog/Unsafe" [1432,841,1013,990,899,1078,1279,926,1017,1209]
+    line "SanitizeLog/Safe" [628,673,708,538,598,725,535,663,724,642]
+    line "SanitizeLog/Unsafe" [841,1013,990,899,1078,1279,926,1017,1209,1232]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,14 +156,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e]
+    x-axis [caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
     line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1312,1312,1312]
-    line "PadString" [0,0,0,0,0,0,0,0,0,0]
+    line "PadString" [0,0,0,0,0,0,0,0,0,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -178,14 +180,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c6f3baa,caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e]
+    x-axis [caca111,6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
     line "LoadGlobalConfig" [37,37,37,37,37,37,37,37,37,37]
-    line "PadString" [0,0,0,0,0,0,0,0,0,0]
+    line "PadString" [0,0,0,0,0,0,0,0,0,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -181,6 +181,7 @@ The file payload is streamed until EOF. The server reads exactly the number of b
 - **MaxFileSize:** 1 GB (`1024 * 1024 * 1024` bytes). Files exceeding this limit are rejected with `EBADMSG` at `server.go:283`.
 - **MaxPathLength:** 4096 bytes. Virtual paths exceeding this limit are rejected with `EBADMSG` in `DecodeFileMetadataList`.
 - **FileInfoLength:** 64 bytes. Hash and name fields exceeding this length are rejected with `EBADMSG` in `DecodeFileMetadataList`.
+- **Fixed-length padding:** Wire fields padded via `common.PadString` (auth tokens, timestamps, hashes, names) must never exceed their fixed byte width. `PadString` **panics** on overlong input instead of silently truncating (recovered at caller boundaries per Rule 37), so an overlong value that slips past validation surfaces as a `syscall.EIO` failure rather than corrupting the stream.
 
 ### Namespace Keying
 

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -26,7 +26,6 @@ func TestPadString(t *testing.T) {
 	}{
 		{"test", 10, "test\x00\x00\x00\x00\x00\x00"},
 		{"test", 4, "test"},
-		{"longstring", 5, "longs"},
 	}
 
 	for _, tc := range testCases {
@@ -35,6 +34,15 @@ func TestPadString(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", tc.expected, result)
 		}
 	}
+}
+
+func TestPadStringOverlongPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("padString overlong input should panic")
+		}
+	}()
+	common.PadString("longstring", 5)
 }
 
 func startMockServer(t *testing.T, authToken string, expectedMode int, delay time.Duration) (string, net.Listener) {

--- a/src/common/string.go
+++ b/src/common/string.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 	"path"
 	"strconv"
 	"strings"
@@ -44,13 +45,19 @@ func HasPathTraversalChars(s string) bool {
 	return false
 }
 
-// PadString pads or truncates a string to the given length.
+// PadString pads a string with null bytes to the given length.
+// Overlong input is a programming error that would silently corrupt wire
+// fields (hashes, auth tokens, names). Failing loudly via panic (Rule 37:
+// recovered at caller boundaries) is safer than silent truncation (Rule 4).
 func PadString(input string, length int) string {
 	if length < 0 {
 		return input
 	}
-	if len(input) >= length {
-		return input[:length]
+	if len(input) > length {
+		panic(fmt.Sprintf("PadString: input length %d exceeds length %d", len(input), length))
+	}
+	if len(input) == length {
+		return input
 	}
 	b := make([]byte, length)
 	copy(b, input)

--- a/src/common/string_test.go
+++ b/src/common/string_test.go
@@ -115,7 +115,6 @@ func TestPadString(t *testing.T) {
 	}{
 		{"Short string", "hello", 10, "hello\x00\x00\x00\x00\x00"},
 		{"Exact length", "hello", 5, "hello"},
-		{"Long string", "hello world", 5, "hello"},
 		{"Empty string", "", 3, "\x00\x00\x00"},
 	}
 
@@ -126,6 +125,15 @@ func TestPadString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPadString_OverlongInputPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("PadString(%q, %d) expected panic, got nil", "hello world", 5)
+		}
+	}()
+	PadString("hello world", 5)
 }
 
 func TestNormalizeVirtualPath(t *testing.T) {

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestMomoTCPCommunicator_Handshake_And_Metadata(t *testing.T) {
-	authToken := "test-token-1234567890123456789012345678901234567890123456789012345" // notsecret
+	authToken := "test-token-11111111111111111111111111111111111111111111111111111" // notsecret, 64 chars
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	addr := "127.0.0.1:45699"
 
@@ -159,7 +159,7 @@ func TestMomoTCPCommunicator_EdgeCases(t *testing.T) {
 }
 
 func runNativeTCPTest(t *testing.T, requestedMode int, clientFn func(net.Conn), mock *mockStore, usePeerToken bool) {
-	authToken := "test-token-1234567890123456789012345678901234567890123456789012345" // notsecret
+	authToken := "test-token-11111111111111111111111111111111111111111111111111111" // notsecret, 64 chars
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	addr := "127.0.0.1:0"
 

--- a/src/transport/oprf_transport_test.go
+++ b/src/transport/oprf_transport_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/alsotoes/momo/src/common"
 )
 
-const testAuthToken = "test-token-1234567890123456789012345678901234567890123456789012345" // notsecret
+const testAuthToken = "test-token-11111111111111111111111111111111111111111111111111111" // notsecret
 
 var errOPRFQuorum = errors.New("oprf quorum not met")
 

--- a/src/transport/s3_communicator_extra_test.go
+++ b/src/transport/s3_communicator_extra_test.go
@@ -12,7 +12,7 @@ import (
 func TestS3Communicator_FullFlow(t *testing.T) {
 	defer verifyNoLeaks(t)
 
-	authToken := "test-token-1234567890123456789012345678901234567890123456789012345" // notsecret
+	authToken := "test-token-11111111111111111111111111111111111111111111111111111" // notsecret
 	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
 	addr := "127.0.0.1:45698"
 


### PR DESCRIPTION
Resolves #608


## Location
`src/common/string.go:52-54`

## Description
```go
if len(input) >= length {
    return input[:length]  // silent truncation
}
```

## Impact
Silent truncation of a hash or file name could cause **data corruption** (wrong file retrieved, wrong hash stored/compared). Used extensively for auth tokens, file names, hashes, and wire-format fields.

## Changelog
- [f578dce] `PadString` now panics on overlong input (recovered at caller boundaries per Rule 37/43) instead of silently truncating; optimized `len(input) == length` fast path. Updated unit tests to assert the panic behavior; fixed overlong 66-char test tokens (were relying on silent truncation).
- [33f11f9] Documented the fixed-width panic contract in `docs/PROTOCOL.md` (Limits section).
