### PR TITLE
fix: rename AppendPaddedInt to WritePaddedInt with clear write contract

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2772,3 +2772,12 @@ f578dce,BenchmarkLoadGlobalConfig-8,6898.00,1312.00,37.00
 f578dce,BenchmarkPadString-8,46.73,64.00,1.00
 f578dce,BenchmarkSanitizeLog/Safe-8,658.10,0.00,0.00
 f578dce,BenchmarkSanitizeLog/Unsafe-8,802.00,704.00,1.00
+2f6c105,BenchmarkCheckMetricsAndSwap-8,8.65,0.00,0.00
+2f6c105,BenchmarkCrushOptimized-8,402.40,0.00,0.00
+2f6c105,BenchmarkCrushOriginal-8,456.50,164.00,3.00
+2f6c105,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+2f6c105,BenchmarkIndexSearch-8,2.83,0.00,0.00
+2f6c105,BenchmarkLoadGlobalConfig-8,6860.00,1312.00,37.00
+2f6c105,BenchmarkPadString-8,42.74,64.00,1.00
+2f6c105,BenchmarkSanitizeLog/Safe-8,507.10,0.00,0.00
+2f6c105,BenchmarkSanitizeLog/Unsafe-8,778.60,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        675.5n ± ∞ ¹    481.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       435.0n ± ∞ ¹    351.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.163µ ± ∞ ¹    6.898µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            48.50n ± ∞ ¹    46.73n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     642.3n ± ∞ ¹    658.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                  1232.0n ± ∞ ¹    802.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 12.610n ± ∞ ¹    9.532n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.612n ± ∞ ¹    3.434n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.6144n ± ∞ ¹   0.3633n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                109.5n          88.77n        -18.92%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        481.0n ± ∞ ¹    456.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       351.6n ± ∞ ¹    402.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.898µ ± ∞ ¹    6.860µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            46.73n ± ∞ ¹    42.74n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     658.1n ± ∞ ¹    507.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   802.0n ± ∞ ¹    778.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.532n ± ∞ ¹    8.654n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.434n ± ∞ ¹    2.826n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3633n ± ∞ ¹   0.3782n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                88.77n          83.47n        -5.97%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.53 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 351.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 481.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.43 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6898.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
-| BenchmarkPadString-8 | 46.73 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 658.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 802.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.65 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 402.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 456.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.83 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6860.00 ns/op | 1312.00 B/op | 37.00 allocs/op |
+| BenchmarkPadString-8 | 42.74 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 507.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 778.60 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce]
-    line "CheckMetricsAndSwap" [9,10,11,13,13,9,12,13,13,10]
-    line "CrushOptimized" [495,390,390,319,494,306,375,422,435,352]
-    line "CrushOriginal" [637,485,595,606,560,480,523,612,676,481]
-    line "IndexDirectTracking" [0,0,0,0,1,0,0,1,1,0]
-    line "IndexSearch" [3,3,3,3,4,3,4,3,4,3]
-    line "LoadGlobalConfig" [8444,7250,6847,7422,9861,6379,7276,8830,7163,6898]
-    line "PadString" [3,3,3,3,3,3,2,3,48,47]
+    x-axis [52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105]
+    line "CheckMetricsAndSwap" [10,11,13,13,9,12,13,13,10,9]
+    line "CrushOptimized" [390,390,319,494,306,375,422,435,352,402]
+    line "CrushOriginal" [485,595,606,560,480,523,612,676,481,456]
+    line "IndexDirectTracking" [0,0,0,1,0,0,1,1,0,0]
+    line "IndexSearch" [3,3,3,4,3,4,3,4,3,3]
+    line "LoadGlobalConfig" [7250,6847,7422,9861,6379,7276,8830,7163,6898,6860]
+    line "PadString" [3,3,3,3,3,2,3,48,47,43]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [673,708,538,598,725,535,663,724,642,658]
-    line "SanitizeLog/Unsafe" [1013,990,899,1078,1279,926,1017,1209,1232,802]
+    line "SanitizeLog/Safe" [708,538,598,725,535,663,724,642,658,507]
+    line "SanitizeLog/Unsafe" [990,899,1078,1279,926,1017,1209,1232,802,779]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,14 +154,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce]
+    x-axis [52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
     line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1312,1312,1312]
-    line "PadString" [0,0,0,0,0,0,0,0,64,64]
+    line "PadString" [0,0,0,0,0,0,0,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -178,14 +178,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6f3c2bd,52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce]
+    x-axis [52dc2d6,43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
     line "LoadGlobalConfig" [37,37,37,37,37,37,37,37,37,37]
-    line "PadString" [0,0,0,0,0,0,0,0,1,1]
+    line "PadString" [0,0,0,0,0,0,0,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]

--- a/src/common/bolt_appendpaddedint_test.go
+++ b/src/common/bolt_appendpaddedint_test.go
@@ -2,18 +2,49 @@ package common
 
 import (
 	"bytes"
+	"syscall"
 	"testing"
 )
 
-func TestAppendPaddedInt(t *testing.T) {
+func TestWritePaddedInt(t *testing.T) {
 	var buf [64]byte
-	if err := AppendPaddedInt(buf[:], 12345, 64); err != nil {
-		t.Fatalf("AppendPaddedInt failed: %v", err)
+	if err := WritePaddedInt(buf[:], 12345, 64); err != nil {
+		t.Fatalf("WritePaddedInt failed: %v", err)
 	}
 
 	expected := make([]byte, 64)
 	copy(expected, "12345")
 	if !bytes.Equal(buf[:], expected) {
 		t.Errorf("Expected %v, got %v", expected, buf[:])
+	}
+}
+
+func TestWritePaddedInt_OverwritesFromStart(t *testing.T) {
+	var buf [64]byte
+	// Pre-fill to detect accidental append-at-end semantics.
+	for i := range buf {
+		buf[i] = 'x'
+	}
+	if err := WritePaddedInt(buf[:], 42, 4); err != nil {
+		t.Fatalf("WritePaddedInt failed: %v", err)
+	}
+	expected := []byte{'4', '2', 0, 0}
+	if !bytes.Equal(buf[:4], expected) {
+		t.Errorf("Expected %v, got %v", expected, buf[:4])
+	}
+	// Content beyond the written field must remain untouched.
+	for i := 4; i < len(buf); i++ {
+		if buf[i] != 'x' {
+			t.Errorf("buf[%d] modified beyond field width: got %q, want 'x'", i, buf[i])
+		}
+	}
+}
+
+func TestWritePaddedInt_Errors(t *testing.T) {
+	if err := WritePaddedInt(make([]byte, 3), 12345, 64); err != syscall.EINVAL {
+		t.Errorf("expected EINVAL for short dst, got %v", err)
+	}
+	if err := WritePaddedInt(make([]byte, 64), 123456789012345, 4); err != syscall.EINVAL {
+		t.Errorf("expected EINVAL for oversized int, got %v", err)
 	}
 }

--- a/src/common/string.go
+++ b/src/common/string.go
@@ -10,10 +10,12 @@ import (
 	"unsafe"
 )
 
-// AppendPaddedInt appends the string representation of val to dst and pads it to width with null bytes.
-// It assumes dst is large enough to hold at least width bytes and that the int representation
-// is less than or equal to width bytes. If len(dst) < width, it returns syscall.EINVAL.
-func AppendPaddedInt(dst []byte, val int64, width int) error {
+// WritePaddedInt writes the string representation of val into dst starting at
+// dst[0] and zero-pads it to width bytes. It overwrites the start of dst rather
+// than appending at dst[len(dst)]; callers must pass a slice sized exactly
+// width (typically a fixed-size buffer's sub-slice). If len(dst) < width or the
+// int representation exceeds width bytes, it returns syscall.EINVAL.
+func WritePaddedInt(dst []byte, val int64, width int) error {
 	if len(dst) < width {
 		return syscall.EINVAL
 	}

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -108,7 +108,7 @@ func (m *MomoQUICCommunicator) SendOPRFEval(authToken string, timestamp int64, b
 	// Respect challenge-response authentication when enabled.
 	if m.useChallengeResp {
 		var handshakeBuf [common.TimestampLength + 1]byte
-		if err := common.AppendPaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
 			return nil, fmt.Errorf("oprf: failed to format handshake timestamp: %w", err)
 		}
 		handshakeBuf[common.TimestampLength] = byte(common.ModeOPRFEval)
@@ -121,7 +121,7 @@ func (m *MomoQUICCommunicator) SendOPRFEval(authToken string, timestamp int64, b
 	} else {
 		var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
 		copy(handshakeBuf[:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
-		if err := common.AppendPaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
 			return nil, fmt.Errorf("oprf: failed to format handshake timestamp: %w", err)
 		}
 		handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(common.ModeOPRFEval)
@@ -205,7 +205,7 @@ func (m *MomoQUICCommunicator) HandshakeClient(authToken string, timestamp int64
 
 	if m.useChallengeResp {
 		var handshakeBuf [common.TimestampLength + 1]byte
-		if err := common.AppendPaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
 		handshakeBuf[common.TimestampLength] = byte(requestedMode + '0')
@@ -221,7 +221,7 @@ func (m *MomoQUICCommunicator) HandshakeClient(authToken string, timestamp int64
 		var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
 		copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
 
-		if err := common.AppendPaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
 
@@ -371,7 +371,7 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 			var packet [192]byte
 			copy(packet[0:64], common.PadString(file.Hash, 64))
 			copy(packet[64:128], common.PadString(wireName, 64))
-			if err := common.AppendPaddedInt(packet[128:], file.Size, 64); err != nil {
+			if err := common.WritePaddedInt(packet[128:], file.Size, 64); err != nil {
 				return 0, 0, fmt.Errorf("failed to format file size: %v: %w", err, syscall.EINVAL)
 			}
 
@@ -485,7 +485,7 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		// Write '0' (success status) + 64-byte size string
 		var respBuf [65]byte
 		respBuf[0] = '0'
-		if err := common.AppendPaddedInt(respBuf[1:], meta.Size, 64); err != nil {
+		if err := common.WritePaddedInt(respBuf[1:], meta.Size, 64); err != nil {
 			return 0, 0, fmt.Errorf("failed to format GET file size: %v: %w", err, syscall.EINVAL)
 		}
 		if _, err := m.Write(respBuf[:]); err != nil {

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -102,7 +102,7 @@ func (m *MomoTCPCommunicator) SendOPRFEval(authToken string, timestamp int64, bl
 	// Respect challenge-response authentication when enabled.
 	if m.useChallengeResp {
 		var handshakeBuf [common.TimestampLength + 1]byte
-		if err := common.AppendPaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
 			return nil, fmt.Errorf("oprf: failed to format handshake timestamp: %w", err)
 		}
 		handshakeBuf[common.TimestampLength] = byte(common.ModeOPRFEval)
@@ -115,7 +115,7 @@ func (m *MomoTCPCommunicator) SendOPRFEval(authToken string, timestamp int64, bl
 	} else {
 		var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
 		copy(handshakeBuf[:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
-		if err := common.AppendPaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
 			return nil, fmt.Errorf("oprf: failed to format handshake timestamp: %w", err)
 		}
 		handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(common.ModeOPRFEval)
@@ -200,7 +200,7 @@ func (m *MomoTCPCommunicator) HandshakeClient(authToken string, timestamp int64,
 
 	if m.useChallengeResp {
 		var handshakeBuf [common.TimestampLength + 1]byte
-		if err := common.AppendPaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
 		handshakeBuf[common.TimestampLength] = byte(requestedMode + '0')
@@ -216,7 +216,7 @@ func (m *MomoTCPCommunicator) HandshakeClient(authToken string, timestamp int64,
 		var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
 		copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
 
-		if err := common.AppendPaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
+		if err := common.WritePaddedInt(handshakeBuf[common.AuthTokenLength:], timestamp, common.TimestampLength); err != nil {
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
 
@@ -366,7 +366,7 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 			var packet [192]byte
 			copy(packet[0:64], common.PadString(file.Hash, 64))
 			copy(packet[64:128], common.PadString(wireName, 64))
-			if err := common.AppendPaddedInt(packet[128:], file.Size, 64); err != nil {
+			if err := common.WritePaddedInt(packet[128:], file.Size, 64); err != nil {
 				return 0, 0, fmt.Errorf("failed to format file size: %v: %w", err, syscall.EINVAL)
 			}
 
@@ -483,7 +483,7 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		// Write '0' (success status) + 64-byte size string
 		var respBuf [65]byte
 		respBuf[0] = '0'
-		if err := common.AppendPaddedInt(respBuf[1:], meta.Size, 64); err != nil {
+		if err := common.WritePaddedInt(respBuf[1:], meta.Size, 64); err != nil {
 			return 0, 0, fmt.Errorf("failed to format GET file size: %v: %w", err, syscall.EINVAL)
 		}
 		if _, err := m.Write(respBuf[:]); err != nil {


### PR DESCRIPTION
Resolves #609


## Location
`src/common/string.go:12-29`

## Description
The function is named "AppendPaddedInt" but it **overwrites `dst` from position 0**, not from `dst[len(dst)]`.

## Impact
All current callers use it correctly (passing sub-slices), but the misleading name could cause data corruption bugs if a future caller assumes append semantics.

## Suggested Fix
Rename to `WritePaddedInt` or actually append from `len(dst)`.