### PR TITLE
ci: ignore noisy SanitizeLog micro-benchmark in benchstat gate

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2799,3 +2799,12 @@ e2ab47d,BenchmarkSanitizeLog/Unsafe-8,1122.00,704.00,1.00
 8743c29,BenchmarkPadString-8,49.39,64.00,1.00
 8743c29,BenchmarkSanitizeLog/Safe-8,615.20,0.00,0.00
 8743c29,BenchmarkSanitizeLog/Unsafe-8,1010.00,704.00,1.00
+60e554e,BenchmarkCheckMetricsAndSwap-8,8.90,0.00,0.00
+60e554e,BenchmarkCrushOptimized-8,372.50,0.00,0.00
+60e554e,BenchmarkCrushOriginal-8,549.90,164.00,3.00
+60e554e,BenchmarkIndexDirectTracking-8,0.43,0.00,0.00
+60e554e,BenchmarkIndexSearch-8,3.13,0.00,0.00
+60e554e,BenchmarkLoadGlobalConfig-8,7459.00,1320.00,38.00
+60e554e,BenchmarkPadString-8,51.22,64.00,1.00
+60e554e,BenchmarkSanitizeLog/Safe-8,639.50,0.00,0.00
+60e554e,BenchmarkSanitizeLog/Unsafe-8,1023.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2790,3 +2790,12 @@ e2ab47d,BenchmarkLoadGlobalConfig-8,11205.00,1320.00,38.00
 e2ab47d,BenchmarkPadString-8,68.89,64.00,1.00
 e2ab47d,BenchmarkSanitizeLog/Safe-8,704.20,0.00,0.00
 e2ab47d,BenchmarkSanitizeLog/Unsafe-8,1122.00,704.00,1.00
+8743c29,BenchmarkCheckMetricsAndSwap-8,10.42,0.00,0.00
+8743c29,BenchmarkCrushOptimized-8,370.40,0.00,0.00
+8743c29,BenchmarkCrushOriginal-8,494.80,164.00,3.00
+8743c29,BenchmarkIndexDirectTracking-8,0.46,0.00,0.00
+8743c29,BenchmarkIndexSearch-8,2.99,0.00,0.00
+8743c29,BenchmarkLoadGlobalConfig-8,7469.00,1320.00,38.00
+8743c29,BenchmarkPadString-8,49.39,64.00,1.00
+8743c29,BenchmarkSanitizeLog/Safe-8,615.20,0.00,0.00
+8743c29,BenchmarkSanitizeLog/Unsafe-8,1010.00,704.00,1.00

--- a/.github/workflows/benchmark_compare.yml
+++ b/.github/workflows/benchmark_compare.yml
@@ -63,7 +63,7 @@ jobs:
         # Ignore sub-10ns micro-benchmarks known to be extremely noisy on virtualization.
         # Also ignore geomean as it's skewed by micro-benchmarks.
         # Skip the B/s throughput section: +X% there means faster (improvement, not degradation).
-        if grep -v -E 'IndexSearch|CheckMetricsAndSwap|IndexDirectTracking|PadString|LoadGlobalConfig|geomean|RPC_Encode|HeartbeatPayload_Encode|PeerMap_|CrushOriginal|OPRFCombineThreshold3' /tmp/bench_comparison.txt | awk '
+        if grep -v -E 'IndexSearch|CheckMetricsAndSwap|IndexDirectTracking|PadString|LoadGlobalConfig|SanitizeLog|geomean|RPC_Encode|HeartbeatPayload_Encode|PeerMap_|CrushOriginal|OPRFCombineThreshold3' /tmp/bench_comparison.txt | awk '
         /B\/s.*vs base/ { in_bps=1; next }
         /sec\/op.*vs base/ || /B\/op.*vs base/ || /allocs\/op.*vs base/ { in_bps=0 }
         in_bps { next }

--- a/.github/workflows/benchmark_compare.yml
+++ b/.github/workflows/benchmark_compare.yml
@@ -64,6 +64,9 @@ jobs:
         # Also ignore geomean as it's skewed by micro-benchmarks.
         # Skip the B/s throughput section: +X% there means faster (improvement, not degradation).
         if grep -v -E 'IndexSearch|CheckMetricsAndSwap|IndexDirectTracking|PadString|LoadGlobalConfig|SanitizeLog|geomean|RPC_Encode|HeartbeatPayload_Encode|PeerMap_|CrushOriginal|OPRFCombineThreshold3' /tmp/bench_comparison.txt | awk '
+        # SanitizeLog is a sub-microsecond log-sanitization micro-benchmark with
+        # runner-dependent variance well above 5% (base swings 20-35% between
+        # identical reruns); ignored alongside the other noisy micro-benchmarks.
         /B\/s.*vs base/ { in_bps=1; next }
         /sec\/op.*vs base/ || /B\/op.*vs base/ || /allocs\/op.*vs base/ { in_bps=0 }
         in_bps { next }

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        456.5n ± ∞ ¹    782.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       402.4n ± ∞ ¹    502.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     6.860µ ± ∞ ¹   11.205µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            42.74n ± ∞ ¹    68.89n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     507.1n ± ∞ ¹    704.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   778.6n ± ∞ ¹   1122.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.654n ± ∞ ¹   10.850n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.826n ± ∞ ¹    3.223n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3782n ± ∞ ¹   0.3900n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                83.47n          114.1n        +36.67%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        520.1n ± ∞ ¹    494.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       348.9n ± ∞ ¹    370.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.634µ ± ∞ ¹    7.469µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            53.49n ± ∞ ¹    49.39n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     605.8n ± ∞ ¹    615.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   988.4n ± ∞ ¹   1010.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  10.43n ± ∞ ¹    10.42n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          3.667n ± ∞ ¹    2.986n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3702n ± ∞ ¹   0.4576n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                94.97n          94.45n        -0.54%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -56,35 +56,33 @@ geomean                                83.47n          114.1n        +36.67%
                       │            B/op             │     B/op       vs base                │
 CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1.281Ki ± ∞ ¹   1.289Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+LoadGlobalConfig-8                    1.289Ki ± ∞ ¹   1.289Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
 PadString-8                             64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ⁴                  +0.07%               ⁴
+geomean                                           ³                  +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 
                       │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                       │          allocs/op          │  allocs/op   vs base                │
 CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      37.00 ± ∞ ¹   38.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
+LoadGlobalConfig-8                      38.00 ± ∞ ¹   38.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 PadString-8                             1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ⁴                +0.30%               ⁴
+geomean                                           ³                +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 ```
 
 ### Latest Benchmark Results
@@ -95,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.85 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 502.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 782.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.22 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 11205.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 68.89 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 704.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1122.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 370.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 494.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.99 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7469.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 49.39 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 615.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1010.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -132,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d]
-    line "CheckMetricsAndSwap" [11,13,13,9,12,13,13,10,9,11]
-    line "CrushOptimized" [390,319,494,306,375,422,435,352,402,502]
-    line "CrushOriginal" [595,606,560,480,523,612,676,481,456,783]
-    line "IndexDirectTracking" [0,0,1,0,0,1,1,0,0,0]
-    line "IndexSearch" [3,3,4,3,4,3,4,3,3,3]
-    line "LoadGlobalConfig" [6847,7422,9861,6379,7276,8830,7163,6898,6860,11205]
-    line "PadString" [3,3,3,3,2,3,48,47,43,69]
+    x-axis [66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29]
+    line "CheckMetricsAndSwap" [13,13,9,12,13,13,10,9,11,10]
+    line "CrushOptimized" [319,494,306,375,422,435,352,402,502,370]
+    line "CrushOriginal" [606,560,480,523,612,676,481,456,783,495]
+    line "IndexDirectTracking" [0,1,0,0,1,1,0,0,0,0]
+    line "IndexSearch" [3,4,3,4,3,4,3,3,3,3]
+    line "LoadGlobalConfig" [7422,9861,6379,7276,8830,7163,6898,6860,11205,7469]
+    line "PadString" [3,3,3,2,3,48,47,43,69,49]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [538,598,725,535,663,724,642,658,507,704]
-    line "SanitizeLog/Unsafe" [899,1078,1279,926,1017,1209,1232,802,779,1122]
+    line "SanitizeLog/Safe" [598,725,535,663,724,642,658,507,704,615]
+    line "SanitizeLog/Unsafe" [1078,1279,926,1017,1209,1232,802,779,1122,1010]
 ```
 
 #### Memory per Operation (B/op)
@@ -156,14 +154,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d]
+    x-axis [66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1312,1312,1320]
-    line "PadString" [0,0,0,0,0,0,64,64,64,64]
+    line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1312,1320,1320]
+    line "PadString" [0,0,0,0,0,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -180,14 +178,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [43ccc3d,66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d]
+    x-axis [66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [37,37,37,37,37,37,37,37,37,38]
-    line "PadString" [0,0,0,0,0,0,1,1,1,1]
+    line "LoadGlobalConfig" [37,37,37,37,37,37,37,37,38,38]
+    line "PadString" [0,0,0,0,0,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        520.1n ± ∞ ¹    494.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       348.9n ± ∞ ¹    370.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.634µ ± ∞ ¹    7.469µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            53.49n ± ∞ ¹    49.39n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     605.8n ± ∞ ¹    615.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   988.4n ± ∞ ¹   1010.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  10.43n ± ∞ ¹    10.42n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.667n ± ∞ ¹    2.986n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3702n ± ∞ ¹   0.4576n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                94.97n          94.45n        -0.54%
+CrushOriginal-8                        494.8n ± ∞ ¹    549.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       370.4n ± ∞ ¹    372.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.469µ ± ∞ ¹    7.459µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            49.39n ± ∞ ¹    51.22n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     615.2n ± ∞ ¹    639.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   1.010µ ± ∞ ¹    1.023µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.420n ± ∞ ¹    8.904n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.986n ± ∞ ¹    3.128n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4576n ± ∞ ¹   0.4276n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                94.45n          94.65n        +0.21%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.42 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 370.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 494.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.99 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7469.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 49.39 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 615.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1010.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 372.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 549.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.43 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.13 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7459.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 51.22 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 639.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1023.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29]
-    line "CheckMetricsAndSwap" [13,13,9,12,13,13,10,9,11,10]
-    line "CrushOptimized" [319,494,306,375,422,435,352,402,502,370]
-    line "CrushOriginal" [606,560,480,523,612,676,481,456,783,495]
-    line "IndexDirectTracking" [0,1,0,0,1,1,0,0,0,0]
-    line "IndexSearch" [3,4,3,4,3,4,3,3,3,3]
-    line "LoadGlobalConfig" [7422,9861,6379,7276,8830,7163,6898,6860,11205,7469]
-    line "PadString" [3,3,3,2,3,48,47,43,69,49]
+    x-axis [0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e]
+    line "CheckMetricsAndSwap" [13,9,12,13,13,10,9,11,10,9]
+    line "CrushOptimized" [494,306,375,422,435,352,402,502,370,372]
+    line "CrushOriginal" [560,480,523,612,676,481,456,783,495,550]
+    line "IndexDirectTracking" [1,0,0,1,1,0,0,0,0,0]
+    line "IndexSearch" [4,3,4,3,4,3,3,3,3,3]
+    line "LoadGlobalConfig" [9861,6379,7276,8830,7163,6898,6860,11205,7469,7459]
+    line "PadString" [3,3,2,3,48,47,43,69,49,51]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [598,725,535,663,724,642,658,507,704,615]
-    line "SanitizeLog/Unsafe" [1078,1279,926,1017,1209,1232,802,779,1122,1010]
+    line "SanitizeLog/Safe" [725,535,663,724,642,658,507,704,615,640]
+    line "SanitizeLog/Unsafe" [1279,926,1017,1209,1232,802,779,1122,1010,1023]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,14 +154,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29]
+    x-axis [0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1312,1320,1320]
-    line "PadString" [0,0,0,0,0,64,64,64,64,64]
+    line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1312,1312,1320,1320,1320]
+    line "PadString" [0,0,0,0,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -178,14 +178,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [66a6811,0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29]
+    x-axis [0c47d6e,24e5c28,51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [37,37,37,37,37,37,37,37,38,38]
-    line "PadString" [0,0,0,0,0,1,1,1,1,1]
+    line "LoadGlobalConfig" [37,37,37,37,37,37,37,38,38,38]
+    line "PadString" [0,0,0,0,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
Resolves #746

## Summary

The `SanitizeLog/Unsafe` micro-benchmark regresses the `benchstat` gate >5% on essentially every run now, including on `master` itself (failed run +34.85%). The benchmark is pure noise: `SanitizeLog` code is **unmodified** by the triggering commits, and the base measurement itself swings 23-35% between identical reruns of the same SHA on untouched code. The workflow already ignores several similarly noisy micro-benchmarks (IndexSearch, PadString, LoadGlobalConfig, RPC_Encode, etc.).

This change adds `SanitizeLog` to the benchstat noisy-micro-benchmark ignore list. No application code is touched.

## Changelog
- [60e554e] Add `SanitizeLog` to the benchstat noisy-micro-benchmark ignore list.

## Testing
- CI-only change; `make benchmark` output unchanged in semantics (SanitizeLog rows now filtered from the >5% gate).
