### PR TITLE
common: sanitize all control chars in SanitizeLog

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2826,3 +2826,12 @@ c379fe8,BenchmarkLoadGlobalConfig-8,7292.00,1320.00,38.00
 c379fe8,BenchmarkPadString-8,48.82,64.00,1.00
 c379fe8,BenchmarkSanitizeLog/Safe-8,529.30,0.00,0.00
 c379fe8,BenchmarkSanitizeLog/Unsafe-8,1050.00,704.00,1.00
+ac0a8cf,BenchmarkCheckMetricsAndSwap-8,8.38,0.00,0.00
+ac0a8cf,BenchmarkCrushOptimized-8,396.10,0.00,0.00
+ac0a8cf,BenchmarkCrushOriginal-8,566.30,164.00,3.00
+ac0a8cf,BenchmarkIndexDirectTracking-8,0.42,0.00,0.00
+ac0a8cf,BenchmarkIndexSearch-8,1.82,0.00,0.00
+ac0a8cf,BenchmarkLoadGlobalConfig-8,7939.00,1320.00,38.00
+ac0a8cf,BenchmarkPadString-8,56.59,64.00,1.00
+ac0a8cf,BenchmarkSanitizeLog/Safe-8,225.70,0.00,0.00
+ac0a8cf,BenchmarkSanitizeLog/Unsafe-8,760.70,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        498.8n ± ∞ ¹    538.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       323.3n ± ∞ ¹    331.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.314µ ± ∞ ¹    7.292µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            50.80n ± ∞ ¹    48.82n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     566.2n ± ∞ ¹    529.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   950.6n ± ∞ ¹   1050.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.420n ± ∞ ¹    9.094n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          3.601n ± ∞ ¹    2.968n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3462n ± ∞ ¹   0.4339n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                90.79n          90.66n        -0.14%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        538.7n ± ∞ ¹    566.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       331.5n ± ∞ ¹    396.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.292µ ± ∞ ¹    7.939µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            48.82n ± ∞ ¹    56.59n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     529.3n ± ∞ ¹    225.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                  1050.0n ± ∞ ¹    760.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  9.094n ± ∞ ¹    8.385n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.968n ± ∞ ¹    1.820n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4339n ± ∞ ¹   0.4244n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                90.66n          78.41n        -13.51%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 9.09 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 331.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 538.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.43 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7292.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 48.82 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 529.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1050.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 396.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 566.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.82 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7939.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 56.59 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 225.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 760.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8]
-    line "CheckMetricsAndSwap" [12,13,13,10,9,11,10,9,10,9]
-    line "CrushOptimized" [375,422,435,352,402,502,370,372,323,332]
-    line "CrushOriginal" [523,612,676,481,456,783,495,550,499,539]
-    line "IndexDirectTracking" [0,1,1,0,0,0,0,0,0,0]
-    line "IndexSearch" [4,3,4,3,3,3,3,3,4,3]
-    line "LoadGlobalConfig" [7276,8830,7163,6898,6860,11205,7469,7459,7314,7292]
-    line "PadString" [2,3,48,47,43,69,49,51,51,49]
+    x-axis [355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf]
+    line "CheckMetricsAndSwap" [13,13,10,9,11,10,9,10,9,8]
+    line "CrushOptimized" [422,435,352,402,502,370,372,323,332,396]
+    line "CrushOriginal" [612,676,481,456,783,495,550,499,539,566]
+    line "IndexDirectTracking" [1,1,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [3,4,3,3,3,3,3,4,3,2]
+    line "LoadGlobalConfig" [8830,7163,6898,6860,11205,7469,7459,7314,7292,7939]
+    line "PadString" [3,48,47,43,69,49,51,51,49,57]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [663,724,642,658,507,704,615,640,566,529]
-    line "SanitizeLog/Unsafe" [1017,1209,1232,802,779,1122,1010,1023,951,1050]
+    line "SanitizeLog/Safe" [724,642,658,507,704,615,640,566,529,226]
+    line "SanitizeLog/Unsafe" [1209,1232,802,779,1122,1010,1023,951,1050,761]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,14 +154,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8]
+    x-axis [355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1312,1312,1312,1312,1312,1320,1320,1320,1320,1320]
-    line "PadString" [0,0,64,64,64,64,64,64,64,64]
+    line "LoadGlobalConfig" [1312,1312,1312,1312,1320,1320,1320,1320,1320,1320]
+    line "PadString" [0,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -178,14 +178,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [51102d9,355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8]
+    x-axis [355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [37,37,37,37,37,38,38,38,38,38]
-    line "PadString" [0,0,1,1,1,1,1,1,1,1]
+    line "LoadGlobalConfig" [37,37,37,37,38,38,38,38,38,38]
+    line "PadString" [0,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]

--- a/src/common/log.go
+++ b/src/common/log.go
@@ -3,7 +3,6 @@ package common
 import (
 	"io"
 	"log"
-	"strings"
 	"unsafe"
 )
 
@@ -18,21 +17,31 @@ func LogStdOut(logApp bool) {
 	}
 }
 
-// SanitizeLog removes CRLF characters from a string to prevent log injection.
+// SanitizeLog strips control characters from a string to prevent log injection.
+// All control bytes below 0x20 are replaced with '_' except tab (\x09) which is
+// preserved. This neutralizes CRLF, null bytes, ANSI escape sequences (ESC \x1b),
+// and other control characters that could manipulate terminals or hide log content.
 func SanitizeLog(input string) string {
-	idx := strings.IndexAny(input, "\n\r")
-	if idx == -1 {
+	if !hasControlByte(input) {
 		return input
 	}
 
 	b := make([]byte, len(input))
 	copy(b, input)
-	for i := idx; i < len(b); i++ {
-		c := b[i]
-		if c == '\n' || c == '\r' {
+	for i := range b {
+		if b[i] < 0x20 && b[i] != '\t' {
 			b[i] = '_'
 		}
 	}
 	// ⚡ Bolt: Eliminate string allocation overhead by using unsafe.String.
 	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+func hasControlByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if b := s[i]; b < 0x20 && b != '\t' {
+			return true
+		}
+	}
+	return false
 }

--- a/src/common/string_test.go
+++ b/src/common/string_test.go
@@ -16,6 +16,12 @@ func TestSanitizeLog(t *testing.T) {
 		{"Multiple CRLFs", "\r\nhello\r\nworld\r\n", "__hello__world__"},
 		{"Just CR", "hello\rworld", "hello_world"},
 		{"Just LF", "hello\nworld", "hello_world"},
+		{"Null byte", "hello\x00world", "hello_world"},
+		{"ANSI escape", "hello\x1b[31mred", "hello_[31mred"},
+		{"Control chars", "a\x01b\x02c\x07d", "a_b_c_d"},
+		{"Tab preserved", "a\tb", "a\tb"},
+		{"Vertical tab and FF", "a\x0bb\x0cc", "a_b_c"},
+		{"DEL preserved", "a\x7fb", "a\x7fb"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Resolves #613

## Summary

`SanitizeLog` previously only neutralized CR and LF, leaving null bytes, ANSI escape sequences (`\x1b[...m`), and other control characters (0x01-0x08, 0x0b, 0x0c, 0x0e-0x1f) intact. At 90+ audit logging call sites this is an injection vector: ANSI sequences can manipulate/ spoof terminal output and control chars can hide log entries.

### Fix
Replace **all** control bytes below `0x20` with `_`, preserving the established length-preserving replacement contract:
- Tab (`\x09`) is preserved (per suggested fix).
- DEL (`\x7f`) is above the control range and untouched.
- CR/LF/null/ESC/etc. all become `_`.
- Fast path: a single byte scan returns the input unchanged when no control bytes are present (no behavioral/performance regression for safe log lines).

## Changelog
- `src/common/log.go`: `SanitizeLog` now replaces every control byte `< 0x20` (except tab) with `_`; new `hasControlByte` fast-path helper.
- `src/common/string_test.go`: added null-byte, ANSI-escape, control-char, vertical-tab/FF, tab-preserved, and DEL-preserved cases (11 subtests).

## Testing
- `go test ./src/common/ -run TestSanitizeLog -v` — all 11 subtests pass.
- `go test ./src/storage/ ./src/client/ ./src/transport/` — pass.
