### PR TITLE
common: time-based deadline refresh in IdleTimeoutConn

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2835,3 +2835,12 @@ ac0a8cf,BenchmarkLoadGlobalConfig-8,7939.00,1320.00,38.00
 ac0a8cf,BenchmarkPadString-8,56.59,64.00,1.00
 ac0a8cf,BenchmarkSanitizeLog/Safe-8,225.70,0.00,0.00
 ac0a8cf,BenchmarkSanitizeLog/Unsafe-8,760.70,704.00,1.00
+d94dad2,BenchmarkCheckMetricsAndSwap-8,11.19,0.00,0.00
+d94dad2,BenchmarkCrushOptimized-8,452.50,0.00,0.00
+d94dad2,BenchmarkCrushOriginal-8,637.30,164.00,3.00
+d94dad2,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+d94dad2,BenchmarkIndexSearch-8,2.10,0.00,0.00
+d94dad2,BenchmarkLoadGlobalConfig-8,9559.00,1320.00,38.00
+d94dad2,BenchmarkPadString-8,70.45,64.00,1.00
+d94dad2,BenchmarkSanitizeLog/Safe-8,473.70,0.00,0.00
+d94dad2,BenchmarkSanitizeLog/Unsafe-8,960.30,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        538.7n ± ∞ ¹    566.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       331.5n ± ∞ ¹    396.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.292µ ± ∞ ¹    7.939µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            48.82n ± ∞ ¹    56.59n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     529.3n ± ∞ ¹    225.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                  1050.0n ± ∞ ¹    760.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  9.094n ± ∞ ¹    8.385n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.968n ± ∞ ¹    1.820n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4339n ± ∞ ¹   0.4244n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                90.66n          78.41n        -13.51%
+CrushOriginal-8                        566.3n ± ∞ ¹    637.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       396.1n ± ∞ ¹    452.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.939µ ± ∞ ¹    9.559µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            56.59n ± ∞ ¹    70.45n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     225.7n ± ∞ ¹    473.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   760.7n ± ∞ ¹    960.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.385n ± ∞ ¹   11.190n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.820n ± ∞ ¹    2.101n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4244n ± ∞ ¹   0.5046n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                78.41n          100.5n        +28.20%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 396.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 566.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.82 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7939.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 56.59 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 225.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 760.70 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.19 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 452.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 637.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9559.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 70.45 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 473.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 960.30 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf]
-    line "CheckMetricsAndSwap" [13,13,10,9,11,10,9,10,9,8]
-    line "CrushOptimized" [422,435,352,402,502,370,372,323,332,396]
-    line "CrushOriginal" [612,676,481,456,783,495,550,499,539,566]
-    line "IndexDirectTracking" [1,1,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,4,3,3,3,3,3,4,3,2]
-    line "LoadGlobalConfig" [8830,7163,6898,6860,11205,7469,7459,7314,7292,7939]
-    line "PadString" [3,48,47,43,69,49,51,51,49,57]
+    x-axis [554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2]
+    line "CheckMetricsAndSwap" [13,10,9,11,10,9,10,9,8,11]
+    line "CrushOptimized" [435,352,402,502,370,372,323,332,396,452]
+    line "CrushOriginal" [676,481,456,783,495,550,499,539,566,637]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [4,3,3,3,3,3,4,3,2,2]
+    line "LoadGlobalConfig" [7163,6898,6860,11205,7469,7459,7314,7292,7939,9559]
+    line "PadString" [48,47,43,69,49,51,51,49,57,70]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [724,642,658,507,704,615,640,566,529,226]
-    line "SanitizeLog/Unsafe" [1209,1232,802,779,1122,1010,1023,951,1050,761]
+    line "SanitizeLog/Safe" [642,658,507,704,615,640,566,529,226,474]
+    line "SanitizeLog/Unsafe" [1232,802,779,1122,1010,1023,951,1050,761,960]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,14 +154,14 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf]
+    x-axis [554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1312,1312,1312,1312,1320,1320,1320,1320,1320,1320]
-    line "PadString" [0,64,64,64,64,64,64,64,64,64]
+    line "LoadGlobalConfig" [1312,1312,1312,1320,1320,1320,1320,1320,1320,1320]
+    line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]
@@ -178,14 +178,14 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [355507e,554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf]
+    x-axis [554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [37,37,37,37,38,38,38,38,38,38]
-    line "PadString" [0,1,1,1,1,1,1,1,1,1]
+    line "LoadGlobalConfig" [37,37,37,38,38,38,38,38,38,38]
+    line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
     line "SanitizeLog/Safe" [0,0,0,0,0,0,0,0,0,0]

--- a/src/common/net.go
+++ b/src/common/net.go
@@ -22,8 +22,8 @@ type IdleTimeoutConn struct {
 	net.Conn
 	timeout          time.Duration
 	absoluteDeadline atomic.Pointer[time.Time]
-	readCalls        atomic.Uint32
-	writeCalls       atomic.Uint32
+	lastReadRefresh  atomic.Int64
+	lastWriteRefresh atomic.Int64
 	broken           atomic.Bool
 }
 
@@ -70,23 +70,28 @@ func (c *IdleTimeoutConn) applyDeadlines(isRead bool) {
 		}
 	}()
 
-	var calls *atomic.Uint32
+	var lastRefresh *atomic.Int64
 	if isRead {
-		calls = &c.readCalls
+		lastRefresh = &c.lastReadRefresh
 	} else {
-		calls = &c.writeCalls
-	}
-
-	// ⚡ Bolt: Amortize the cost of updating deadlines using a high-performance bitwise check.
-	// We only update the deadline on the first call and every 64 calls thereafter.
-	// This reduces time.Now() and SetDeadline system calls by 98.4%.
-	// For Slowloris, this is actually MORE secure as it requires 64 drip-bytes to reset the timer.
-	count := calls.Add(1)
-	if (count-1)&63 != 0 {
-		return
+		lastRefresh = &c.lastWriteRefresh
 	}
 
 	now := time.Now()
+	// ⚡ Bolt: Amortize the cost of updating deadlines by refreshing, at most,
+	// once per amortization window based on elapsed time rather than call count.
+	// Counting calls (e.g. every 64th call) breaks slow-but-progressing
+	// connections: a link delivering 1 byte/sec only advances the deadline every
+	// 64 seconds, exceeding a 30s timeout and killing a live transfer. A time
+	// window keeps the deadline within `refresh` of real data progress, so
+	// healthy slow links survive while idle connections still time out. This
+	// still avoids time.Now()/SetDeadline syscalls on high-throughput paths.
+	refresh := c.timeout / 4
+	if prev := lastRefresh.Load(); prev != 0 && now.Sub(time.Unix(0, prev)) < refresh {
+		return
+	}
+	lastRefresh.Store(now.UnixNano())
+
 	deadline := now.Add(c.timeout)
 	if dp := c.absoluteDeadline.Load(); dp != nil && !dp.IsZero() && dp.Before(deadline) {
 		deadline = *dp

--- a/src/common/net_test.go
+++ b/src/common/net_test.go
@@ -160,6 +160,57 @@ func TestIdleTimeoutConn_ReadPreservesEOF(t *testing.T) {
 	}
 }
 
+func TestIdleTimeoutConn_SlowProgressiveReadSurvives(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Regression for #614: a slow-but-progressing connection must not be cut
+	// because the deadline amortization was call-count based (1 byte/sec over
+	// 64 bytes = 64s > timeout). With a time-based refresh window the deadline
+	// tracks real data progress, so a drip-fed stream lives on.
+
+	client, server := net.Pipe()
+	idleConn := NewIdleTimeoutConn(client, 50*time.Millisecond)
+
+	const totalBytes = 50
+	const dripInterval = 4 * time.Millisecond
+
+	go func() {
+		defer server.Close()
+		buf := make([]byte, 1)
+		for range totalBytes {
+			if _, err := server.Write(buf); err != nil {
+				return
+			}
+			time.Sleep(dripInterval)
+		}
+	}()
+
+	defer func() {
+		idleConn.Close()
+		client.Close()
+	}()
+
+	// Total window: 50 * 4ms = 200ms. With the old call-count logic the first
+	// (and only until the 64th) deadline refresh would have expired the 50ms
+	// timeout ~13 bytes in; time-based refresh must survive the whole stream.
+	readBuf := make([]byte, 1)
+	wallClock := time.After(2 * time.Second)
+	for bytesRead := 0; bytesRead < totalBytes; {
+		select {
+		case <-wallClock:
+			t.Fatalf("test timed out after %d bytes", bytesRead)
+		default:
+		}
+		if _, err := idleConn.Read(readBuf); err != nil {
+			if isTimeout(err) {
+				t.Fatalf("slow progressive read hit deadline at byte %d: %v", bytesRead, err)
+			}
+			return
+		}
+		bytesRead++
+	}
+}
+
 func TestDialSocket(t *testing.T) {
 	defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
Resolves #614

## Summary

`IdleTimeoutConn.applyDeadlines` refreshed the connection deadline only on the 1st call and every 64th call thereafter (byte-count amortization). A slow but actively-flowing connection — e.g. 1 byte/sec over a satellite or congested link — advanced the deadline only every 64 seconds, exceeding the 30s timeout and cutting a live transfer mid-stream.

### Fix
Switch to **time-based** amortization: refresh the deadline at most once every `timeout/4` of real elapsed time, tracked per direction (`lastReadRefresh` / `lastWriteRefresh`, atomic).

- Slow links stay alive: the deadline now tracks actual data progress, so any connection delivering bytes faster than `timeout/4` keeps sliding its deadline forward.
- Idle connections still time out exactly as before.
- High-throughput paths still amortize the `time.Now()` + `SetRead/WriteDeadline` syscall cost (just based on elapsed time, not call count).

## Changelog
- `src/common/net.go`: replace `readCalls`/`writeCalls` call counters with `lastReadRefresh`/`lastWriteRefresh` nanosecond atomics; throttle refresh to once per `timeout/4`.
- `src/common/net_test.go`: new `TestIdleTimeoutConn_SlowProgressiveReadSurvives` — a 4ms-drip stream across 50 bytes (200ms > 50ms timeout) must not be cut mid-window.

## Testing
- `go test ./src/common/ -run 'TestIdleTimeoutConn|TestDialSocket' -v` — all pass (incl. new slow-drip regression test).
- `go test -race ./src/common/` — pass.

## Note
This PR was recreated on the correct branch after a branch-naming mix-up that placed the work on the (already-merged) #613 branch; the commit is identical.
