### PR TITLE
common: skip zero-weight nodes in CRUSH Placement

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2844,3 +2844,12 @@ d94dad2,BenchmarkLoadGlobalConfig-8,9559.00,1320.00,38.00
 d94dad2,BenchmarkPadString-8,70.45,64.00,1.00
 d94dad2,BenchmarkSanitizeLog/Safe-8,473.70,0.00,0.00
 d94dad2,BenchmarkSanitizeLog/Unsafe-8,960.30,704.00,1.00
+efd8101,BenchmarkCheckMetricsAndSwap-8,12.25,0.00,0.00
+efd8101,BenchmarkCrushOptimized-8,427.60,0.00,0.00
+efd8101,BenchmarkCrushOriginal-8,571.00,164.00,3.00
+efd8101,BenchmarkIndexDirectTracking-8,0.62,0.00,0.00
+efd8101,BenchmarkIndexSearch-8,2.14,0.00,0.00
+efd8101,BenchmarkLoadGlobalConfig-8,7558.00,1320.00,38.00
+efd8101,BenchmarkPadString-8,52.65,64.00,1.00
+efd8101,BenchmarkSanitizeLog/Safe-8,303.40,0.00,0.00
+efd8101,BenchmarkSanitizeLog/Unsafe-8,883.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        566.3n ± ∞ ¹    637.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       396.1n ± ∞ ¹    452.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.939µ ± ∞ ¹    9.559µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            56.59n ± ∞ ¹    70.45n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     225.7n ± ∞ ¹    473.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   760.7n ± ∞ ¹    960.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.385n ± ∞ ¹   11.190n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.820n ± ∞ ¹    2.101n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4244n ± ∞ ¹   0.5046n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                78.41n          100.5n        +28.20%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        637.3n ± ∞ ¹    571.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       452.5n ± ∞ ¹    427.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.559µ ± ∞ ¹    7.558µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            70.45n ± ∞ ¹    52.65n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     473.7n ± ∞ ¹    303.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   960.3n ± ∞ ¹    883.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  11.19n ± ∞ ¹    12.25n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.101n ± ∞ ¹    2.137n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.5046n ± ∞ ¹   0.6248n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                100.5n          90.95n        -9.52%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 11.19 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 452.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 637.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9559.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 70.45 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 473.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 960.30 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 12.25 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 427.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 571.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.62 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.14 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7558.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 52.65 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 303.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 883.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2]
-    line "CheckMetricsAndSwap" [13,10,9,11,10,9,10,9,8,11]
-    line "CrushOptimized" [435,352,402,502,370,372,323,332,396,452]
-    line "CrushOriginal" [676,481,456,783,495,550,499,539,566,637]
-    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [4,3,3,3,3,3,4,3,2,2]
-    line "LoadGlobalConfig" [7163,6898,6860,11205,7469,7459,7314,7292,7939,9559]
-    line "PadString" [48,47,43,69,49,51,51,49,57,70]
+    x-axis [f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101]
+    line "CheckMetricsAndSwap" [10,9,11,10,9,10,9,8,11,12]
+    line "CrushOptimized" [352,402,502,370,372,323,332,396,452,428]
+    line "CrushOriginal" [481,456,783,495,550,499,539,566,637,571]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
+    line "IndexSearch" [3,3,3,3,3,4,3,2,2,2]
+    line "LoadGlobalConfig" [6898,6860,11205,7469,7459,7314,7292,7939,9559,7558]
+    line "PadString" [47,43,69,49,51,51,49,57,70,53]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [642,658,507,704,615,640,566,529,226,474]
-    line "SanitizeLog/Unsafe" [1232,802,779,1122,1010,1023,951,1050,761,960]
+    line "SanitizeLog/Safe" [658,507,704,615,640,566,529,226,474,303]
+    line "SanitizeLog/Unsafe" [802,779,1122,1010,1023,951,1050,761,960,883]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2]
+    x-axis [f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1312,1312,1312,1320,1320,1320,1320,1320,1320,1320]
+    line "LoadGlobalConfig" [1312,1312,1320,1320,1320,1320,1320,1320,1320,1320]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [554181f,f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2]
+    x-axis [f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [37,37,37,38,38,38,38,38,38,38]
+    line "LoadGlobalConfig" [37,37,38,38,38,38,38,38,38,38]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -48,8 +48,22 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 		return nil, fmt.Errorf("invalid object hash: empty: %w", syscall.EINVAL)
 	}
 
-	if replicationFactor > len(m.Nodes) {
-		replicationFactor = len(m.Nodes)
+	// Filter out zero/negative-weight nodes: a disabled or decommissioned node
+	// (Weight <= 0) must never receive data, even when replicationFactor is
+	// large enough that last-sorted zero-score nodes would otherwise be selected.
+	eligible := make([]*Node, 0, len(m.Nodes))
+	for _, node := range m.Nodes {
+		if node != nil && node.Weight > 0 {
+			eligible = append(eligible, node)
+		}
+	}
+
+	if len(eligible) == 0 {
+		return nil, fmt.Errorf("cluster map has no nodes with positive weight: %w", syscall.EINVAL)
+	}
+
+	if replicationFactor > len(eligible) {
+		replicationFactor = len(eligible)
 	}
 
 	type score struct {
@@ -57,9 +71,9 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 		value float64
 	}
 
-	scores := make([]score, len(m.Nodes))
+	scores := make([]score, len(eligible))
 
-	for i, node := range m.Nodes {
+	for i, node := range eligible {
 		// Calculate a deterministic float score between 0 and 1 for this node/hash pair.
 		h := sha256.New()
 		h.Write([]byte(objectHash))

--- a/src/common/crush_test.go
+++ b/src/common/crush_test.go
@@ -120,14 +120,14 @@ func TestClusterMap_Placement_Defensive(t *testing.T) {
 		t.Errorf("Expected error to wrap syscall.EINVAL, got %v", err)
 	}
 
-	// Test panic recovery with nil Node
-	mPanic := &ClusterMap{Nodes: []*Node{nil}}
+	// Test no eligible (positive-weight) nodes: nil/zero-weight nodes are filtered
+	mPanic := &ClusterMap{Nodes: []*Node{nil, {ID: 0, Weight: 0}}}
 	_, err = mPanic.Placement("some-hash", 1)
 	if err == nil {
-		t.Errorf("Expected error from panic recovery, got nil")
+		t.Errorf("Expected error when no positive-weight nodes, got nil")
 	}
-	if !errors.Is(err, syscall.EIO) {
-		t.Errorf("Expected error to wrap syscall.EIO, got %v", err)
+	if !errors.Is(err, syscall.EINVAL) {
+		t.Errorf("Expected error to wrap syscall.EINVAL, got %v", err)
 	}
 }
 
@@ -149,5 +149,49 @@ func TestClusterMap_LargeNodeIDs(t *testing.T) {
 	}
 	if p1[0].ID == p1[1].ID {
 		t.Fatalf("Node IDs collided: both are %d", p1[0].ID)
+	}
+}
+
+func TestClusterMap_Placement_SkipsZeroWeightNodes(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	nodes := []*Node{
+		{ID: 0, Weight: 1, Addr: "127.0.0.1:4440"},
+		{ID: 1, Weight: 1, Addr: "127.0.0.1:4441"},
+		{ID: 2, Weight: 0, Addr: "127.0.0.1:4442"},   // disabled
+		{ID: 3, Weight: -5, Addr: "127.0.0.1:4443"}, // decommissioned
+	}
+	m := &ClusterMap{Nodes: nodes}
+
+	// With replicationFactor == 4 (>= len(nodes)), zero/negative-weight nodes
+	// must never be selected even though scoring would sort them last.
+	p, err := m.Placement("some-hash", 4)
+	if err != nil {
+		t.Fatalf("Placement failed: %v", err)
+	}
+	if len(p) != 2 {
+		t.Fatalf("Expected 2 eligible nodes, got %d", len(p))
+	}
+	for _, node := range p {
+		if node.Weight <= 0 {
+			t.Errorf("Placement selected node %d with weight %d", node.ID, node.Weight)
+		}
+	}
+}
+
+func TestClusterMap_Placement_AllZeroWeight(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	m := &ClusterMap{Nodes: []*Node{
+		{ID: 0, Weight: 0, Addr: "127.0.0.1:4440"},
+		{ID: 1, Weight: -1, Addr: "127.0.0.1:4441"},
+	}}
+
+	_, err := m.Placement("some-hash", 2)
+	if err == nil {
+		t.Fatal("Expected error when all nodes have Weight <= 0, got nil")
+	}
+	if !errors.Is(err, syscall.EINVAL) {
+		t.Errorf("Expected error to wrap syscall.EINVAL, got %v", err)
 	}
 }


### PR DESCRIPTION
Resolves #615

## Summary

In `ClusterMap.Placement`, nodes with `Weight <= 0` received `finalScore = 0` and were sorted last, but were still returned when `replicationFactor` was large enough — placing data on disabled/decommissioned nodes that must never receive objects.

### Fix
Filter nodes with `Weight <= 0` (and nil pointers) into an `eligible` slice before scoring and selection:
- Only positive-weight nodes are scored and can be selected.
- `replicationFactor` is clamped to the number of eligible nodes.
- If no positive-weight node remains, an `EINVAL` error is returned.

## Changelog
- `src/common/crush.go`: build `eligible` list (skip `node == nil || node.Weight <= 0`); clamp against it; error when empty.
- `src/common/crush_test.go`: 
  - `TestClusterMap_Placement_SkipsZeroWeightNodes` — RF=4 with 2 zero-weight nodes returns only the 2 eligible; none selected have `Weight <= 0`.
  - `TestClusterMap_Placement_AllZeroWeight` — EINVAL when no positive-weight node.
  - `TestClusterMap_Placement_Defensive` — nil/zero-weight nodes now yield EINVAL (previously exercised panic-recovery path).

## Testing
- `go test ./src/common/ -run TestClusterMap -v` — all 6 tests pass.
- `go test ./src/common/ ./src/storage/ ./src/client/ ./src/transport/ ./src/server/` — pass.
