### PR TITLE
common: pad expected auth token in challenge-response server

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2853,3 +2853,12 @@ efd8101,BenchmarkLoadGlobalConfig-8,7558.00,1320.00,38.00
 efd8101,BenchmarkPadString-8,52.65,64.00,1.00
 efd8101,BenchmarkSanitizeLog/Safe-8,303.40,0.00,0.00
 efd8101,BenchmarkSanitizeLog/Unsafe-8,883.00,704.00,1.00
+0271e7d,BenchmarkCheckMetricsAndSwap-8,11.18,0.00,0.00
+0271e7d,BenchmarkCrushOptimized-8,468.40,0.00,0.00
+0271e7d,BenchmarkCrushOriginal-8,542.50,164.00,3.00
+0271e7d,BenchmarkIndexDirectTracking-8,0.54,0.00,0.00
+0271e7d,BenchmarkIndexSearch-8,2.10,0.00,0.00
+0271e7d,BenchmarkLoadGlobalConfig-8,8021.00,1320.00,38.00
+0271e7d,BenchmarkPadString-8,52.31,64.00,1.00
+0271e7d,BenchmarkSanitizeLog/Safe-8,288.10,0.00,0.00
+0271e7d,BenchmarkSanitizeLog/Unsafe-8,849.10,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        637.3n ± ∞ ¹    571.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       452.5n ± ∞ ¹    427.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     9.559µ ± ∞ ¹    7.558µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            70.45n ± ∞ ¹    52.65n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     473.7n ± ∞ ¹    303.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   960.3n ± ∞ ¹    883.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  11.19n ± ∞ ¹    12.25n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.101n ± ∞ ¹    2.137n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.5046n ± ∞ ¹   0.6248n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                100.5n          90.95n        -9.52%
+CrushOriginal-8                        571.0n ± ∞ ¹    542.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       427.6n ± ∞ ¹    468.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.558µ ± ∞ ¹    8.021µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            52.65n ± ∞ ¹    52.31n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     303.4n ± ∞ ¹    288.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   883.0n ± ∞ ¹    849.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  12.25n ± ∞ ¹    11.18n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.137n ± ∞ ¹    2.098n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.6248n ± ∞ ¹   0.5422n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                90.95n          88.46n        -2.74%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 12.25 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 427.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 571.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.62 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.14 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7558.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 52.65 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 303.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 883.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.18 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 468.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 542.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.54 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8021.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 52.31 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 288.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 849.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101]
-    line "CheckMetricsAndSwap" [10,9,11,10,9,10,9,8,11,12]
-    line "CrushOptimized" [352,402,502,370,372,323,332,396,452,428]
-    line "CrushOriginal" [481,456,783,495,550,499,539,566,637,571]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
-    line "IndexSearch" [3,3,3,3,3,4,3,2,2,2]
-    line "LoadGlobalConfig" [6898,6860,11205,7469,7459,7314,7292,7939,9559,7558]
-    line "PadString" [47,43,69,49,51,51,49,57,70,53]
+    x-axis [2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d]
+    line "CheckMetricsAndSwap" [9,11,10,9,10,9,8,11,12,11]
+    line "CrushOptimized" [402,502,370,372,323,332,396,452,428,468]
+    line "CrushOriginal" [456,783,495,550,499,539,566,637,571,542]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,1]
+    line "IndexSearch" [3,3,3,3,4,3,2,2,2,2]
+    line "LoadGlobalConfig" [6860,11205,7469,7459,7314,7292,7939,9559,7558,8021]
+    line "PadString" [43,69,49,51,51,49,57,70,53,52]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [658,507,704,615,640,566,529,226,474,303]
-    line "SanitizeLog/Unsafe" [802,779,1122,1010,1023,951,1050,761,960,883]
+    line "SanitizeLog/Safe" [507,704,615,640,566,529,226,474,303,288]
+    line "SanitizeLog/Unsafe" [779,1122,1010,1023,951,1050,761,960,883,849]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101]
+    x-axis [2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1312,1312,1320,1320,1320,1320,1320,1320,1320,1320]
+    line "LoadGlobalConfig" [1312,1320,1320,1320,1320,1320,1320,1320,1320,1320]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [f578dce,2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101]
+    x-axis [2f6c105,e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [37,37,38,38,38,38,38,38,38,38]
+    line "LoadGlobalConfig" [37,38,38,38,38,38,38,38,38,38]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/common/auth.go
+++ b/src/common/auth.go
@@ -57,7 +57,13 @@ func DerivePeerTokenString(authToken string) string {
 // client's HMAC-SHA256 response, and verifies it against the expected token.
 // The auth token is never transmitted over the wire.
 // Returns true if authentication succeeded, false otherwise.
+//
+// The expected token is padded to AuthTokenLength internally, mirroring the
+// client's padding, so callers may pass an unpadded shared secret without
+// introducing a silent authentication failure for short tokens.
 func ChallengeResponseServer(rw io.ReadWriter, expectedAuthToken []byte) (bool, error) {
+	expectedAuthToken = padAuthToken(expectedAuthToken)
+
 	var nonce [challengeNonceSize]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return false, fmt.Errorf("failed to generate nonce: %w", err)
@@ -102,7 +108,11 @@ func ChallengeResponseClient(rw io.ReadWriter, authToken string) error {
 // ChallengeResponseServerPeer is like ChallengeResponseServer but also checks
 // the peer token. It returns (isPeer, error) where isPeer indicates whether
 // the client authenticated with the peer token vs the client token.
+// The expected token is padded to AuthTokenLength internally (idempotent for
+// already-padded tokens), matching the client's token format.
 func ChallengeResponseServerPeer(rw io.ReadWriter, expectedAuthToken []byte) (isPeer bool, err error) {
+	expectedAuthToken = padAuthToken(expectedAuthToken)
+
 	var nonce [challengeNonceSize]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return false, fmt.Errorf("failed to generate nonce: %w", err)
@@ -129,6 +139,17 @@ func ChallengeResponseServerPeer(rw io.ReadWriter, expectedAuthToken []byte) (is
 	}
 
 	return false, fmt.Errorf("authentication failed: HMAC mismatch: %w", syscall.EACCES)
+}
+
+// padAuthToken pads an auth token to AuthTokenLength. The client always pads
+// before signing, so the server must compare against the padded form. Padding
+// is a no-op for tokens already AuthTokenLength bytes long, keeping the
+// function safe for both new (unpadded) and legacy (padded) call sites.
+func padAuthToken(token []byte) []byte {
+	if len(token) >= AuthTokenLength {
+		return token
+	}
+	return []byte(PadString(string(token), AuthTokenLength))
 }
 
 // computeHMAC returns HMAC-SHA256(key, message).

--- a/src/common/auth_test.go
+++ b/src/common/auth_test.go
@@ -70,6 +70,56 @@ func TestChallengeResponse_Success(t *testing.T) {
 	}
 }
 
+func TestChallengeResponse_UnpaddedServerToken(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Regression for #616: the server must accept an unpadded shared token,
+	// since the client always pads before computing the HMAC. Previously an
+	// unpadded expectedAuthToken silently failed for any token < 64 bytes.
+	authToken := "my-secret-token"         // notsecret
+	expectedAuthToken := []byte(authToken) // deliberately unpadded
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	errChan := make(chan error, 1)
+	go func() {
+		isPeer, err := ChallengeResponseServerPeer(server, expectedAuthToken)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if isPeer {
+			errChan <- io.EOF
+			return
+		}
+		errChan <- nil
+	}()
+
+	err := ChallengeResponseClient(client, authToken)
+	if err != nil {
+		t.Fatalf("Client challenge-response failed: %v", err)
+	}
+
+	if err := <-errChan; err != nil {
+		t.Fatalf("Server rejected unpadded token: %v", err)
+	}
+}
+
+func TestChallengeResponse_ExactLengthTokenUnchanged(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// #616: padding must be a no-op for already-AuthTokenLength-byte tokens.
+	longToken := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if len(longToken) != AuthTokenLength {
+		t.Fatalf("test token length %d != AuthTokenLength %d", len(longToken), AuthTokenLength)
+	}
+	if got, want := string(padAuthToken([]byte(longToken))), longToken; got != want {
+		t.Fatalf("padAuthToken changed an exact-length token: %q != %q", got, want)
+	}
+}
+
 func TestChallengeResponse_PeerToken(t *testing.T) {
 	defer goleak.VerifyNone(t)
 


### PR DESCRIPTION
Resolves #616

## Summary

`ChallengeResponseServer` / `ChallengeResponseServerPeer` compared the **raw** `expectedAuthToken` against an HMAC the client computes over the **padded** form (`PadString(authToken, AuthTokenLength)`). Any caller passing an unpadded token silently failed authentication for tokens shorter than 64 bytes — an undocumented and fragile API contract.

### Fix
Pad the expected token internally via `padAuthToken` (a no-op for tokens already ≥ `AuthTokenLength`, so legacy padded call sites keep working) before computing the expected HMAC. The server now behaves identically regardless of whether callers pass padded or unpadded tokens.

## Changelog
- `src/common/auth.go`: new `padAuthToken` helper; both server challenge functions pad before verify.
- `src/common/auth_test.go`: `TestChallengeResponse_UnpaddedServerToken` (regression) + `TestChallengeResponse_ExactLengthTokenUnchanged`.

## Testing
- `go test ./src/common/ -run 'TestChallengeResponse|TestDerivePeerToken' -v` — all pass.
- `go test ./src/common/ ./src/storage/ ./src/client/ ./src/transport/ ./src/server/` — pass.
