### PR TITLE
storage: record + wire file modification time; use in S3 LastModified

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2871,3 +2871,12 @@ efd8101,BenchmarkSanitizeLog/Unsafe-8,883.00,704.00,1.00
 5240efa,BenchmarkPadString-8,52.88,64.00,1.00
 5240efa,BenchmarkSanitizeLog/Safe-8,316.50,0.00,0.00
 5240efa,BenchmarkSanitizeLog/Unsafe-8,775.30,704.00,1.00
+37c23c2,BenchmarkCheckMetricsAndSwap-8,7.44,0.00,0.00
+37c23c2,BenchmarkCrushOptimized-8,355.70,0.00,0.00
+37c23c2,BenchmarkCrushOriginal-8,468.90,164.00,3.00
+37c23c2,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+37c23c2,BenchmarkIndexSearch-8,1.61,0.00,0.00
+37c23c2,BenchmarkLoadGlobalConfig-8,6507.00,1320.00,38.00
+37c23c2,BenchmarkPadString-8,46.58,64.00,1.00
+37c23c2,BenchmarkSanitizeLog/Safe-8,265.70,0.00,0.00
+37c23c2,BenchmarkSanitizeLog/Unsafe-8,714.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                       │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        542.5n ± ∞ ¹    558.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       468.4n ± ∞ ¹    378.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.021µ ± ∞ ¹    8.176µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            52.31n ± ∞ ¹    52.88n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     288.1n ± ∞ ¹    316.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   849.1n ± ∞ ¹    775.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 11.180n ± ∞ ¹    8.393n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.098n ± ∞ ¹    1.747n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.5422n ± ∞ ¹   0.3526n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                88.46n          78.70n        -11.04%
+CrushOriginal-8                        558.4n ± ∞ ¹    468.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       378.0n ± ∞ ¹    355.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     8.176µ ± ∞ ¹    6.507µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            52.88n ± ∞ ¹    46.58n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     316.5n ± ∞ ¹    265.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   775.3n ± ∞ ¹    714.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.393n ± ∞ ¹    7.443n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.747n ± ∞ ¹    1.614n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3526n ± ∞ ¹   0.3700n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                78.70n          70.43n        -10.50%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 378.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 558.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8176.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 52.88 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 316.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 775.30 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 355.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 468.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6507.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 46.58 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 265.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 714.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa]
-    line "CheckMetricsAndSwap" [11,10,9,10,9,8,11,12,11,8]
-    line "CrushOptimized" [502,370,372,323,332,396,452,428,468,378]
-    line "CrushOriginal" [783,495,550,499,539,566,637,571,542,558]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,1,0]
-    line "IndexSearch" [3,3,3,4,3,2,2,2,2,2]
-    line "LoadGlobalConfig" [11205,7469,7459,7314,7292,7939,9559,7558,8021,8176]
-    line "PadString" [69,49,51,51,49,57,70,53,52,53]
+    x-axis [8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2]
+    line "CheckMetricsAndSwap" [10,9,10,9,8,11,12,11,8,7]
+    line "CrushOptimized" [370,372,323,332,396,452,428,468,378,356]
+    line "CrushOriginal" [495,550,499,539,566,637,571,542,558,469]
+    line "IndexDirectTracking" [0,0,0,0,0,0,1,1,0,0]
+    line "IndexSearch" [3,3,4,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [7469,7459,7314,7292,7939,9559,7558,8021,8176,6507]
+    line "PadString" [49,51,51,49,57,70,53,52,53,47]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [704,615,640,566,529,226,474,303,288,316]
-    line "SanitizeLog/Unsafe" [1122,1010,1023,951,1050,761,960,883,849,775]
+    line "SanitizeLog/Safe" [615,640,566,529,226,474,303,288,316,266]
+    line "SanitizeLog/Unsafe" [1010,1023,951,1050,761,960,883,849,775,714]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa]
+    x-axis [8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e2ab47d,8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa]
+    x-axis [8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -10,6 +10,9 @@ type FileMetadata struct {
 	Size int64
 	// RemotePath is the virtual folder or directory path of the file.
 	RemotePath string
+	// ModTime is the last modification time in Unix nanoseconds.
+	// A value of 0 means the modification time is unknown.
+	ModTime int64
 }
 
 // ReplicationData stores the information about a replication mode change.

--- a/src/server/query_handler.go
+++ b/src/server/query_handler.go
@@ -132,14 +132,14 @@ func (h *StorageQueryHandler) handleDelete(data []byte) (result []byte, err erro
 }
 
 // EncodeFileMetadataList serializes a list of FileMetadata into binary.
-// Format: [4B count] [for each: 4B nameLen + name + 4B hashLen + hash + 8B size + 4B pathLen + path]
+// Format: [4B count] [for each: 4B nameLen + name + 4B hashLen + hash + 8B size + 4B pathLen + path + 8B modtime]
 // Uses dynamic length prefixes (not fixed 64-byte buffers), so Rule 35's
 // 64-byte padding limit does not apply here. Buffer is pre-sized exactly
 // and copy() prevents overflow. Metadata comes from trusted local store.
 func EncodeFileMetadataList(files []common.FileMetadata) []byte {
 	size := 4
 	for _, f := range files {
-		size += 4 + len(f.Name) + 4 + len(f.Hash) + 8 + 4 + len(f.RemotePath)
+		size += 4 + len(f.Name) + 4 + len(f.Hash) + 8 + 4 + len(f.RemotePath) + 8
 	}
 	buf := make([]byte, size)
 	binary.BigEndian.PutUint32(buf[0:4], uint32(len(files)))
@@ -159,6 +159,8 @@ func EncodeFileMetadataList(files []common.FileMetadata) []byte {
 		off += 4
 		copy(buf[off:], f.RemotePath)
 		off += len(f.RemotePath)
+		binary.BigEndian.PutUint64(buf[off:off+8], uint64(f.ModTime))
+		off += 8
 	}
 	return buf
 }
@@ -177,7 +179,7 @@ func DecodeFileMetadataList(data []byte) (result []common.FileMetadata, err erro
 	}
 	count := int(binary.BigEndian.Uint32(data[0:4]))
 	off := 4
-	maxCount := (len(data) - 4) / 20
+	maxCount := (len(data) - 4) / 28
 	if count > maxCount {
 		return nil, fmt.Errorf("file metadata list count %d exceeds max %d for data length %d: %w", count, maxCount, len(data), syscall.EBADMSG)
 	}
@@ -234,6 +236,12 @@ func DecodeFileMetadataList(data []byte) (result []common.FileMetadata, err erro
 		remotePath := string(data[off : off+pathLen])
 		off += pathLen
 
+		if off+8 > len(data) {
+			return nil, fmt.Errorf("truncated modtime at entry %d", i)
+		}
+		modTime := int64(binary.BigEndian.Uint64(data[off : off+8]))
+		off += 8
+
 		// 🛡️ Sentinel: Sanitize decoded metadata to prevent path traversal and resource exhaustion from malicious peers.
 		if common.HasPathTraversalChars(hash) {
 			return nil, fmt.Errorf("invalid hash at entry %d: %w", i, syscall.EBADMSG)
@@ -250,6 +258,7 @@ func DecodeFileMetadataList(data []byte) (result []common.FileMetadata, err erro
 			Hash:       hash,
 			Size:       fileSize,
 			RemotePath: remotePath,
+			ModTime:    modTime,
 		})
 	}
 	return files, nil

--- a/src/server/query_handler_test.go
+++ b/src/server/query_handler_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/alsotoes/momo/src/common"
+)
+
+func TestEncodeDecodeFileMetadataList_ModTime(t *testing.T) {
+	files := []common.FileMetadata{
+		{Name: "a.txt", Hash: "hash1", Size: 10, RemotePath: "", ModTime: 1700000000123456789},
+		{Name: "b.txt", Hash: "hash2", Size: 20, RemotePath: "docs", ModTime: 0},
+		{Name: "c.txt", Hash: "hash3", Size: 30, RemotePath: "deep/nested", ModTime: 1700000000987654321},
+	}
+
+	encoded := EncodeFileMetadataList(files)
+	decoded, err := DecodeFileMetadataList(encoded)
+	if err != nil {
+		t.Fatalf("DecodeFileMetadataList failed: %v", err)
+	}
+	if len(decoded) != len(files) {
+		t.Fatalf("Expected %d entries, got %d", len(files), len(decoded))
+	}
+	for i := range files {
+		if decoded[i] != files[i] {
+			t.Errorf("Entry %d mismatch:\n got  %+v\n want %+v", i, decoded[i], files[i])
+		}
+	}
+}
+
+func TestDecodeFileMetadataList_RejectsOversizedCount(t *testing.T) {
+	// A payload claiming far more entries than its length can contain must be rejected (Rule 32).
+	bad := []byte{0, 0, 0, 200} // count=200 with no actual entries
+	if _, err := DecodeFileMetadataList(bad); err == nil {
+		t.Fatal("Expected error for oversized count, got nil")
+	}
+}

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -231,6 +231,9 @@ func (s *CASStore) ApplyTombstone(name string, deletedAt int64) (err error) {
 		if err := paths.Delete([]byte(name)); err != nil {
 			return fmt.Errorf("paths delete error: %w", err)
 		}
+		if err := tx.Bucket(bucketModTimes).Delete([]byte(name)); err != nil {
+			return fmt.Errorf("modtime delete error: %w", err)
+		}
 		return nil
 	})
 	if err != nil {

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -22,6 +22,7 @@ var (
 	bucketNamespace  = []byte("namespace")  // Maps FileName -> ContentHash
 	bucketPaths      = []byte("paths")      // Maps FileName -> RemotePath
 	bucketTombstones = []byte("tombstones") // Maps FileName -> deletion timestamp (unix nano)
+	bucketModTimes   = []byte("modtimes")   // Maps FileName -> modification timestamp (unix nano)
 )
 
 // ObjectMeta is the binary metadata stored in the objects bucket.
@@ -115,6 +116,9 @@ func newCASStore(dataDir string, blobs BlobStore) (*CASStore, error) {
 			return err
 		}
 		if _, err := tx.CreateBucketIfNotExists(bucketPaths); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists(bucketModTimes); err != nil {
 			return err
 		}
 		_, err = tx.CreateBucketIfNotExists(bucketTombstones)
@@ -212,6 +216,13 @@ func (s *CASStore) Put(name string, hash string, size int64, remotePath string, 
 			return fmt.Errorf("tombstone delete error: %w", err)
 		}
 
+		// Record modification time as Unix nanoseconds.
+		var mtBuf [8]byte
+		binary.BigEndian.PutUint64(mtBuf[:], uint64(time.Now().UnixNano()))
+		if err := tx.Bucket(bucketModTimes).Put([]byte(name), mtBuf[:]); err != nil {
+			return fmt.Errorf("metadata error: %w", syscall.EIO)
+		}
+
 		// Store RemotePath
 		if len(name) > common.FileInfoLength {
 			return fmt.Errorf("name exceeds maximum length: %w", syscall.ENAMETOOLONG)
@@ -304,7 +315,19 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 		return nil, common.FileMetadata{}, fmt.Errorf("failed to read remotePath: %w", err)
 	}
 
-	return f, common.FileMetadata{Name: name, Hash: hash, Size: size, RemotePath: remotePath}, nil
+	var modTime int64
+	err = s.db.View(func(tx *bbolt.Tx) error {
+		mt := tx.Bucket(bucketModTimes).Get([]byte(name))
+		if len(mt) >= 8 {
+			modTime = int64(binary.BigEndian.Uint64(mt[:8]))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, common.FileMetadata{}, fmt.Errorf("failed to read modtime: %w", err)
+	}
+
+	return f, common.FileMetadata{Name: name, Hash: hash, Size: size, RemotePath: remotePath, ModTime: modTime}, nil
 }
 
 // Has checks if a content hash exists in the store.
@@ -416,6 +439,9 @@ func (s *CASStore) Delete(name string) (err error) {
 		if err := paths.Delete([]byte(name)); err != nil {
 			return fmt.Errorf("paths delete error: %w", err)
 		}
+		if err := tx.Bucket(bucketModTimes).Delete([]byte(name)); err != nil {
+			return fmt.Errorf("modtime delete error: %w", err)
+		}
 		return nil
 	})
 	if err != nil {
@@ -460,6 +486,7 @@ func (s *CASStore) List() (list []common.FileMetadata, err error) {
 		}
 		obj := tx.Bucket(bucketObjects)
 		paths := tx.Bucket(bucketPaths)
+		mtimes := tx.Bucket(bucketModTimes)
 		ts := tx.Bucket(bucketTombstones)
 
 		c := ns.Cursor()
@@ -474,6 +501,7 @@ func (s *CASStore) List() (list []common.FileMetadata, err error) {
 
 			var size int64 = 0
 			var remotePath string = ""
+			var modTime int64 = 0
 
 			if obj != nil {
 				sizeBytes := obj.Get(v)
@@ -489,11 +517,19 @@ func (s *CASStore) List() (list []common.FileMetadata, err error) {
 				}
 			}
 
+			if mtimes != nil {
+				mtBytes := mtimes.Get(k)
+				if len(mtBytes) >= 8 {
+					modTime = int64(binary.BigEndian.Uint64(mtBytes[:8]))
+				}
+			}
+
 			list = append(list, common.FileMetadata{
 				Name:       name,
 				Hash:       hash,
 				Size:       size,
 				RemotePath: remotePath,
+				ModTime:    modTime,
 			})
 		}
 		return nil

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	"go.uber.org/goleak"
@@ -260,6 +261,9 @@ func TestCASStore_List(t *testing.T) {
 	found := make(map[string]bool)
 	for _, f := range list {
 		found[f.Name] = true
+		if f.ModTime <= 0 {
+			t.Errorf("Expected positive ModTime for %s, got %d", f.Name, f.ModTime)
+		}
 		// Verify properties
 		switch f.Name {
 		case "file1.txt":
@@ -281,6 +285,56 @@ func TestCASStore_List(t *testing.T) {
 
 	if len(found) != 3 {
 		t.Errorf("Not all files were found in list: %+v", found)
+	}
+}
+
+func TestCASStore_ModTime(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-storage-modtime-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("modtime content")
+	hash := "dummyhash123"
+	name := "modtime.txt"
+
+	if err := store.Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	// Get should report the recorded ModTime.
+	before := time.Now().Add(-5 * time.Second).UnixNano()
+	_, meta, err := store.Get(name)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if meta.ModTime <= 0 {
+		t.Errorf("Expected recorded ModTime, got %d", meta.ModTime)
+	}
+	if meta.ModTime < before || meta.ModTime > time.Now().Add(5*time.Second).UnixNano() {
+		t.Errorf("ModTime %d outside expected window", meta.ModTime)
+	}
+
+	// Delete should remove the ModTime record.
+	if err := store.Delete(name); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	for _, f := range list {
+		if f.Name == name {
+			t.Errorf("Expected %s to be removed after delete", name)
+		}
 	}
 }
 

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -841,6 +841,13 @@ func extractS3BucketAndKey(req *http.Request) (bucket string, key string) {
 	return bucket, key
 }
 
+// formatLastModified renders a Unix-nano modification time in the
+// S3 XML LastModified format (UTC with millisecond precision).
+// A zero timestamp (unknown/modern fallback) renders as the Unix epoch.
+func formatLastModified(modTime int64) string {
+	return time.Unix(0, modTime).UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
 // FormatListObjectsV2XML constructs an S3-compliant ListObjectsV2 XML response
 // using a pre-allocated bytes.Buffer to avoid excessive heap allocations (⚡ Bolt pattern).
 func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, files []common.FileMetadata) (xmlBytes []byte, err error) {
@@ -918,7 +925,9 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 		buf.WriteString(`<Key>`)
 		xmlEscape(&buf, key)
 		buf.WriteString(`</Key>`)
-		buf.WriteString(`<LastModified>2026-06-29T12:00:00.000Z</LastModified>`)
+		buf.WriteString(`<LastModified>`)
+		buf.WriteString(formatLastModified(file.ModTime))
+		buf.WriteString(`</LastModified>`)
 		buf.WriteString(`<ETag>"`)
 		xmlEscape(&buf, file.Hash)
 		buf.WriteString(`"</ETag>`)

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -512,8 +512,8 @@ func TestS3Communicator_KeyTraversalValidation(t *testing.T) {
 
 func TestS3Communicator_XMLFormatting(t *testing.T) {
 	files := []common.FileMetadata{
-		{Name: "file1.txt", Hash: "hash1", Size: 100, RemotePath: ""},
-		{Name: "docs/file2.txt", Hash: "hash2", Size: 200, RemotePath: "docs"},
+		{Name: "file1.txt", Hash: "hash1", Size: 100, RemotePath: "", ModTime: 1700000000123000000},
+		{Name: "docs/file2.txt", Hash: "hash2", Size: 200, RemotePath: "docs", ModTime: 1700000000456000000},
 		{Name: "docs/nested/file3.txt", Hash: "hash3", Size: 300, RemotePath: "docs/nested"},
 		{Name: "oversized-filename-exceeding-sixty-four-characters-limit-should-be-skipped-entirely.txt", Hash: "hash4", Size: 400},
 		{Name: "valid.txt", Hash: "oversized-hash-exceeding-sixty-four-characters-limit-should-be-skipped-entirely", Size: 500},
@@ -546,6 +546,14 @@ func TestS3Communicator_XMLFormatting(t *testing.T) {
 	}
 	if strings.Contains(xmlStr, "oversized-hash-exceeding") {
 		t.Errorf("Did not expect oversized hash in XML")
+	}
+
+	// 1b. LastModified must reflect the actual ModTime, not a hardcoded value.
+	if !strings.Contains(xmlStr, "<LastModified>2023-11-14T22:13:20.123Z</LastModified>") {
+		t.Errorf("Expected LastModified derived from ModTime, got: %s", xmlStr)
+	}
+	if strings.Contains(xmlStr, "2026-06-29T12:00:00.000Z") {
+		t.Errorf("Hardcoded LastModified timestamp leaked into XML")
 	}
 
 	// 2. Prefix and delimiter grouping


### PR DESCRIPTION
## Summary

Fixes #618: the `ListObjectsV2` XML response hardcoded the same `<LastModified>2026-06-29T12:00:00.000Z</LastModified>` for every listed file, breaking S3 clients that rely on `LastModified` for caching/sync/incremental downloads.

### Change

- **`common.FileMetadata`**: added `ModTime int64` (Unix nanoseconds; `0` = unknown).
- **`CASStore`**: new `modtimes` bbolt bucket records the modification time at `Put`, clears it on `Delete`/`ApplyTombstone`, and `Get`/`List` now populate `ModTime`.
- **Wire format** (`EncodeFileMetadataList`/`DecodeFileMetadataList`): each entry now carries an 8-byte big-endian `ModTime` appended after the path. Decoder bounds updated (entry minimum grows 20→28 bytes); truncation + oversized-count checks preserved.
- **`FormatListObjectsV2XML`**: renders `LastModified` from `file.ModTime` via `formatLastModified` (UTC, millisecond precision). A zero timestamp renders as the Unix epoch instead of a bogus fixed 2026 date.

### Tests

- `TestCASStore_ModTime`: `Get` returns the recorded `ModTime` in a sane window; `Delete` removes it from listings.
- `TestCASStore_List`: asserts every listed file has a positive `ModTime`.
- `TestEncodeDecodeFileMetadataList_ModTime`: full wire round-trip preserves `ModTime` (incl. `0`).
- `TestDecodeFileMetadataList_RejectsOversizedCount`: oversized-count guard still fires.
- `TestS3Communicator_XMLFormatting`: asserts `LastModified` is derived from `ModTime` and the hardcoded 2026 string is gone.

### Verification

- `go build ./...`, `go vet`, `go test -race` all green across common/storage/server/transport/client.

Resolves https://github.com/alsotoes/momo/issues/618