### PR TITLE
fix: S3 ListObjectsV2 KeyCount excludes CommonPrefixes (#619)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2880,3 +2880,12 @@ efd8101,BenchmarkSanitizeLog/Unsafe-8,883.00,704.00,1.00
 37c23c2,BenchmarkPadString-8,46.58,64.00,1.00
 37c23c2,BenchmarkSanitizeLog/Safe-8,265.70,0.00,0.00
 37c23c2,BenchmarkSanitizeLog/Unsafe-8,714.40,704.00,1.00
+1b241ec,BenchmarkCheckMetricsAndSwap-8,7.35,0.00,0.00
+1b241ec,BenchmarkCrushOptimized-8,305.40,0.00,0.00
+1b241ec,BenchmarkCrushOriginal-8,408.80,164.00,3.00
+1b241ec,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+1b241ec,BenchmarkIndexSearch-8,1.57,0.00,0.00
+1b241ec,BenchmarkLoadGlobalConfig-8,5825.00,1320.00,38.00
+1b241ec,BenchmarkPadString-8,38.56,64.00,1.00
+1b241ec,BenchmarkSanitizeLog/Safe-8,229.20,0.00,0.00
+1b241ec,BenchmarkSanitizeLog/Unsafe-8,666.90,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2889,3 +2889,12 @@ efd8101,BenchmarkSanitizeLog/Unsafe-8,883.00,704.00,1.00
 1b241ec,BenchmarkPadString-8,38.56,64.00,1.00
 1b241ec,BenchmarkSanitizeLog/Safe-8,229.20,0.00,0.00
 1b241ec,BenchmarkSanitizeLog/Unsafe-8,666.90,704.00,1.00
+1ddb702,BenchmarkCheckMetricsAndSwap-8,7.10,0.00,0.00
+1ddb702,BenchmarkCrushOptimized-8,338.40,0.00,0.00
+1ddb702,BenchmarkCrushOriginal-8,387.00,164.00,3.00
+1ddb702,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+1ddb702,BenchmarkIndexSearch-8,1.47,0.00,0.00
+1ddb702,BenchmarkLoadGlobalConfig-8,5598.00,1320.00,38.00
+1ddb702,BenchmarkPadString-8,35.80,64.00,1.00
+1ddb702,BenchmarkSanitizeLog/Safe-8,212.10,0.00,0.00
+1ddb702,BenchmarkSanitizeLog/Unsafe-8,636.20,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        408.8n ± ∞ ¹    408.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       305.4n ± ∞ ¹    305.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.825µ ± ∞ ¹    5.825µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            38.56n ± ∞ ¹    38.56n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     229.2n ± ∞ ¹    229.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   666.9n ± ∞ ¹    666.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.354n ± ∞ ¹    7.354n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.571n ± ∞ ¹    1.571n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3647n ± ∞ ¹   0.3647n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                64.02n          64.02n        +0.00%
+CrushOriginal-8                        408.8n ± ∞ ¹    387.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       305.4n ± ∞ ¹    338.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.825µ ± ∞ ¹    5.598µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            38.56n ± ∞ ¹    35.80n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     229.2n ± ∞ ¹    212.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   666.9n ± ∞ ¹    636.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.354n ± ∞ ¹    7.098n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.571n ± ∞ ¹    1.472n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3647n ± ∞ ¹   0.3512n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                64.02n          61.72n        -3.59%
 ¹ need >= 6 samples for confidence interval at level 0.95
-² all samples are equal
+² need >= 4 samples to detect a difference at alpha level 0.05
 
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │            B/op             │     B/op       vs base                │
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 305.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 408.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.57 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5825.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 38.56 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 229.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 666.90 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 338.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 387.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5598.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 35.80 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 212.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 636.20 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec]
-    line "CheckMetricsAndSwap" [9,10,9,8,11,12,11,8,7,7]
-    line "CrushOptimized" [372,323,332,396,452,428,468,378,356,305]
-    line "CrushOriginal" [550,499,539,566,637,571,542,558,469,409]
-    line "IndexDirectTracking" [0,0,0,0,0,1,1,0,0,0]
-    line "IndexSearch" [3,4,3,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [7459,7314,7292,7939,9559,7558,8021,8176,6507,5825]
-    line "PadString" [51,51,49,57,70,53,52,53,47,39]
+    x-axis [d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702]
+    line "CheckMetricsAndSwap" [10,9,8,11,12,11,8,7,7,7]
+    line "CrushOptimized" [323,332,396,452,428,468,378,356,305,338]
+    line "CrushOriginal" [499,539,566,637,571,542,558,469,409,387]
+    line "IndexDirectTracking" [0,0,0,0,1,1,0,0,0,0]
+    line "IndexSearch" [4,3,2,2,2,2,2,2,2,1]
+    line "LoadGlobalConfig" [7314,7292,7939,9559,7558,8021,8176,6507,5825,5598]
+    line "PadString" [51,49,57,70,53,52,53,47,39,36]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [640,566,529,226,474,303,288,316,266,229]
-    line "SanitizeLog/Unsafe" [1023,951,1050,761,960,883,849,775,714,667]
+    line "SanitizeLog/Safe" [566,529,226,474,303,288,316,266,229,212]
+    line "SanitizeLog/Unsafe" [951,1050,761,960,883,849,775,714,667,636]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec]
+    x-axis [d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec]
+    x-axis [d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        558.4n ± ∞ ¹    468.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       378.0n ± ∞ ¹    355.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.176µ ± ∞ ¹    6.507µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            52.88n ± ∞ ¹    46.58n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     316.5n ± ∞ ¹    265.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   775.3n ± ∞ ¹    714.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.393n ± ∞ ¹    7.443n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.747n ± ∞ ¹    1.614n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3526n ± ∞ ¹   0.3700n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                78.70n          70.43n        -10.50%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        408.8n ± ∞ ¹    408.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       305.4n ± ∞ ¹    305.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.825µ ± ∞ ¹    5.825µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            38.56n ± ∞ ¹    38.56n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     229.2n ± ∞ ¹    229.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   666.9n ± ∞ ¹    666.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.354n ± ∞ ¹    7.354n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.571n ± ∞ ¹    1.571n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3647n ± ∞ ¹   0.3647n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                64.02n          64.02n        +0.00%
 ¹ need >= 6 samples for confidence interval at level 0.95
-² need >= 4 samples to detect a difference at alpha level 0.05
+² all samples are equal
 
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │            B/op             │     B/op       vs base                │
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 355.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 468.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6507.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 46.58 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 265.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 714.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 305.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 408.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.57 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5825.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 38.56 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 229.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 666.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2]
-    line "CheckMetricsAndSwap" [10,9,10,9,8,11,12,11,8,7]
-    line "CrushOptimized" [370,372,323,332,396,452,428,468,378,356]
-    line "CrushOriginal" [495,550,499,539,566,637,571,542,558,469]
-    line "IndexDirectTracking" [0,0,0,0,0,0,1,1,0,0]
-    line "IndexSearch" [3,3,4,3,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [7469,7459,7314,7292,7939,9559,7558,8021,8176,6507]
-    line "PadString" [49,51,51,49,57,70,53,52,53,47]
+    x-axis [60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec]
+    line "CheckMetricsAndSwap" [9,10,9,8,11,12,11,8,7,7]
+    line "CrushOptimized" [372,323,332,396,452,428,468,378,356,305]
+    line "CrushOriginal" [550,499,539,566,637,571,542,558,469,409]
+    line "IndexDirectTracking" [0,0,0,0,0,1,1,0,0,0]
+    line "IndexSearch" [3,4,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [7459,7314,7292,7939,9559,7558,8021,8176,6507,5825]
+    line "PadString" [51,51,49,57,70,53,52,53,47,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [615,640,566,529,226,474,303,288,316,266]
-    line "SanitizeLog/Unsafe" [1010,1023,951,1050,761,960,883,849,775,714]
+    line "SanitizeLog/Safe" [640,566,529,226,474,303,288,316,266,229]
+    line "SanitizeLog/Unsafe" [1023,951,1050,761,960,883,849,775,714,667]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2]
+    x-axis [60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [8743c29,60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2]
+    x-axis [60e554e,d70a84a,c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -945,7 +945,6 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 		xmlEscape(&buf, cp)
 		buf.WriteString(`</Prefix>`)
 		buf.WriteString(`</CommonPrefixes>`)
-		keyCount++
 	}
 
 	buf.WriteString(`<IsTruncated>`)

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -507,6 +509,43 @@ func TestS3Communicator_KeyTraversalValidation(t *testing.T) {
 				t.Errorf("Expected error to wrap syscall.EBADMSG, got %v", err)
 			}
 		})
+	}
+}
+
+func TestS3Communicator_ListObjectsV2KeyCount(t *testing.T) {
+	files := []common.FileMetadata{
+		{Name: "file1.txt", Hash: "hash1", Size: 100},
+		{Name: "docs/file2.txt", Hash: "hash2", Size: 200},
+		{Name: "docs/nested/file3.txt", Hash: "hash3", Size: 300},
+		{Name: "src/file4.go", Hash: "hash4", Size: 400},
+	}
+
+	xmlBytes, err := FormatListObjectsV2XML("mybucket", "", "/", 1000, files)
+	if err != nil {
+		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
+	}
+	xmlStr := string(xmlBytes)
+
+	contentsCount := strings.Count(xmlStr, "<Contents>")
+	prefixesCount := strings.Count(xmlStr, "<CommonPrefixes>")
+	if contentsCount != 1 {
+		t.Fatalf("Expected 1 Contents entry, got %d", contentsCount)
+	}
+	if prefixesCount != 2 {
+		t.Fatalf("Expected 2 CommonPrefixes (docs/, src/), got %d", prefixesCount)
+	}
+
+	re := regexp.MustCompile(`<KeyCount>(\d+)</KeyCount>`)
+	m := re.FindStringSubmatch(xmlStr)
+	if m == nil {
+		t.Fatalf("KeyCount element not found in XML")
+	}
+	keyCount, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("KeyCount not an integer: %v", err)
+	}
+	if keyCount != contentsCount {
+		t.Errorf("KeyCount (%d) must equal number of Contents entries (%d), excluding CommonPrefixes", keyCount, contentsCount)
 	}
 }
 

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -572,6 +572,9 @@ func TestS3Communicator_XMLFormatting(t *testing.T) {
 	if !strings.Contains(xmlStrDelim, "<Prefix>docs/</Prefix>") {
 		t.Errorf("Expected docs/ as CommonPrefix")
 	}
+	if !strings.Contains(xmlStrDelim, "<KeyCount>1</KeyCount>") {
+		t.Errorf("Expected KeyCount to exclude CommonPrefixes (got XML: %s)", xmlStrDelim)
+	}
 
 	// 3. Reject input exceeding 64 bytes (Rule 35)
 	_, err = FormatListObjectsV2XML("my-very-long-bucket-name-that-exceeds-sixty-four-characters-limit-completely", "", "", 1000, files)


### PR DESCRIPTION
Resolves #619

## Summary
Fix S3 ListObjectsV2 `KeyCount` to count only keys in `Contents`, excluding `CommonPrefixes` per the S3 specification.

## Change
- `src/transport/s3_communicator.go`: removed the `keyCount++` inside the `commonPrefixes` emission loop, so `KeyCount` reflects only entries in `Contents`.

## Test
- Added assertion in `TestS3Communicator_ListObjectsV2` verifying `KeyCount` excludes the `docs/` CommonPrefix when using a delimiter.
- `go build ./...`, `go vet`, `go test ./src/transport/` all pass.

## Changelog
- **1ddb702**: Remove CommonPrefixes from KeyCount count

- **Reviewer feedback (Rule 53)**: Confirmed all 3 findings already satisfied — KeyCount now strictly counts Contents; `defer recover()` (Rule 37) and 64-byte validation (Rule 35) pre-exist on master.


- **c48d598**: Add `TestS3Communicator_ListObjectsV2KeyCount` regression test (KeyCount == Contents count, excludes CommonPrefixes)

