### PR TITLE
fix: add read deadlines before S3 http.ReadResponse to prevent hangs (#620)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2907,3 +2907,12 @@ a8e6bbc,BenchmarkLoadGlobalConfig-8,5683.00,1320.00,38.00
 a8e6bbc,BenchmarkPadString-8,39.38,64.00,1.00
 a8e6bbc,BenchmarkSanitizeLog/Safe-8,222.10,0.00,0.00
 a8e6bbc,BenchmarkSanitizeLog/Unsafe-8,710.10,704.00,1.00
+bd016ee,BenchmarkCheckMetricsAndSwap-8,7.61,0.00,0.00
+bd016ee,BenchmarkCrushOptimized-8,289.00,0.00,0.00
+bd016ee,BenchmarkCrushOriginal-8,396.30,164.00,3.00
+bd016ee,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+bd016ee,BenchmarkIndexSearch-8,1.67,0.00,0.00
+bd016ee,BenchmarkLoadGlobalConfig-8,5474.00,1320.00,38.00
+bd016ee,BenchmarkPadString-8,36.06,64.00,1.00
+bd016ee,BenchmarkSanitizeLog/Safe-8,244.90,0.00,0.00
+bd016ee,BenchmarkSanitizeLog/Unsafe-8,639.90,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        387.0n ± ∞ ¹    442.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       338.4n ± ∞ ¹    300.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.598µ ± ∞ ¹    5.683µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            35.80n ± ∞ ¹    39.38n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     212.1n ± ∞ ¹    222.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   636.2n ± ∞ ¹    710.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.098n ± ∞ ¹    8.605n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.472n ± ∞ ¹    1.561n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3512n ± ∞ ¹   0.3714n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                61.72n          65.88n        +6.75%
+CrushOriginal-8                        442.8n ± ∞ ¹    396.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       300.0n ± ∞ ¹    289.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.683µ ± ∞ ¹    5.474µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            39.38n ± ∞ ¹    36.06n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     222.1n ± ∞ ¹    244.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   710.1n ± ∞ ¹    639.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.605n ± ∞ ¹    7.612n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.561n ± ∞ ¹    1.671n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3714n ± ∞ ¹   0.3798n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                65.88n          63.64n        -3.41%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 300.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 442.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5683.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 39.38 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 222.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 710.10 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 289.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 396.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.67 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5474.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 36.06 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 244.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 639.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc]
-    line "CheckMetricsAndSwap" [9,8,11,12,11,8,7,7,7,9]
-    line "CrushOptimized" [332,396,452,428,468,378,356,305,338,300]
-    line "CrushOriginal" [539,566,637,571,542,558,469,409,387,443]
-    line "IndexDirectTracking" [0,0,0,1,1,0,0,0,0,0]
-    line "IndexSearch" [3,2,2,2,2,2,2,2,1,2]
-    line "LoadGlobalConfig" [7292,7939,9559,7558,8021,8176,6507,5825,5598,5683]
-    line "PadString" [49,57,70,53,52,53,47,39,36,39]
+    x-axis [ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee]
+    line "CheckMetricsAndSwap" [8,11,12,11,8,7,7,7,9,8]
+    line "CrushOptimized" [396,452,428,468,378,356,305,338,300,289]
+    line "CrushOriginal" [566,637,571,542,558,469,409,387,443,396]
+    line "IndexDirectTracking" [0,0,1,1,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,2,2,1,2,2]
+    line "LoadGlobalConfig" [7939,9559,7558,8021,8176,6507,5825,5598,5683,5474]
+    line "PadString" [57,70,53,52,53,47,39,36,39,36]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [529,226,474,303,288,316,266,229,212,222]
-    line "SanitizeLog/Unsafe" [1050,761,960,883,849,775,714,667,636,710]
+    line "SanitizeLog/Safe" [226,474,303,288,316,266,229,212,222,245]
+    line "SanitizeLog/Unsafe" [761,960,883,849,775,714,667,636,710,640]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc]
+    x-axis [ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c379fe8,ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc]
+    x-axis [ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -223,7 +223,11 @@ func (m *S3Communicator) HandshakeClient(authToken string, timestamp int64, requ
 		return 0, fmt.Errorf("failed to write handshake request: %v: %w", err, syscall.EPIPE)
 	}
 
+	// 🛡️ Zero-Crash: Set a read deadline before reading the handshake response to
+	// prevent the client from blocking indefinitely on an unresponsive server (issue #620).
+	m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout))
 	resp, err := http.ReadResponse(m.reader, nil)
+	m.conn.SetReadDeadline(time.Time{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to read handshake response: %v: %w", err, syscall.EBADMSG)
 	}
@@ -637,7 +641,11 @@ func (m *S3Communicator) SendMetadata(meta *common.FileMetadata) (status int, er
 	}
 
 	// ⚡ Bolt: Read the response immediately to get the metadata status.
+	// 🛡️ Zero-Crash: Set a read deadline to prevent the client from blocking
+	// indefinitely on an unresponsive server (issue #620).
+	m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout))
 	resp, err := http.ReadResponse(m.reader, nil)
+	m.conn.SetReadDeadline(time.Time{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to read metadata status response: %v: %w", err, syscall.EBADMSG)
 	}
@@ -772,7 +780,11 @@ func (m *S3Communicator) ReceiveACK() (err error) {
 			err = fmt.Errorf("internal S3 protocol panic: %w", syscall.EIO)
 		}
 	}()
+	// 🛡️ Zero-Crash: Set a read deadline before reading the ACK response to
+	// prevent the client from blocking indefinitely on an unresponsive server (issue #620).
+	m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout))
 	resp, err := http.ReadResponse(m.reader, nil)
+	m.conn.SetReadDeadline(time.Time{})
 	if err != nil {
 		return fmt.Errorf("failed to read ACK response: %v: %w", err, syscall.EBADMSG)
 	}

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -727,6 +727,99 @@ func TestS3Communicator_HandshakeClient_CRLFInjection(t *testing.T) {
 	}
 }
 
+func TestS3Communicator_HandshakeClient_ReadDeadline(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	origTimeout := s3ReadHeaderTimeout
+	s3ReadHeaderTimeout = 50 * time.Millisecond
+	defer func() { s3ReadHeaderTimeout = origTimeout }()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// The peer accepts the handshake request but never writes a response,
+	// simulating a malicious/unresponsive server (issue #620).
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			if _, err := clientConn.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	comm := NewS3Communicator(serverConn)
+	start := time.Now()
+	_, err := comm.HandshakeClient("valid-token", 12345, 1)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected HandshakeClient to fail on unresponsive server, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("HandshakeClient blocked for %v instead of honoring read deadline", elapsed)
+	}
+}
+
+func TestS3Communicator_SendMetadata_ReadDeadline(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	origTimeout := s3ReadHeaderTimeout
+	s3ReadHeaderTimeout = 50 * time.Millisecond
+	defer func() { s3ReadHeaderTimeout = origTimeout }()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			if _, err := clientConn.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	comm := NewS3Communicator(serverConn)
+	meta := &common.FileMetadata{Name: "test-file.txt", Hash: "hash1", Size: 100}
+	start := time.Now()
+	_, err := comm.SendMetadata(meta)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected SendMetadata to fail on unresponsive server, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("SendMetadata blocked for %v instead of honoring read deadline", elapsed)
+	}
+}
+
+func TestS3Communicator_ReceiveACK_ReadDeadline(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	origTimeout := s3ReadHeaderTimeout
+	s3ReadHeaderTimeout = 50 * time.Millisecond
+	defer func() { s3ReadHeaderTimeout = origTimeout }()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	comm := NewS3Communicator(serverConn)
+	start := time.Now()
+	err := comm.ReceiveACK()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected ReceiveACK to fail on unresponsive server, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("ReceiveACK blocked for %v instead of honoring read deadline", elapsed)
+	}
+}
+
 func TestS3Communicator_SendMetadataPathTraversal(t *testing.T) {
 	defer verifyNoLeaks(t)
 


### PR DESCRIPTION
Resolves #620

## Summary
Prevent the S3 client from blocking indefinitely when a malicious or unresponsive server fails to respond. `HandshakeClient`, `SendMetadata`, and `ReceiveACK` now set a read deadline (`s3ReadHeaderTimeout`, 10s) before each `http.ReadResponse` call, matching the existing slowloris-mitigation pattern already used for `http.ReadRequest` (lines 255, 669).

## Change
- `src/transport/s3_communicator.go`:
  - `HandshakeClient`: set `SetReadDeadline` before reading handshake response, clear after.
  - `SendMetadata`: set `SetReadDeadline` before reading metadata status response, clear after.
  - `ReceiveACK`: set `SetReadDeadline` before reading ACK response, clear after.

## Test
- Added 3 regression tests (`TestS3Communicator_HandshakeClient_ReadDeadline`, `TestS3Communicator_SendMetadata_ReadDeadline`, `TestS3Communicator_ReceiveACK_ReadDeadline`) that run against an unresponsive peer and assert the call returns (with error) within 5s instead of blocking.
- `go build ./...`, `go vet ./src/transport/`, `go test ./src/transport/` (incl. `-race`) all pass.

## Changelog
- **f38bc16**: Add read deadlines before S3 http.ReadResponse calls

## Reviewer Status
- Awaiting Gemini review.
