### PR TITLE
fix(transport): use fixed-length 4-byte ACK to drop fragile 5ms deadline

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2916,3 +2916,12 @@ bd016ee,BenchmarkLoadGlobalConfig-8,5474.00,1320.00,38.00
 bd016ee,BenchmarkPadString-8,36.06,64.00,1.00
 bd016ee,BenchmarkSanitizeLog/Safe-8,244.90,0.00,0.00
 bd016ee,BenchmarkSanitizeLog/Unsafe-8,639.90,704.00,1.00
+6e7bf28,BenchmarkCheckMetricsAndSwap-8,7.79,0.00,0.00
+6e7bf28,BenchmarkCrushOptimized-8,304.20,0.00,0.00
+6e7bf28,BenchmarkCrushOriginal-8,419.30,164.00,3.00
+6e7bf28,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+6e7bf28,BenchmarkIndexSearch-8,1.83,0.00,0.00
+6e7bf28,BenchmarkLoadGlobalConfig-8,6080.00,1320.00,38.00
+6e7bf28,BenchmarkPadString-8,38.81,64.00,1.00
+6e7bf28,BenchmarkSanitizeLog/Safe-8,238.40,0.00,0.00
+6e7bf28,BenchmarkSanitizeLog/Unsafe-8,671.20,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2925,3 +2925,12 @@ bd016ee,BenchmarkSanitizeLog/Unsafe-8,639.90,704.00,1.00
 6e7bf28,BenchmarkPadString-8,38.81,64.00,1.00
 6e7bf28,BenchmarkSanitizeLog/Safe-8,238.40,0.00,0.00
 6e7bf28,BenchmarkSanitizeLog/Unsafe-8,671.20,704.00,1.00
+8b3edae,BenchmarkCheckMetricsAndSwap-8,8.41,0.00,0.00
+8b3edae,BenchmarkCrushOptimized-8,293.20,0.00,0.00
+8b3edae,BenchmarkCrushOriginal-8,409.00,164.00,3.00
+8b3edae,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+8b3edae,BenchmarkIndexSearch-8,1.87,0.00,0.00
+8b3edae,BenchmarkLoadGlobalConfig-8,5863.00,1320.00,38.00
+8b3edae,BenchmarkPadString-8,39.41,64.00,1.00
+8b3edae,BenchmarkSanitizeLog/Safe-8,230.90,0.00,0.00
+8b3edae,BenchmarkSanitizeLog/Unsafe-8,674.70,704.00,1.00

--- a/docs/CONTRACT_TESTING.md
+++ b/docs/CONTRACT_TESTING.md
@@ -35,9 +35,9 @@ The Momo wire protocol has fixed-size fields that **must not change** without a 
 - `1` = `MetadataStatusSendPayload` — client should send file payload
 - `2` = `MetadataStatusSkipPayload` — server has content (CAS deduplication hit)
 
-### ACK (3+ bytes, variable)
+### ACK (4 bytes, fixed-length)
 
-- `"ACK" + serverId digits` (e.g., `"ACK0"`, `"ACK1"`) — server acknowledgment after successful file transfer
+- `"ACK" + serverId byte` (raw byte value, not ASCII digits; e.g. `ACK\x00` for server 0) — server acknowledgment after successful file transfer. Fixed-length framing prevents leftover bytes from corrupting the next protocol message (issue #621).
 
 ### P2P RPC Framing (4-byte length prefix + body)
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        442.8n ± ∞ ¹    396.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       300.0n ± ∞ ¹    289.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.683µ ± ∞ ¹    5.474µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            39.38n ± ∞ ¹    36.06n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     222.1n ± ∞ ¹    244.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   710.1n ± ∞ ¹    639.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.605n ± ∞ ¹    7.612n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.561n ± ∞ ¹    1.671n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3714n ± ∞ ¹   0.3798n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                65.88n          63.64n        -3.41%
+CrushOriginal-8                        396.3n ± ∞ ¹    419.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       289.0n ± ∞ ¹    304.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.474µ ± ∞ ¹    6.080µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            36.06n ± ∞ ¹    38.81n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     244.9n ± ∞ ¹    238.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   639.9n ± ∞ ¹    671.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.612n ± ∞ ¹    7.793n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.671n ± ∞ ¹    1.831n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3798n ± ∞ ¹   0.3385n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                63.64n          65.84n        +3.47%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 289.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 396.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.67 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5474.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 36.06 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 244.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 639.90 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.79 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 304.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 419.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.83 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 6080.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 38.81 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 238.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 671.20 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee]
-    line "CheckMetricsAndSwap" [8,11,12,11,8,7,7,7,9,8]
-    line "CrushOptimized" [396,452,428,468,378,356,305,338,300,289]
-    line "CrushOriginal" [566,637,571,542,558,469,409,387,443,396]
-    line "IndexDirectTracking" [0,0,1,1,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,1,2,2]
-    line "LoadGlobalConfig" [7939,9559,7558,8021,8176,6507,5825,5598,5683,5474]
-    line "PadString" [57,70,53,52,53,47,39,36,39,36]
+    x-axis [d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28]
+    line "CheckMetricsAndSwap" [11,12,11,8,7,7,7,9,8,8]
+    line "CrushOptimized" [452,428,468,378,356,305,338,300,289,304]
+    line "CrushOriginal" [637,571,542,558,469,409,387,443,396,419]
+    line "IndexDirectTracking" [0,1,1,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,2,1,2,2,2]
+    line "LoadGlobalConfig" [9559,7558,8021,8176,6507,5825,5598,5683,5474,6080]
+    line "PadString" [70,53,52,53,47,39,36,39,36,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [226,474,303,288,316,266,229,212,222,245]
-    line "SanitizeLog/Unsafe" [761,960,883,849,775,714,667,636,710,640]
+    line "SanitizeLog/Safe" [474,303,288,316,266,229,212,222,245,238]
+    line "SanitizeLog/Unsafe" [960,883,849,775,714,667,636,710,640,671]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee]
+    x-axis [d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ac0a8cf,d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee]
+    x-axis [d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        396.3n ± ∞ ¹    419.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       289.0n ± ∞ ¹    304.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.474µ ± ∞ ¹    6.080µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            36.06n ± ∞ ¹    38.81n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     244.9n ± ∞ ¹    238.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   639.9n ± ∞ ¹    671.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.612n ± ∞ ¹    7.793n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.671n ± ∞ ¹    1.831n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3798n ± ∞ ¹   0.3385n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                63.64n          65.84n        +3.47%
+CrushOriginal-8                        419.3n ± ∞ ¹    409.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       304.2n ± ∞ ¹    293.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     6.080µ ± ∞ ¹    5.863µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            38.81n ± ∞ ¹    39.41n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     238.4n ± ∞ ¹    230.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   671.2n ± ∞ ¹    674.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  7.793n ± ∞ ¹    8.414n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.831n ± ∞ ¹    1.868n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3385n ± ∞ ¹   0.3449n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                65.84n          65.89n        +0.07%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 7.79 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 304.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 419.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 293.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 409.00 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.83 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 6080.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 38.81 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 238.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 671.20 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5863.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 39.41 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 230.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 674.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28]
-    line "CheckMetricsAndSwap" [11,12,11,8,7,7,7,9,8,8]
-    line "CrushOptimized" [452,428,468,378,356,305,338,300,289,304]
-    line "CrushOriginal" [637,571,542,558,469,409,387,443,396,419]
-    line "IndexDirectTracking" [0,1,1,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,1,2,2,2]
-    line "LoadGlobalConfig" [9559,7558,8021,8176,6507,5825,5598,5683,5474,6080]
-    line "PadString" [70,53,52,53,47,39,36,39,36,39]
+    x-axis [efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae]
+    line "CheckMetricsAndSwap" [12,11,8,7,7,7,9,8,8,8]
+    line "CrushOptimized" [428,468,378,356,305,338,300,289,304,293]
+    line "CrushOriginal" [571,542,558,469,409,387,443,396,419,409]
+    line "IndexDirectTracking" [1,1,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,1,2,2,2,2]
+    line "LoadGlobalConfig" [7558,8021,8176,6507,5825,5598,5683,5474,6080,5863]
+    line "PadString" [53,52,53,47,39,36,39,36,39,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [474,303,288,316,266,229,212,222,245,238]
-    line "SanitizeLog/Unsafe" [960,883,849,775,714,667,636,710,640,671]
+    line "SanitizeLog/Safe" [303,288,316,266,229,212,222,245,238,231]
+    line "SanitizeLog/Unsafe" [883,849,775,714,667,636,710,640,671,675]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28]
+    x-axis [efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [d94dad2,efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28]
+    x-axis [efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -602,7 +602,7 @@ Wire protocol byte-level assertions that prevent accidental protocol breaking ch
 | `contractHandshakeLen` | 84 bytes | AuthToken (64) + Timestamp (19) + Mode (1) |
 | `contractMetadataLen` | 192 bytes | Hash (64) + FileName (64) + FileSize (64) |
 | `contractStatusLen` | 1 byte | Metadata status code |
-| `contractACKLen` | 4+ bytes | Server ACK ("ACK" + serverId digits, e.g. "ACK0") |
+| `contractACKLen` | 4 bytes | Server ACK ("ACK" + 1-byte serverId, fixed-length) |
 
 #### Tests
 

--- a/src/server/contract_test.go
+++ b/src/server/contract_test.go
@@ -27,7 +27,7 @@ const (
 	contractMetadataLen = contractHashLen + contractFileNameLen + contractFileSizeLen // 192
 
 	contractStatusLen = 1
-	contractACKLen    = 4 // "ACK" + 1-digit serverId (e.g., "ACK0")
+	contractACKLen    = 4 // "ACK" + 1-byte serverId (fixed-length, issue #621)
 )
 
 func TestContract_HandshakeLayout(t *testing.T) {

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -149,9 +149,9 @@ func TestDaemonLogic(t *testing.T) {
 		expectedAck         string
 		expectedReplication int
 	}{
-		{"ReplicationNone", common.ReplicationNone, 0, "ACK0", common.ReplicationNone},
-		{"ReplicationSplay", common.ReplicationSplay, 0, "ACK0", common.ReplicationSplay},
-		{"ReplicationChain", common.ReplicationChain, 1, "ACK1", common.ReplicationChain},
+		{"ReplicationNone", common.ReplicationNone, 0, "ACK\x00", common.ReplicationNone},
+		{"ReplicationSplay", common.ReplicationSplay, 0, "ACK\x00", common.ReplicationSplay},
+		{"ReplicationChain", common.ReplicationChain, 1, "ACK\x01", common.ReplicationChain},
 	}
 
 	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -692,8 +692,20 @@ func (m *MomoQUICCommunicator) SendACK(serverId int) (err error) {
 		}
 	}()
 
-	var ackBuf [32]byte
-	if _, err := m.Write(strconv.AppendInt(append(ackBuf[:0], "ACK"...), int64(serverId), 10)); err != nil {
+	if serverId < 0 || serverId > 255 {
+		return fmt.Errorf("invalid server ID %d: %w", serverId, syscall.EBADMSG)
+	}
+
+	// Fixed-length ACK: "ACK" + 1-byte server ID (issue #621).
+	// This removes the variable-length decimal digits that required a fragile
+	// 5ms deadline on the read side and could corrupt the next protocol message
+	// when digits arrived in multiple segments.
+	var ackBuf [4]byte
+	ackBuf[0] = 'A'
+	ackBuf[1] = 'C'
+	ackBuf[2] = 'K'
+	ackBuf[3] = byte(serverId)
+	if _, err := m.Write(ackBuf[:]); err != nil {
 		return fmt.Errorf("failed to send ACK: %v: %w", err, syscall.EIO)
 	}
 	return nil
@@ -707,28 +719,15 @@ func (m *MomoQUICCommunicator) ReceiveACK() (err error) {
 		}
 	}()
 
-	var ackBuffer [3]byte
-	if _, err := io.ReadFull(io.LimitReader(m, 3), ackBuffer[:]); err != nil {
-		return fmt.Errorf("failed to read ACK prefix: %v: %w", err, syscall.EBADMSG)
+	var ackBuffer [4]byte
+	if _, err := io.ReadFull(io.LimitReader(m, 4), ackBuffer[:]); err != nil {
+		return fmt.Errorf("failed to read ACK: %v: %w", err, syscall.EBADMSG)
 	}
 
-	if !bytes.Equal(ackBuffer[:], []byte("ACK")) {
-		return fmt.Errorf("unexpected response: %s: %w", string(ackBuffer[:]), syscall.EBADMSG)
+	if !bytes.Equal(ackBuffer[:3], []byte("ACK")) {
+		return fmt.Errorf("unexpected response: %s: %w", string(ackBuffer[:3]), syscall.EBADMSG)
 	}
 
-	// ⚡ Bolt: Read any trailing server ID digits under a short deadline to prevent blocking,
-	// limited to at most 10 iterations to prevent infinite-loop CPU exhaustion (DoS).
-	m.Stream.SetDeadline(time.Now().Add(5 * time.Millisecond))
-	var oneByte [1]byte
-	for i := 0; i < 10; i++ {
-		n, _ := m.Read(oneByte[:])
-		if n == 1 && oneByte[0] >= '0' && oneByte[0] <= '9' {
-			// Continue
-		} else {
-			break
-		}
-	}
-	m.Stream.SetDeadline(time.Time{}) // Restore default deadline
 	return nil
 }
 

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -698,8 +698,20 @@ func (m *MomoTCPCommunicator) SendACK(serverId int) (err error) {
 		}
 	}()
 
-	var ackBuf [32]byte
-	if _, err := m.Write(strconv.AppendInt(append(ackBuf[:0], "ACK"...), int64(serverId), 10)); err != nil {
+	if serverId < 0 || serverId > 255 {
+		return fmt.Errorf("invalid server ID %d: %w", serverId, syscall.EBADMSG)
+	}
+
+	// Fixed-length ACK: "ACK" + 1-byte server ID (issue #621).
+	// This removes the variable-length decimal digits that required a fragile
+	// 5ms deadline on the read side and could corrupt the next protocol message
+	// when digits arrived in multiple segments.
+	var ackBuf [4]byte
+	ackBuf[0] = 'A'
+	ackBuf[1] = 'C'
+	ackBuf[2] = 'K'
+	ackBuf[3] = byte(serverId)
+	if _, err := m.Write(ackBuf[:]); err != nil {
 		return fmt.Errorf("failed to send ACK: %v: %w", err, syscall.EIO)
 	}
 	return nil
@@ -713,28 +725,15 @@ func (m *MomoTCPCommunicator) ReceiveACK() (err error) {
 		}
 	}()
 
-	var ackBuffer [3]byte
-	if _, err := io.ReadFull(io.LimitReader(m, 3), ackBuffer[:]); err != nil {
-		return fmt.Errorf("failed to read ACK prefix: %v: %w", err, syscall.EBADMSG)
+	var ackBuffer [4]byte
+	if _, err := io.ReadFull(io.LimitReader(m, 4), ackBuffer[:]); err != nil {
+		return fmt.Errorf("failed to read ACK: %v: %w", err, syscall.EBADMSG)
 	}
 
-	if !bytes.Equal(ackBuffer[:], []byte("ACK")) {
-		return fmt.Errorf("unexpected response: %s: %w", string(ackBuffer[:]), syscall.EBADMSG)
+	if !bytes.Equal(ackBuffer[:3], []byte("ACK")) {
+		return fmt.Errorf("unexpected response: %s: %w", string(ackBuffer[:3]), syscall.EBADMSG)
 	}
 
-	// ⚡ Bolt: Read any trailing server ID digits under a short deadline to prevent blocking,
-	// limited to at most 10 iterations to prevent infinite-loop CPU exhaustion (DoS).
-	m.SetDeadline(time.Now().Add(5 * time.Millisecond))
-	var oneByte [1]byte
-	for i := 0; i < 10; i++ {
-		n, _ := m.Read(oneByte[:])
-		if n == 1 && oneByte[0] >= '0' && oneByte[0] <= '9' {
-			// Continue
-		} else {
-			break
-		}
-	}
-	m.SetDeadline(time.Time{}) // Restore default deadline
 	return nil
 }
 

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -113,6 +113,61 @@ func TestMomoTCPCommunicator_Deadline(t *testing.T) {
 	}
 }
 
+// TestMomoTCPCommunicator_ACKFixedLength verifies the ACK uses a fixed-length
+// 4-byte wire format ("ACK" + 1-byte server ID), so the receiver never needs a
+// fragile 5ms deadline and cannot leave unread trailing digits (issue #621).
+func TestMomoTCPCommunicator_ACKFixedLength(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// Server sends a fixed-length ACK for server ID 2, then closes the conn so
+	// the client observes EOF with no leftover bytes.
+	go func() {
+		server := NewMomoTCPCommunicator(serverConn)
+		if err := server.SendACK(2); err != nil {
+			t.Errorf("SendACK failed: %v", err)
+			return
+		}
+		serverConn.Close()
+	}()
+
+	client := NewMomoTCPCommunicator(clientConn)
+	if err := client.ReceiveACK(); err != nil {
+		t.Fatalf("ReceiveACK failed: %v", err)
+	}
+
+	// Verify the exact 4-byte wire format (no variable-length digits): after
+	// consuming the ACK, the next read must yield EOF with zero leftover bytes.
+	clientConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	buf := make([]byte, 8)
+	n, err := clientConn.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("expected EOF after 4-byte ACK, got read error: %v", err)
+	}
+	if n != 0 {
+		// Any leftover bytes would corrupt the next protocol message.
+		t.Errorf("unexpected leftover bytes after ACK: %v", buf[:n])
+	}
+}
+
+// TestMomoTCPCommunicator_SendACKInvalidServerID verifies SendACK rejects
+// server IDs that do not fit in the fixed 1-byte field (issue #621).
+func TestMomoTCPCommunicator_SendACKInvalidServerID(t *testing.T) {
+	conn, _ := net.Pipe()
+	defer conn.Close()
+	comm := NewMomoTCPCommunicator(conn)
+
+	if err := comm.SendACK(-1); err == nil {
+		t.Error("Expected SendACK(-1) to fail")
+	}
+	if err := comm.SendACK(256); err == nil {
+		t.Error("Expected SendACK(256) to fail")
+	}
+}
+
 func TestMomoTCPCommunicator_EdgeCases(t *testing.T) {
 	// 1. Panic recovery tests (Rule 4) via nil communicator
 	var nilComm *MomoTCPCommunicator


### PR DESCRIPTION
## Description

Fixes #621 — `ReceiveACK` used a fragile 5ms timeout with no length prefix.

### Problem

`SendACK` wrote `"ACK"` followed by variable-length decimal server ID digits, and `ReceiveACK` read only the 3-byte `"ACK"` prefix, then tried to drain any trailing digits under a **5ms read deadline**. When the digits arrived in multiple TCP/QUIC segments (or the 5ms window elapsed between bytes), the leftover digits were never consumed and corrupted the next protocol message on the wire.

### Fix

- `SendACK` now writes a **fixed-length 4-byte ACK**: `"ACK"` + a single server ID byte (range-validated 0–255, `EBADMSG` on overflow).
- `ReceiveACK` reads **exactly 4 bytes** via `io.ReadFull(io.LimitReader(m, 4))` — no deadline, no digit loop, no leftover bytes.
- Applied identically to both `MomoTCPCommunicator` (`src/transport/momo_tcp.go`) and `MomoQUICCommunicator` (`src/transport/momo_quic.go`).

### Tests

- `TestMomoTCPCommunicator_ACKFixedLength`: verifies the exact 4-byte wire format — after `ReceiveACK`, the next read returns EOF with **zero leftover bytes** (regression for message corruption).
- `TestMomoTCPCommunicator_SendACKInvalidServerID`: `SendACK(-1)` and `SendACK(256)` must fail.
- Full suite passes with `go test ./...` and `-race`.

Resolves #621
