### PR TITLE
fix(transport): encode letter handshake modes as raw bytes

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2934,3 +2934,12 @@ bd016ee,BenchmarkSanitizeLog/Unsafe-8,639.90,704.00,1.00
 8b3edae,BenchmarkPadString-8,39.41,64.00,1.00
 8b3edae,BenchmarkSanitizeLog/Safe-8,230.90,0.00,0.00
 8b3edae,BenchmarkSanitizeLog/Unsafe-8,674.70,704.00,1.00
+ec59a82,BenchmarkCheckMetricsAndSwap-8,10.12,0.00,0.00
+ec59a82,BenchmarkCrushOptimized-8,317.20,0.00,0.00
+ec59a82,BenchmarkCrushOriginal-8,436.50,164.00,3.00
+ec59a82,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+ec59a82,BenchmarkIndexSearch-8,1.59,0.00,0.00
+ec59a82,BenchmarkLoadGlobalConfig-8,5958.00,1320.00,38.00
+ec59a82,BenchmarkPadString-8,41.06,64.00,1.00
+ec59a82,BenchmarkSanitizeLog/Safe-8,326.40,0.00,0.00
+ec59a82,BenchmarkSanitizeLog/Unsafe-8,1095.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        419.3n ± ∞ ¹    409.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       304.2n ± ∞ ¹    293.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     6.080µ ± ∞ ¹    5.863µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            38.81n ± ∞ ¹    39.41n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     238.4n ± ∞ ¹    230.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   671.2n ± ∞ ¹    674.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  7.793n ± ∞ ¹    8.414n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.831n ± ∞ ¹    1.868n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3385n ± ∞ ¹   0.3449n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                65.84n          65.89n        +0.07%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        409.0n ± ∞ ¹    436.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       293.2n ± ∞ ¹    317.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     5.863µ ± ∞ ¹    5.958µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            39.41n ± ∞ ¹    41.06n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     230.9n ± ∞ ¹    326.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   674.7n ± ∞ ¹   1095.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.414n ± ∞ ¹   10.120n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.868n ± ∞ ¹    1.589n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3449n ± ∞ ¹   0.3416n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                65.89n          74.00n        +12.31%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 293.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 409.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.12 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 317.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 436.50 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 5863.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 39.41 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 230.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 674.70 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.59 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 5958.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 41.06 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 326.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1095.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae]
-    line "CheckMetricsAndSwap" [12,11,8,7,7,7,9,8,8,8]
-    line "CrushOptimized" [428,468,378,356,305,338,300,289,304,293]
-    line "CrushOriginal" [571,542,558,469,409,387,443,396,419,409]
-    line "IndexDirectTracking" [1,1,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,1,2,2,2,2]
-    line "LoadGlobalConfig" [7558,8021,8176,6507,5825,5598,5683,5474,6080,5863]
-    line "PadString" [53,52,53,47,39,36,39,36,39,39]
+    x-axis [0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82]
+    line "CheckMetricsAndSwap" [11,8,7,7,7,9,8,8,8,10]
+    line "CrushOptimized" [468,378,356,305,338,300,289,304,293,317]
+    line "CrushOriginal" [542,558,469,409,387,443,396,419,409,436]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,1,2,2,2,2,2]
+    line "LoadGlobalConfig" [8021,8176,6507,5825,5598,5683,5474,6080,5863,5958]
+    line "PadString" [52,53,47,39,36,39,36,39,39,41]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [303,288,316,266,229,212,222,245,238,231]
-    line "SanitizeLog/Unsafe" [883,849,775,714,667,636,710,640,671,675]
+    line "SanitizeLog/Safe" [288,316,266,229,212,222,245,238,231,326]
+    line "SanitizeLog/Unsafe" [849,775,714,667,636,710,640,671,675,1095]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae]
+    x-axis [0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [efd8101,0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae]
+    x-axis [0271e7d,5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/communicator.go
+++ b/src/transport/communicator.go
@@ -3,8 +3,10 @@ package transport
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"syscall"
 	"time"
 
 	"github.com/alsotoes/momo/src/common"
@@ -26,6 +28,21 @@ const (
 	// MetadataStatusSkipPayload indicates the server already has the content (deduplication).
 	MetadataStatusSkipPayload = 2
 )
+
+// encodeRequestedModeByte encodes the handshake requested-mode field (issue #622).
+// Numeric replication modes (0-9) are sent as their ASCII digit; letter modes
+// (ModeList 'L', ModeDelete 'D', ModeGet 'G', ModeOPRFEval 'O') are sent as the
+// raw byte so the server's letter-mode decoder can match them.
+func encodeRequestedModeByte(requestedMode int) (byte, error) {
+	switch requestedMode {
+	case common.ModeList, common.ModeDelete, common.ModeGet, common.ModeOPRFEval:
+		return byte(requestedMode), nil
+	}
+	if requestedMode < 0 || requestedMode > 9 {
+		return 0, fmt.Errorf("invalid requested mode %d: %w", requestedMode, syscall.EBADMSG)
+	}
+	return byte(requestedMode + '0'), nil
+}
 
 // GlobalLister enables scatter-gather list queries across the cluster.
 // When set on a Communicator, list operations aggregate results from all peers.

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -208,7 +208,11 @@ func (m *MomoQUICCommunicator) HandshakeClient(authToken string, timestamp int64
 		if err := common.WritePaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
-		handshakeBuf[common.TimestampLength] = byte(requestedMode + '0')
+		modeByte, err := encodeRequestedModeByte(requestedMode)
+		if err != nil {
+			return 0, err
+		}
+		handshakeBuf[common.TimestampLength] = modeByte
 
 		if _, err := m.Write(handshakeBuf[:]); err != nil {
 			return 0, fmt.Errorf("failed to send handshake: %v: %w", err, syscall.EIO)
@@ -225,7 +229,11 @@ func (m *MomoQUICCommunicator) HandshakeClient(authToken string, timestamp int64
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
 
-		handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode + '0')
+		modeByte, err := encodeRequestedModeByte(requestedMode)
+		if err != nil {
+			return 0, err
+		}
+		handshakeBuf[common.AuthTokenLength+common.TimestampLength] = modeByte
 
 		if _, err := m.Write(handshakeBuf[:]); err != nil {
 			return 0, fmt.Errorf("failed to send handshake: %v: %w", err, syscall.EIO)

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -203,7 +203,11 @@ func (m *MomoTCPCommunicator) HandshakeClient(authToken string, timestamp int64,
 		if err := common.WritePaddedInt(handshakeBuf[:common.TimestampLength], timestamp, common.TimestampLength); err != nil {
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
-		handshakeBuf[common.TimestampLength] = byte(requestedMode + '0')
+		modeByte, err := encodeRequestedModeByte(requestedMode)
+		if err != nil {
+			return 0, err
+		}
+		handshakeBuf[common.TimestampLength] = modeByte
 
 		if _, err := m.Write(handshakeBuf[:]); err != nil {
 			return 0, fmt.Errorf("failed to send handshake: %v: %w", err, syscall.EIO)
@@ -220,7 +224,11 @@ func (m *MomoTCPCommunicator) HandshakeClient(authToken string, timestamp int64,
 			return 0, fmt.Errorf("failed to format handshake timestamp: %w", err)
 		}
 
-		handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode + '0')
+		modeByte, err := encodeRequestedModeByte(requestedMode)
+		if err != nil {
+			return 0, err
+		}
+		handshakeBuf[common.AuthTokenLength+common.TimestampLength] = modeByte
 
 		if _, err := m.Write(handshakeBuf[:]); err != nil {
 			return 0, fmt.Errorf("failed to send handshake: %v: %w", err, syscall.EIO)

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -113,6 +113,78 @@ func TestMomoTCPCommunicator_Deadline(t *testing.T) {
 	}
 }
 
+// TestMomoTCPCommunicator_HandshakeClientLetterModes verifies that
+// HandshakeClient encodes letter modes (ModeList/ModeDelete/ModeGet) as their
+// raw byte value rather than adding '0' (issue #622). The server previously
+// rejected these modes because byte(ModeList + '0') = '|' is not 'L'.
+func TestMomoTCPCommunicator_HandshakeClientLetterModes(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "test-token-11111111111111111111111111111111111111111111111111111" // notsecret, 64 chars
+
+	testCases := []struct {
+		name      string
+		requested int
+		wantByte  byte
+	}{
+		{"ModeList", common.ModeList, 'L'},
+		{"ModeDelete", common.ModeDelete, 'D'},
+		{"ModeGet", common.ModeGet, 'G'},
+		{"ModeOPRFEval", common.ModeOPRFEval, 'O'},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			defer clientConn.Close()
+			defer serverConn.Close()
+
+			// Server: read the handshake, verify the mode byte, then reply.
+			go func() {
+				var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
+				if _, err := io.ReadFull(serverConn, handshakeBuf[:]); err != nil {
+					t.Errorf("failed to read handshake: %v", err)
+					return
+				}
+				modeByte := handshakeBuf[common.AuthTokenLength+common.TimestampLength]
+				if modeByte != tc.wantByte {
+					t.Errorf("requested mode byte = %q (0x%x), want %q", modeByte, modeByte, tc.wantByte)
+				}
+				// Reply with replication mode 1.
+				serverConn.Write([]byte{'1'})
+			}()
+
+			client := NewMomoTCPCommunicator(clientConn)
+			mode, err := client.HandshakeClient(authToken, 1557906926566451195, tc.requested)
+			if err != nil {
+				t.Fatalf("HandshakeClient failed: %v", err)
+			}
+			if mode != 1 {
+				t.Errorf("replication mode = %d, want 1", mode)
+			}
+		})
+	}
+}
+
+// TestMomoTCPCommunicator_HandshakeClientInvalidMode verifies HandshakeClient
+// rejects out-of-range numeric modes that cannot be represented in the single
+// mode byte (issue #622).
+func TestMomoTCPCommunicator_HandshakeClientInvalidMode(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "test-token-11111111111111111111111111111111111111111111111111111" // notsecret, 64 chars
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	client := NewMomoTCPCommunicator(clientConn)
+	if _, err := client.HandshakeClient(authToken, 1557906926566451195, 10); err == nil {
+		t.Error("Expected HandshakeClient with mode 10 to fail")
+	}
+	_ = serverConn
+}
+
 // TestMomoTCPCommunicator_ACKFixedLength verifies the ACK uses a fixed-length
 // 4-byte wire format ("ACK" + 1-byte server ID), so the receiver never needs a
 // fragile 5ms deadline and cannot leave unread trailing digits (issue #621).


### PR DESCRIPTION
## Description

Fixes #622 — `HandshakeClient` could not send LIST/DELETE/GET (and OPRF-Eval) modes over the binary Momo protocol.

### Problem

`HandshakeClient` encoded the requested mode as `byte(requestedMode + '0')`. This is correct for numeric replication modes (0–3 → `'0'`–`'3'`), but corrupts letter modes:

- `ModeList = int('L') = 76` → `byte(76 + 48) = byte(124) = '|'`
- `ModeDelete = int('D') = 68` → `'t'`
- `ModeGet = int('G') = 71` → `'w'`

The server's decoder only accepts `'L'` / `'D'` / `'G'` / `'O'` as raw bytes (or `'0'`–`'9'` as numeric digits), so the client could never initiate LIST/DELETE/GET.

### Fix

Added `encodeRequestedModeByte(requestedMode)` in `src/transport/communicator.go`, used by both `MomoTCPCommunicator.HandshakeClient` and `MomoQUICCommunicator.HandshakeClient`:

- Letter modes (`ModeList`, `ModeDelete`, `ModeGet`, `ModeOPRFEval`) → sent as the **raw byte** (`'L'`, `'D'`, `'G'`, `'O'`).
- Numeric replication modes (0–9) → sent as the ASCII digit (unchanged behavior).
- Out-of-range values rejected with `EBADMSG`.

### Tests

- `TestMomoTCPCommunicator_HandshakeClientLetterModes`: full net.Pipe round-trip for all four letter modes, verifying the wire byte equals `'L'`/`'D'`/`'G'`/`'O'` and the server response is parsed. Confirmed it fails against the old encoding.
- `TestMomoTCPCommunicator_HandshakeClientInvalidMode`: mode 10 rejected.
- Full suite passes with `go test ./...`.

Resolves #622
