### PR TITLE
fix: QUIC listener/server use configured TLS cert and CA pool (#624)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2952,3 +2952,12 @@ aaf6479,BenchmarkLoadGlobalConfig-8,8220.00,1320.00,38.00
 aaf6479,BenchmarkPadString-8,58.75,64.00,1.00
 aaf6479,BenchmarkSanitizeLog/Safe-8,287.10,0.00,0.00
 aaf6479,BenchmarkSanitizeLog/Unsafe-8,866.40,704.00,1.00
+28ed539,BenchmarkCheckMetricsAndSwap-8,8.93,0.00,0.00
+28ed539,BenchmarkCrushOptimized-8,587.30,0.00,0.00
+28ed539,BenchmarkCrushOriginal-8,667.20,164.00,3.00
+28ed539,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+28ed539,BenchmarkIndexSearch-8,1.60,0.00,0.00
+28ed539,BenchmarkLoadGlobalConfig-8,8445.00,1320.00,38.00
+28ed539,BenchmarkPadString-8,48.86,64.00,1.00
+28ed539,BenchmarkSanitizeLog/Safe-8,252.30,0.00,0.00
+28ed539,BenchmarkSanitizeLog/Unsafe-8,989.10,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        436.5n ± ∞ ¹    626.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       317.2n ± ∞ ¹    419.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     5.958µ ± ∞ ¹    8.220µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            41.06n ± ∞ ¹    58.75n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     326.4n ± ∞ ¹    287.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                  1095.0n ± ∞ ¹    866.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  10.12n ± ∞ ¹    10.91n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.589n ± ∞ ¹    2.717n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3416n ± ∞ ¹   0.6005n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                74.00n          93.80n        +26.77%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        626.6n ± ∞ ¹    667.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       419.6n ± ∞ ¹    587.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     8.220µ ± ∞ ¹    8.445µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            58.75n ± ∞ ¹    48.86n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     287.1n ± ∞ ¹    252.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   866.4n ± ∞ ¹    989.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.910n ± ∞ ¹    8.933n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.717n ± ∞ ¹    1.601n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.6005n ± ∞ ¹   0.3796n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                93.80n          84.47n        -9.94%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 419.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 626.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8220.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 58.75 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 287.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 866.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 587.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 667.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8445.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
+| BenchmarkPadString-8 | 48.86 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 252.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 989.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479]
-    line "CheckMetricsAndSwap" [8,7,7,7,9,8,8,8,10,11]
-    line "CrushOptimized" [378,356,305,338,300,289,304,293,317,420]
-    line "CrushOriginal" [558,469,409,387,443,396,419,409,436,627]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
-    line "IndexSearch" [2,2,2,1,2,2,2,2,2,3]
-    line "LoadGlobalConfig" [8176,6507,5825,5598,5683,5474,6080,5863,5958,8220]
-    line "PadString" [53,47,39,36,39,36,39,39,41,59]
+    x-axis [37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539]
+    line "CheckMetricsAndSwap" [7,7,7,9,8,8,8,10,11,9]
+    line "CrushOptimized" [356,305,338,300,289,304,293,317,420,587]
+    line "CrushOriginal" [469,409,387,443,396,419,409,436,627,667]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
+    line "IndexSearch" [2,2,1,2,2,2,2,2,3,2]
+    line "LoadGlobalConfig" [6507,5825,5598,5683,5474,6080,5863,5958,8220,8445]
+    line "PadString" [47,39,36,39,36,39,39,41,59,49]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [316,266,229,212,222,245,238,231,326,287]
-    line "SanitizeLog/Unsafe" [775,714,667,636,710,640,671,675,1095,866]
+    line "SanitizeLog/Safe" [266,229,212,222,245,238,231,326,287,252]
+    line "SanitizeLog/Unsafe" [714,667,636,710,640,671,675,1095,866,989]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,7 +154,7 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479]
+    x-axis [37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -178,7 +178,7 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [5240efa,37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479]
+    x-axis [37c23c2,1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -63,12 +63,15 @@ type ConfigurationGlobal struct {
 	// PolymorphicSystem enables or disables the polymorphic system.
 	PolymorphicSystem bool
 	// CACertPath is the path to a PEM-encoded CA certificate file used to verify
-	// QUIC peer certificates. When empty, InsecureSkipVerify is used with a warning.
+	// QUIC/TCP peer certificates and to require client certificates (mutual TLS)
+	// on servers. When empty, InsecureSkipVerify is used with a warning.
 	CACertPath string
-	// TLSCertPath is the path to a PEM-encoded TLS certificate for TCP protocols.
-	// When empty, TCP connections use plaintext (backward compatible).
+	// TLSCertPath is the path to a PEM-encoded TLS certificate, used for both
+	// TCP and QUIC (the QUIC listener presents it instead of a self-signed cert).
+	// When empty, TCP connections use plaintext (backward compatible) and QUIC
+	// listeners fall back to a self-signed certificate.
 	TLSCertPath string
-	// TLSKeyPath is the path to a PEM-encoded TLS private key for TCP protocols.
+	// TLSKeyPath is the path to a PEM-encoded TLS private key, matching TLSCertPath.
 	// When empty, TCP connections use plaintext (backward compatible).
 	TLSKeyPath string
 	// TLSInsecure skips TLS certificate verification. Defaults to false.

--- a/src/transport/factory.go
+++ b/src/transport/factory.go
@@ -96,7 +96,12 @@ func (f *ProtocolFactory) Dial(address string) (Communicator, error) {
 	case "momo-quic", "s3-quic":
 		ctx, cancel := context.WithTimeout(context.Background(), quicDialTimeout)
 		defer cancel()
-		conn, stream, err := DialQUIC(ctx, address, f.certPool, f.cfg.Global.TLSInsecure)
+		var clientCert *tls.Certificate
+		if f.tlsConfig != nil && len(f.tlsConfig.Certificates) > 0 {
+			cert := f.tlsConfig.Certificates[0]
+			clientCert = &cert
+		}
+		conn, stream, err := DialQUIC(ctx, address, f.certPool, f.cfg.Global.TLSInsecure, clientCert)
 		if err != nil {
 			return nil, err
 		}
@@ -124,13 +129,24 @@ func (f *ProtocolFactory) Listen(address string) (MomoListener, error) {
 		}
 		return &TCPListener{Listener: l, factory: f}, nil
 	case "momo-quic", "s3-quic":
-		cert, err := GenerateSelfSignedCert()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate cert: %w", err)
-		}
-		tlsConf := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			NextProtos:   []string{"momo-quic"},
+		// Use the configured TLS certificate when available (issue #624);
+		// fall back to a self-signed certificate only when not configured.
+		tlsConf := &tls.Config{NextProtos: []string{"momo-quic"}}
+		if f.tlsConfig != nil {
+			tlsConf = f.tlsConfig.Clone()
+			tlsConf.NextProtos = []string{"momo-quic"}
+			if f.certPool != nil {
+				// Mutual TLS: require and verify client certificates against
+				// the configured CA pool, mirroring buildP2PTLSConfig.
+				tlsConf.ClientCAs = f.certPool
+				tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
+			}
+		} else {
+			cert, err := GenerateSelfSignedCert()
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate cert: %w", err)
+			}
+			tlsConf.Certificates = []tls.Certificate{cert}
 		}
 		l, err := quic.ListenAddr(address, tlsConf, nil)
 		if err != nil {

--- a/src/transport/factory_tls_test.go
+++ b/src/transport/factory_tls_test.go
@@ -1,0 +1,183 @@
+package transport
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/alsotoes/momo/src/common"
+)
+
+type testCertChain struct {
+	caPool    *x509.CertPool
+	serverTLS *tls.Config
+	clientTLS *tls.Config
+}
+
+// generateTestCertChain builds a CA and two leaf certificates signed by it:
+// one for the QUIC server and one for the QUIC client (mutual TLS).
+func generateTestCertChain(t *testing.T) *testCertChain {
+	t.Helper()
+
+	caPub, caPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "momo-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, &caTmpl, &caTmpl, caPub, caPriv)
+	if err != nil {
+		t.Fatalf("failed to create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("failed to parse CA cert: %v", err)
+	}
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	leaf := func(name string, keyUsage x509.ExtKeyUsage, ips []net.IP) (tls.Certificate, error) {
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return tls.Certificate{}, err
+		}
+		tmpl := x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: name},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{keyUsage},
+			IPAddresses:  ips,
+		}
+		der, err := x509.CreateCertificate(rand.Reader, &tmpl, caCert, pub, caPriv)
+		if err != nil {
+			return tls.Certificate{}, err
+		}
+		return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}, nil
+	}
+
+	serverCert, err := leaf("momo-test-server", x509.ExtKeyUsageServerAuth, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")})
+	if err != nil {
+		t.Fatalf("failed to create server cert: %v", err)
+	}
+	clientCert, err := leaf("momo-test-client", x509.ExtKeyUsageClientAuth, nil)
+	if err != nil {
+		t.Fatalf("failed to create client cert: %v", err)
+	}
+
+	return &testCertChain{
+		caPool: caPool,
+		serverTLS: &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			MinVersion:   tls.VersionTLS12,
+		},
+		clientTLS: &tls.Config{
+			Certificates: []tls.Certificate{clientCert},
+			MinVersion:   tls.VersionTLS12,
+		},
+	}
+}
+
+// TestProtocolFactory_Listen_QUIC_ConfiguredTLS verifies (issue #624) that the
+// QUIC listener presents the configured TLS certificate and requires a client
+// certificate signed by the configured CA (mutual TLS) instead of always
+// generating a self-signed certificate.
+func TestProtocolFactory_Listen_QUIC_ConfiguredTLS(t *testing.T) {
+	chain := generateTestCertChain(t)
+
+	serverFactory := &ProtocolFactory{
+		cfg: common.Configuration{
+			Global: common.ConfigurationGlobal{Protocol: "momo-quic"},
+		},
+		tlsConfig: chain.serverTLS,
+		certPool:  chain.caPool,
+	}
+
+	l, err := serverFactory.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("server failed to listen: %v", err)
+	}
+	defer l.Close()
+
+	// A client presenting a certificate signed by the CA must succeed.
+	clientFactory := &ProtocolFactory{
+		cfg: common.Configuration{
+			Global: common.ConfigurationGlobal{Protocol: "momo-quic"},
+		},
+		tlsConfig:        chain.clientTLS,
+		certPool:         chain.caPool,
+		useChallengeResp: true,
+	}
+
+	comm, err := clientFactory.Dial(l.Addr().String())
+	if err != nil {
+		t.Fatalf("client failed to dial with mTLS cert: %v", err)
+	}
+	comm.Close()
+
+	// A client with the CA pool but no client certificate must be rejected:
+	// proving the listener now enforces mutual TLS via the configured CA.
+	// quic-go may return the dial before the server's rejection lands, so the
+	// error surfaces on the next connection operation (same pattern as quic-go's
+	// own TestHandshakeFailsWithoutClientCert).
+	noCertFactory := &ProtocolFactory{
+		cfg: common.Configuration{
+			Global: common.ConfigurationGlobal{Protocol: "momo-quic"},
+		},
+		certPool: chain.caPool,
+	}
+
+	noCertComm, err := noCertFactory.Dial(l.Addr().String())
+	if err != nil {
+		t.Fatalf("unexpected dial error: %v", err)
+	}
+	mc := noCertComm.(*MomoQUICCommunicator)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = mc.conn.AcceptStream(ctx)
+	if err == nil {
+		t.Fatal("expected mTLS rejection (no client cert) to surface on the connection")
+	}
+	noCertComm.Close()
+}
+
+// TestProtocolFactory_Listen_QUIC_DefaultSelfSigned verifies the fallback: with
+// no configured TLS certificate, the QUIC listener still works using the
+// self-signed certificate (backward compatible with tls_insecure dialing).
+func TestProtocolFactory_Listen_QUIC_DefaultSelfSigned(t *testing.T) {
+	cfg := common.Configuration{
+		Global: common.ConfigurationGlobal{
+			Protocol:    "momo-quic",
+			TLSInsecure: true,
+		},
+	}
+	factory := NewProtocolFactory(cfg)
+
+	l, err := factory.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer l.Close()
+
+	dialFactory := NewProtocolFactory(cfg)
+	comm, err := dialFactory.Dial(l.Addr().String())
+	if err != nil {
+		t.Fatalf("client failed to dial self-signed listener: %v", err)
+	}
+	comm.Close()
+}

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -809,7 +809,8 @@ func GenerateSelfSignedCert() (tls.Certificate, error) {
 // When caCertPool is non-nil, peer certificates are verified against it.
 // When caCertPool is nil and tlsInsecure is false, the connection fails.
 // When caCertPool is nil and tlsInsecure is true, InsecureSkipVerify is used with a warning.
-func DialQUIC(ctx context.Context, address string, caCertPool *x509.CertPool, tlsInsecure bool) (conn *quic.Conn, stream *quic.Stream, err error) {
+// When clientCert is non-nil, it is presented to the peer for mutual TLS (issue #624).
+func DialQUIC(ctx context.Context, address string, caCertPool *x509.CertPool, tlsInsecure bool, clientCert *tls.Certificate) (conn *quic.Conn, stream *quic.Stream, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("CRITICAL: Panic recovered in DialQUIC for %s: %v", address, r)
@@ -824,6 +825,9 @@ func DialQUIC(ctx context.Context, address string, caCertPool *x509.CertPool, tl
 
 	tlsConf := &tls.Config{
 		NextProtos: []string{"momo-quic"},
+	}
+	if clientCert != nil {
+		tlsConf.Certificates = []tls.Certificate{*clientCert}
 	}
 	if caCertPool != nil {
 		tlsConf.RootCAs = caCertPool


### PR DESCRIPTION
Resolves #624

## Problem
The QUIC listener (`src/transport/factory.go`) always generated a self-signed certificate via `GenerateSelfSignedCert()` and ignored both the configured TLS certificate (`tls_cert_path`/`tls_key_path` → `f.tlsConfig`) and the CA pool (`ca_cert_path` → `f.certPool`). Impact:
- `tls_cert_path`/`tls_key_path`/`ca_cert_path` were silently ignored for `momo-quic`/`s3-quic` listeners.
- mTLS was broken for QUIC: the server presented a self-signed cert while clients verify against the configured CA, and the server never requested client certificates.

## Fix
- **Listener**: QUIC listen now presents the configured TLS certificate when `f.tlsConfig` is set (falls back to self-signed only when not configured). When a CA pool is configured, the listener enables mutual TLS (`ClientCAs` + `ClientAuth: RequireAndVerifyClientCert`), mirroring `buildP2PTLSConfig` in `server.go`.
- **Dial**: `DialQUIC` and the factory dial path now present the configured client certificate when available, so the client can authenticate in mTLS mode.
- Updated `ConfigurationGlobal` doc comments to reflect that TLS/CA paths now apply to both TCP and QUIC.

## Tests
- `TestProtocolFactory_Listen_QUIC_ConfiguredTLS`: builds a CA + server/client leaf certs, verifies (a) a client presenting a CA-signed cert succeeds, and (b) a client with the CA pool but no client cert is rejected (mTLS enforced). The negative case mirrors quic-go's own `TestHandshakeFailsWithoutClientCert`, since the rejection may surface on the connection after dial returns.
- `TestProtocolFactory_Listen_QUIC_DefaultSelfSigned`: confirms the self-signed fallback still works with `tls_insecure=true` (backward compatible).
- Verified the configured-TLS test fails on the pre-fix code (server presented self-signed cert → client verification failed).

## Changelog
- `src/transport/factory.go`: QUIC listen uses `f.tlsConfig` (+ mTLS via `f.certPool`), self-signed fallback retained; QUIC dial passes client cert.
- `src/transport/momo_quic.go`: `DialQUIC` accepts an optional `clientCert *tls.Certificate`.
- `src/common/struct.go`: doc comments updated.
- `src/transport/factory_tls_test.go`: new regression tests.
- `docs/PERFORMANCE.md`, `.github/data/benchmark_history.csv`: regenerated by pre-commit hook.

## Reviewer Status
Awaiting review.