### PR TITLE
feat: client-held envelope E2EE for native momo-tcp/quic protocols (#780)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2970,3 +2970,12 @@ c6829fc,BenchmarkLoadGlobalConfig-8,9134.00,1320.00,38.00
 c6829fc,BenchmarkPadString-8,67.09,64.00,1.00
 c6829fc,BenchmarkSanitizeLog/Safe-8,341.70,0.00,0.00
 c6829fc,BenchmarkSanitizeLog/Unsafe-8,837.80,704.00,1.00
+1cfce56,BenchmarkCheckMetricsAndSwap-8,8.50,0.00,0.00
+1cfce56,BenchmarkCrushOptimized-8,362.90,0.00,0.00
+1cfce56,BenchmarkCrushOriginal-8,505.60,164.00,3.00
+1cfce56,BenchmarkIndexDirectTracking-8,0.41,0.00,0.00
+1cfce56,BenchmarkIndexSearch-8,2.03,0.00,0.00
+1cfce56,BenchmarkLoadGlobalConfig-8,7656.00,1576.00,46.00
+1cfce56,BenchmarkPadString-8,47.53,64.00,1.00
+1cfce56,BenchmarkSanitizeLog/Safe-8,469.50,0.00,0.00
+1cfce56,BenchmarkSanitizeLog/Unsafe-8,634.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        667.2n ± ∞ ¹    619.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       587.3n ± ∞ ¹    395.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     8.445µ ± ∞ ¹    9.134µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            48.86n ± ∞ ¹    67.09n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     252.3n ± ∞ ¹    341.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   989.1n ± ∞ ¹    837.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.933n ± ∞ ¹    8.874n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.601n ± ∞ ¹    1.671n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3796n ± ∞ ¹   0.3689n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                84.47n          85.15n        +0.80%
+CrushOriginal-8                        619.5n ± ∞ ¹    505.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       395.7n ± ∞ ¹    362.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.134µ ± ∞ ¹    7.656µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            67.09n ± ∞ ¹    47.53n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     341.7n ± ∞ ¹    469.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   837.8n ± ∞ ¹    634.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.874n ± ∞ ¹    8.496n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.671n ± ∞ ¹    2.028n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3689n ± ∞ ¹   0.4093n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                85.15n          80.39n        -5.58%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -56,33 +56,35 @@ geomean                                84.47n          85.15n        +0.80%
                       │            B/op             │     B/op       vs base                │
 CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1.289Ki ± ∞ ¹   1.289Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    1.289Ki ± ∞ ¹   1.539Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 PadString-8                             64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ³                  +0.00%               ³
+geomean                                           ⁴                  +1.99%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ summaries must be >0 to compute geomean
+³ need >= 4 samples to detect a difference at alpha level 0.05
+⁴ summaries must be >0 to compute geomean
 
                       │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                       │          allocs/op          │  allocs/op   vs base                │
 CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      38.00 ± ∞ ¹   38.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                      38.00 ± ∞ ¹   46.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
 PadString-8                             1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ³                +0.00%               ³
+geomean                                           ⁴                +2.15%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ summaries must be >0 to compute geomean
+³ need >= 4 samples to detect a difference at alpha level 0.05
+⁴ summaries must be >0 to compute geomean
 ```
 
 ### Latest Benchmark Results
@@ -93,15 +95,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 395.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 619.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.67 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9134.00 ns/op | 1320.00 B/op | 38.00 allocs/op |
-| BenchmarkPadString-8 | 67.09 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 341.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 837.80 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 362.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 505.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.03 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7656.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 47.53 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 469.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 634.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +132,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc]
-    line "CheckMetricsAndSwap" [7,7,9,8,8,8,10,11,9,9]
-    line "CrushOptimized" [305,338,300,289,304,293,317,420,587,396]
-    line "CrushOriginal" [409,387,443,396,419,409,436,627,667,620]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,0]
-    line "IndexSearch" [2,1,2,2,2,2,2,3,2,2]
-    line "LoadGlobalConfig" [5825,5598,5683,5474,6080,5863,5958,8220,8445,9134]
-    line "PadString" [39,36,39,36,39,39,41,59,49,67]
+    x-axis [1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56]
+    line "CheckMetricsAndSwap" [7,9,8,8,8,10,11,9,9,8]
+    line "CrushOptimized" [338,300,289,304,293,317,420,587,396,363]
+    line "CrushOriginal" [387,443,396,419,409,436,627,667,620,506]
+    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,0]
+    line "IndexSearch" [1,2,2,2,2,2,3,2,2,2]
+    line "LoadGlobalConfig" [5598,5683,5474,6080,5863,5958,8220,8445,9134,7656]
+    line "PadString" [36,39,36,39,39,41,59,49,67,48]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [229,212,222,245,238,231,326,287,252,342]
-    line "SanitizeLog/Unsafe" [667,636,710,640,671,675,1095,866,989,838]
+    line "SanitizeLog/Safe" [212,222,245,238,231,326,287,252,342,470]
+    line "SanitizeLog/Unsafe" [636,710,640,671,675,1095,866,989,838,634]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +156,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc]
+    x-axis [1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1320,1320,1320]
+    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1320,1320,1576]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +180,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [1b241ec,1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc]
+    x-axis [1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [38,38,38,38,38,38,38,38,38,38]
+    line "LoadGlobalConfig" [38,38,38,38,38,38,38,38,38,46]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -496,3 +496,49 @@ When `encryption_enabled = true` and `encryption_key` is set, the storage
 factory (`NewStore`) wraps the blob store with `EncryptedBlobStore` before
 passing it to `CASStore`. No changes to S3 key handling or S3 communicator
 logic are required.
+
+## Envelope E2EE (Phase 4, issue #780)
+
+The `encryption_key` model above is **shared secret**: both the client and the
+server hold the same master key, so the server could decrypt content in
+principle. For **zero-trust vs. the serving node**, the native protocol
+(`momo-tcp` / `momo-quic`) supports a client-held envelope model modeled on the
+AWS S3 Encryption Client v3:
+
+- A **client-held** `e2ee_key` (64-hex, 256-bit) is configured client-side
+  only; it is **never** configured on, or sent to, any server daemon.
+- On upload, the client generates a fresh **per-object data key**, wraps it
+  with the client-held master key, and writes a self-describing envelope header
+  (`MOMOENV1` magic + version/algorithm + key-id + wrapped data key) followed by
+  the streaming AES-256-GCM ciphertext under the data key
+  (`crypto.EncryptEnvelope`).
+- The server stores the envelope bytes **as-is** (opaque). Its `TeeReader`
+  hashes the wire bytes → `SHA-256(envelope)`, which becomes the CAS/dedup key.
+  The server can neither read nor derive the content key; SSE
+  (`EncryptedBlobStore`) may still wrap the opaque envelope for at-rest
+  defense-in-depth, but that is optional.
+- On download, the client reads the envelope, unwraps the data key with its
+  client-held master key, and streams the plaintext out
+  (`crypto.DecryptEnvelope`).
+- Metadata (filename) confidentiality uses the same HMAC-SHA256 obfuscation as
+  Phase 3, but the HMAC key is derived from the **client-held** master key
+  (`DomainContent`), so the server can never derive it either.
+- **Mutually exclusive with OPRF** confidential dedup in this iteration: the
+  two models share the wire format's key-management slot. Config with both
+  `e2ee_key` and `oprf_enabled` is rejected.
+
+```
+Client → [EnvelopeE2EE: wrap data key + EncryptStream] → Server → [opaque store]
+```
+
+### Configuration (client side)
+
+```ini
+[global]
+e2ee_key = <64-char hex string (32 bytes)>
+e2ee_key_id = default
+```
+
+Or via CLI flag for the native client: `momo -imp client -file F -e2ee-key <hex>`.
+The same `-e2ee-key` / `-e2ee-key-id` flags power the S3 `s3enc` / `s3dec`
+impersonations (issue #777).

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -44,7 +44,37 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 	// Load encryption cipher if E2EE is enabled.
 	var encCipher *momocrypto.Cipher
 	var tenantKey []byte
-	if cfg.Global.EncryptionEnabled {
+	// envelopeMode enables client-held envelope encryption (zero-trust vs the
+	// serving node, issue #780). When set, content is wrapped in a
+	// self-describing momo E2EE envelope under a per-object data key; the
+	// client's E2EE master key never leaves the client.
+	envelopeMode := cfg.Global.E2EEKey != ""
+	var e2eeMasterKey []byte
+	if envelopeMode {
+		if len(cfg.Global.E2EEKey) != momocrypto.MaxKeyHexSize {
+			err = fmt.Errorf("invalid E2EE key: must be 64 hex characters: %w", syscall.EINVAL)
+			log.Printf("%v", err)
+			return
+		}
+		e2eeMasterKey, err = hex.DecodeString(cfg.Global.E2EEKey)
+		if err != nil {
+			err = fmt.Errorf("failed to decode E2EE key: %v: %w", err, syscall.EINVAL)
+			log.Printf("%v", err)
+			return
+		}
+		// The metadata wireName HMAC key is derived from the client-held E2EE
+		// master key (DomainContent), so the server can never derive it.
+		tenantKey, err = momocrypto.DeriveKey(e2eeMasterKey, cfg.Global.EncryptionTenant, momocrypto.DomainContent)
+		if err != nil {
+			log.Printf("Failed to derive tenant key: %v", err)
+			return
+		}
+		if cfg.Global.OPRFEnabled {
+			err = fmt.Errorf("envelope E2EE mode is mutually exclusive with OPRF confidential dedup: %w", syscall.EINVAL)
+			log.Printf("%v", err)
+			return
+		}
+	} else if cfg.Global.EncryptionEnabled {
 		masterKey, decErr := hex.DecodeString(cfg.Global.EncryptionKey)
 		if decErr != nil {
 			err = fmt.Errorf("failed to decode encryption key: %v: %w", decErr, syscall.EINVAL)
@@ -96,7 +126,7 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 	// encryptedTmp, when non-empty, holds the streaming ciphertext for
 	// encrypted uploads. It is removed after send.
 	var encryptedTmp string
-	if cfg.Global.EncryptionEnabled {
+	if cfg.Global.EncryptionEnabled || envelopeMode {
 		// 🛡️ Zero-Crash: Validate file size before encryption to prevent
 		// unbounded growth (Rule 4).
 		fileInfo, rErr := os.Stat(filePath)
@@ -154,21 +184,36 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 		}
 		encryptedTmp = tmp.Name()
 		h := sha256.New()
-		if err = encCipher.EncryptStream(file, io.MultiWriter(tmp, h)); err != nil {
-			tmp.Close()
-			os.Remove(encryptedTmp)
-			file.Close()
-			log.Printf("Failed to encrypt file %s: %v", common.SanitizeLog(filePath), err)
-			return
+		if envelopeMode {
+			// Envelope E2EE (zero-trust): wrap the content under a fresh
+			// per-object data key inside a self-describing envelope keyed by
+			// the client-held E2EE master key. The spool is the envelope bytes
+			// (opaque to the server); the CAS/dedup hash is H(ciphertext).
+			if err = momocrypto.EncryptEnvelope(io.MultiWriter(tmp, h), file, e2eeMasterKey, cfg.Global.E2EEKeyID); err != nil {
+				tmp.Close()
+				os.Remove(encryptedTmp)
+				file.Close()
+				log.Printf("Failed to encrypt envelope for %s: %v", common.SanitizeLog(filePath), common.SanitizeLog(err.Error()))
+				return
+			}
+			fileHash = hex.EncodeToString(h.Sum(nil))
+		} else {
+			if err = encCipher.EncryptStream(file, io.MultiWriter(tmp, h)); err != nil {
+				tmp.Close()
+				os.Remove(encryptedTmp)
+				file.Close()
+				log.Printf("Failed to encrypt file %s: %v", common.SanitizeLog(filePath), err)
+				return
+			}
+			// The CAS/dedup key is H(plaintext) when OPRF is enabled; otherwise
+			// it is H(ciphertext) (Phase A behavior).
+			if !cfg.Global.OPRFEnabled {
+				fileHash = hex.EncodeToString(h.Sum(nil))
+			}
 		}
 		file.Close()
 		if sErr := tmp.Close(); sErr != nil {
 			log.Printf("Failed to close encrypted spool: %v", sErr)
-		}
-		// The CAS/dedup key is H(plaintext) when OPRF is enabled; otherwise it
-		// is H(ciphertext) (Phase A behavior).
-		if !cfg.Global.OPRFEnabled {
-			fileHash = hex.EncodeToString(h.Sum(nil))
 		}
 	} else {
 		fileHash, err = common.HashFile(filePath)
@@ -248,7 +293,9 @@ func Connect(wg *sync.WaitGroup, cfg common.Configuration, filePath string, remo
 	// E2EE: encrypt the wireName for metadata confidentiality.
 	// Uses HMAC-SHA256 with the tenant key to produce a deterministic
 	// opaque key (64 hex chars) that fits within FileInfoLength.
-	if encCipher != nil {
+	// In envelope mode the tenant key is derived from the client-held E2EE
+	// master key, so the server can never derive the wireName either.
+	if encCipher != nil || envelopeMode {
 		mac := hmac.New(sha256.New, tenantKey)
 		mac.Write([]byte(wireName))
 		wireName = hex.EncodeToString(mac.Sum(nil))
@@ -495,7 +542,23 @@ func Download(cfg common.Configuration, encryptedName string, contentHash string
 
 	// ⚡ Bolt: Stream content directly from network to decryptor to output.
 	// No intermediate buffer allocation — peak memory is chunk-sized.
-	if cfg.Global.EncryptionEnabled {
+	limited := io.LimitReader(comm, size)
+	if cfg.Global.E2EEKey != "" {
+		// Envelope E2EE (zero-trust): the wire bytes are a self-describing
+		// envelope whose data key is wrapped by the client-held E2EE master
+		// key. The serving node only ever stores opaque ciphertext, so the
+		// client (and only the client) can unwrap it.
+		if cfg.Global.OPRFEnabled {
+			return fmt.Errorf("envelope E2EE mode is mutually exclusive with OPRF confidential dedup: %w", syscall.EINVAL)
+		}
+		masterKey, dErr := hex.DecodeString(cfg.Global.E2EEKey)
+		if dErr != nil {
+			return fmt.Errorf("failed to decode E2EE key: %w", dErr)
+		}
+		if _, dErr := momocrypto.DecryptEnvelope(limited, dst, masterKey); dErr != nil {
+			return fmt.Errorf("failed to decrypt envelope content: %w", dErr)
+		}
+	} else if cfg.Global.EncryptionEnabled {
 		var cipher *momocrypto.Cipher
 		if cfg.Global.OPRFEnabled {
 			// The content key is derived from the dedup tag H(plaintext) via the

--- a/src/client/envelope_test.go
+++ b/src/client/envelope_test.go
@@ -1,0 +1,317 @@
+package client
+
+import (
+	"bytes"
+	"encoding/hex"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alsotoes/momo/src/common"
+	momocrypto "github.com/alsotoes/momo/src/crypto"
+	"github.com/alsotoes/momo/src/transport"
+	"go.uber.org/goleak"
+)
+
+// TestConnect_EnvelopeStreamsToSpool is a regression test for issue #780: the
+// native client must stream envelope-encrypted (zero-trust) content to a temp
+// spool file rather than buffering ciphertext, the wire payload must be a
+// self-describing momo E2EE envelope (starts with the envelope magic) and never
+// contain the plaintext, and the temp spool must be cleaned up after upload.
+func TestConnect_EnvelopeStreamsToSpool(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	plaintext := "e2e-envelope-regression-test-780"
+	masterKeyHex := strings.Repeat("b", 64)
+
+	file, err := os.CreateTemp("", "test_env_stream_*.txt")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	if _, err := file.WriteString(plaintext); err != nil {
+		t.Fatalf("Failed to write plaintext: %v", err)
+	}
+	file.Close()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	payloadCh := make(chan []byte, 1)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Logf("Mock server panic recovered: %v", r)
+			}
+		}()
+
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		bufAuth := make([]byte, common.AuthTokenLength)
+		if _, err := io.ReadFull(conn, bufAuth); err != nil {
+			return
+		}
+
+		buf := make([]byte, common.TimestampLength+1)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			return
+		}
+
+		conn.Write([]byte("0"))
+
+		metaBuf := make([]byte, 64+common.FileInfoLength+common.FileInfoLength)
+		if _, err := io.ReadFull(conn, metaBuf); err != nil {
+			return
+		}
+
+		sizeStr := strings.TrimRight(string(metaBuf[64+common.FileInfoLength:]), "\x00")
+		payloadSize, err := strconv.Atoi(sizeStr)
+		if err != nil || payloadSize <= 0 || payloadSize > common.MaxFileSize {
+			return
+		}
+
+		conn.Write([]byte{transport.MetadataStatusSendPayload})
+
+		payload := make([]byte, payloadSize)
+		if _, err := io.ReadFull(conn, payload); err != nil {
+			return
+		}
+
+		conn.Write([]byte("ACK"))
+
+		payloadCh <- payload
+	}()
+
+	cfg := common.Configuration{
+		Daemons: []*common.Daemon{
+			{Host: ln.Addr().String(), ChangeReplication: ln.Addr().String(), Data: "/tmp", Drive: "/dev/sda1"},
+		},
+		Global: common.ConfigurationGlobal{
+			AuthToken:        authToken,
+			Protocol:         "momo-tcp",
+			E2EEKey:          masterKeyHex,
+			E2EEKeyID:        "test-key",
+			EncryptionTenant: "default",
+		},
+	}
+
+	stale, _ := filepath.Glob(filepath.Join(os.TempDir(), "momo-enc-*"))
+	for _, s := range stale {
+		os.Remove(s)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err = Connect(&wg, cfg, file.Name(), "", 0, time.Now().UnixNano(), 0, 3)
+	wg.Wait()
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	select {
+	case payload := <-payloadCh:
+		if len(payload) == 0 {
+			t.Fatal("Empty payload received")
+		}
+		if !bytes.HasPrefix(payload, []byte(momocrypto.EnvelopeMagic)) {
+			t.Errorf("Expected payload to start with envelope magic %q, got %q", momocrypto.EnvelopeMagic, payload[:min(len(payload), len(momocrypto.EnvelopeMagic))])
+		}
+		if bytes.Contains(payload, []byte(plaintext)) {
+			t.Error("FAIL: Plaintext leaked to wire (not envelope-encrypted)")
+		}
+		// The envelope must round-trip to plaintext under the client-held key,
+		// proving the server never needs the key (zero-trust).
+		masterKey, _ := hexDecodeMasterKey(t, masterKeyHex)
+		var out bytes.Buffer
+		if _, err := momocrypto.DecryptEnvelope(bytes.NewReader(payload), &out, masterKey); err != nil {
+			t.Fatalf("Failed to decrypt captured envelope with client key: %v", err)
+		}
+		if out.String() != plaintext {
+			t.Errorf("Decrypted envelope mismatch: got %q, want %q", out.String(), plaintext)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Mock server did not receive payload (timeout)")
+	}
+
+	leftover, _ := filepath.Glob(filepath.Join(os.TempDir(), "momo-enc-*"))
+	if len(leftover) > 0 {
+		t.Errorf("Temp spool files left behind: %v", leftover)
+		for _, f := range leftover {
+			os.Remove(f)
+		}
+	}
+}
+
+// TestDownload_EnvelopeRoundTrip is a regression test for issue #780: client
+// Download must detect the self-describing envelope and decrypt it with the
+// client-held E2EE key. It verifies the GET wire flow, envelope dispatch, and
+// plaintext round-trip.
+func TestDownload_EnvelopeRoundTrip(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	plaintext := "e2e-download-envelope-roundtrip-780"
+	masterKeyHex := strings.Repeat("c", 64)
+	masterKey, err := hexDecodeMasterKey(t, masterKeyHex)
+
+	// Build the envelope that the serving node stores (opaque to it).
+	var envelope bytes.Buffer
+	if err := momocrypto.EncryptEnvelope(&envelope, strings.NewReader(plaintext), masterKey, "test-key"); err != nil {
+		t.Fatalf("Failed to encrypt envelope: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		bufAuth := make([]byte, common.AuthTokenLength)
+		if _, err := io.ReadFull(conn, bufAuth); err != nil {
+			return
+		}
+		buf := make([]byte, common.TimestampLength+1)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			return
+		}
+
+		reqBuf := make([]byte, 128)
+		if _, err := io.ReadFull(conn, reqBuf); err != nil {
+			return
+		}
+
+		// status '0' + 64-byte size
+		var respBuf [65]byte
+		respBuf[0] = '0'
+		copy(respBuf[1:65], common.PadString(strconv.Itoa(envelope.Len()), 64))
+		if _, err := conn.Write(respBuf[:]); err != nil {
+			return
+		}
+
+		if _, err := conn.Write(envelope.Bytes()); err != nil {
+			return
+		}
+	}()
+
+	cfg := common.Configuration{
+		Daemons: []*common.Daemon{
+			{Host: ln.Addr().String(), ChangeReplication: ln.Addr().String(), Data: "/tmp", Drive: "/dev/sda1"},
+		},
+		Global: common.ConfigurationGlobal{
+			AuthToken:        authToken,
+			Protocol:         "momo-tcp",
+			E2EEKey:          masterKeyHex,
+			E2EEKeyID:        "test-key",
+			EncryptionTenant: "default",
+		},
+	}
+
+	var out bytes.Buffer
+	if err := Download(cfg, "enc-name", "deadbeef", 0, &out); err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	if out.String() != plaintext {
+		t.Errorf("Decrypted content mismatch: got %q, want %q", out.String(), plaintext)
+	}
+}
+
+// TestDownload_EnvelopeWrongKey verifies that decrypting an envelope with the
+// wrong client-held key fails closed (zero-trust: only the correct key holder
+// recovers plaintext).
+func TestDownload_EnvelopeWrongKey(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	plaintext := "e2e-download-envelope-wrongkey-780"
+	encryptKey, _ := hexDecodeMasterKey(t, strings.Repeat("d", 64))
+	wrongKey, _ := hexDecodeMasterKey(t, strings.Repeat("e", 64))
+
+	var envelope bytes.Buffer
+	if err := momocrypto.EncryptEnvelope(&envelope, strings.NewReader(plaintext), encryptKey, "test-key"); err != nil {
+		t.Fatalf("Failed to encrypt envelope: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		bufAuth := make([]byte, common.AuthTokenLength)
+		if _, err := io.ReadFull(conn, bufAuth); err != nil {
+			return
+		}
+		buf := make([]byte, common.TimestampLength+1)
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			return
+		}
+
+		reqBuf := make([]byte, 128)
+		if _, err := io.ReadFull(conn, reqBuf); err != nil {
+			return
+		}
+
+		var respBuf [65]byte
+		respBuf[0] = '0'
+		copy(respBuf[1:65], common.PadString(strconv.Itoa(envelope.Len()), 64))
+		if _, err := conn.Write(respBuf[:]); err != nil {
+			return
+		}
+		if _, err := conn.Write(envelope.Bytes()); err != nil {
+			return
+		}
+	}()
+
+	cfg := common.Configuration{
+		Daemons: []*common.Daemon{
+			{Host: ln.Addr().String(), ChangeReplication: ln.Addr().String(), Data: "/tmp", Drive: "/dev/sda1"},
+		},
+		Global: common.ConfigurationGlobal{
+			AuthToken:        authToken,
+			Protocol:         "momo-tcp",
+			E2EEKey:          strings.Repeat("e", 64),
+			E2EEKeyID:        "test-key",
+			EncryptionTenant: "default",
+		},
+	}
+
+	var out bytes.Buffer
+	if err := Download(cfg, "enc-name", "deadbeef", 0, &out); err == nil {
+		t.Fatal("Download succeeded with wrong E2EE key; expected failure")
+	}
+	_ = wrongKey
+}
+
+func hexDecodeMasterKey(t *testing.T, s string) ([]byte, error) {
+	t.Helper()
+	return hex.DecodeString(s)
+}

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -308,6 +308,27 @@ func loadGlobalConfig(section *ini.Section) (ConfigurationGlobal, error) {
 		globalCfg.EncryptionTenant = key.String()
 	}
 
+	if key, err := section.GetKey("e2ee_key"); err == nil {
+		globalCfg.E2EEKey = key.String()
+	}
+
+	if key, err := section.GetKey("e2ee_key_id"); err == nil {
+		globalCfg.E2EEKeyID = key.String()
+	}
+
+	if globalCfg.E2EEKey != "" {
+		if len(globalCfg.E2EEKey) != 64 {
+			return ConfigurationGlobal{}, fmt.Errorf("'e2ee_key' must be 64 hex characters (256-bit): %w", syscall.EINVAL)
+		}
+		if _, err := hex.DecodeString(globalCfg.E2EEKey); err != nil {
+			return ConfigurationGlobal{}, fmt.Errorf("'e2ee_key' must be valid hex: %w", err)
+		}
+	}
+
+	if globalCfg.E2EEKeyID == "" {
+		globalCfg.E2EEKeyID = "default"
+	}
+
 	if globalCfg.EncryptionEnabled {
 		if len(globalCfg.EncryptionKey) != 64 {
 			return ConfigurationGlobal{}, fmt.Errorf("'encryption_key' must be 64 hex characters (256-bit) when encryption is enabled: %w", syscall.EINVAL)
@@ -334,6 +355,13 @@ func loadGlobalConfig(section *ini.Section) (ConfigurationGlobal, error) {
 			}
 			globalCfg.OPRFThreshold = v
 		}
+	}
+
+	// Envelope E2EE (client-held key) and OPRF confidential dedup share the
+	// wire format's key-management slot; they are mutually exclusive in the
+	// first iteration (issue #780).
+	if globalCfg.E2EEKey != "" && globalCfg.OPRFEnabled {
+		return ConfigurationGlobal{}, fmt.Errorf("'e2ee_key' (envelope E2EE) is mutually exclusive with OPRF confidential dedup: %w", syscall.EINVAL)
 	}
 
 	return globalCfg, nil

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -381,3 +381,140 @@ func TestGetConfig_OPRF_ValidationErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestGetConfig_E2EE_Valid verifies that a 64-hex 'e2ee_key' loads correctly
+// with a default key id (issue #780).
+func TestGetConfig_E2EE_Valid(t *testing.T) {
+	cfg := `
+[global]
+debug = true
+auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # notsecret
+replication_order = 2,3,1
+polymorphic_system = true
+e2ee_key = 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+e2ee_key_id = my-key
+
+[metrics]
+interval = 10
+min_threshold = 0.1
+max_threshold = 0.9
+fallback_interval = 30
+
+[daemon.0]
+host = localhost:8080
+change_replication = localhost:2222
+data = /data/0
+drive = /dev/sda1
+`
+	tmp := filepath.Join(t.TempDir(), "momo.conf")
+	if err := os.WriteFile(tmp, []byte(cfg), 0666); err != nil {
+		t.Fatal(err)
+	}
+	config, err := GetConfig(tmp)
+	if err != nil {
+		t.Fatalf("valid E2EE config rejected: %v", err)
+	}
+	if config.Global.E2EEKey != "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" {
+		t.Errorf("E2EEKey mismatch: %q", config.Global.E2EEKey)
+	}
+	if config.Global.E2EEKeyID != "my-key" {
+		t.Errorf("E2EEKeyID mismatch: %q", config.Global.E2EEKeyID)
+	}
+}
+
+// TestGetConfig_E2EE_DefaultKeyID verifies the "default" key id fallback when
+// only 'e2ee_key' is provided.
+func TestGetConfig_E2EE_DefaultKeyID(t *testing.T) {
+	cfg := `
+[global]
+debug = true
+auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # notsecret
+replication_order = 2,3,1
+polymorphic_system = true
+e2ee_key = 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+[metrics]
+interval = 10
+min_threshold = 0.1
+max_threshold = 0.9
+fallback_interval = 30
+
+[daemon.0]
+host = localhost:8080
+change_replication = localhost:2222
+data = /data/0
+drive = /dev/sda1
+`
+	tmp := filepath.Join(t.TempDir(), "momo.conf")
+	if err := os.WriteFile(tmp, []byte(cfg), 0666); err != nil {
+		t.Fatal(err)
+	}
+	config, err := GetConfig(tmp)
+	if err != nil {
+		t.Fatalf("valid E2EE config rejected: %v", err)
+	}
+	if config.Global.E2EEKeyID != "default" {
+		t.Errorf("expected default E2EEKeyID, got %q", config.Global.E2EEKeyID)
+	}
+}
+
+// TestGetConfig_E2EE_ValidationErrors covers E2EE config validation (issue #780).
+func TestGetConfig_E2EE_ValidationErrors(t *testing.T) {
+	testCases := []struct {
+		name          string
+		globalExtra   string
+		expectedError string
+	}{
+		{
+			name:          "Key wrong length",
+			globalExtra:   "e2ee_key = aabb\n",
+			expectedError: "must be 64 hex characters",
+		},
+		{
+			name:          "Key invalid hex",
+			globalExtra:   "e2ee_key = " + strings.Repeat("z", 64) + "\n",
+			expectedError: "must be valid hex",
+		},
+		{
+			name:          "Mutually exclusive with OPRF",
+			globalExtra:   "e2ee_key = 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\noprf_enabled = true\noprf_threshold = 1\n",
+			expectedError: "mutually exclusive with OPRF",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := `
+[global]
+debug = true
+auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # notsecret
+replication_order = 2,3,1
+polymorphic_system = true
+` + tc.globalExtra + `
+[metrics]
+interval = 10
+min_threshold = 0.1
+max_threshold = 0.9
+fallback_interval = 30
+
+[daemon.0]
+host = localhost:8080
+change_replication = localhost:2222
+data = /data/0
+drive = /dev/sda1
+oprf_share = ` + validOPRFShare + `
+`
+			tmp := filepath.Join(t.TempDir(), "momo.conf")
+			if err := os.WriteFile(tmp, []byte(content), 0666); err != nil {
+				t.Fatal(err)
+			}
+			_, err := GetConfig(tmp)
+			if err == nil {
+				t.Fatal("expected an error, got none")
+			}
+			if !strings.Contains(err.Error(), tc.expectedError) {
+				t.Errorf("expected error containing %q, got %q", tc.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -94,6 +94,16 @@ type ConfigurationGlobal struct {
 	// to derive a content key. Defaults to the number of configured daemons
 	// when 0. Must satisfy 1 <= OPRFThreshold <= len(daemons).
 	OPRFThreshold int
+	// E2EEKey is the 64-hex 256-bit client-held master key for native protocol
+	// (momo-tcp/momo-quic) envelope encryption. When set, content is wrapped in
+	// a self-describing momo E2EE envelope (per-object data key under this
+	// client-held master key) so the serving node never sees plaintext
+	// (zero-trust vs the serving node, issue #780). The key is client-held only
+	// and must never be the server's EncryptionKey.
+	E2EEKey string
+	// E2EEKeyID is the key identifier stored in the envelope header. Defaults
+	// to "default" when empty.
+	E2EEKeyID string
 }
 
 // ConfigurationMetrics holds the metrics configuration for the application.

--- a/src/momo.go
+++ b/src/momo.go
@@ -46,7 +46,7 @@ func Run() {
 	configPathPtr := flag.String("config", "conf/momo.conf", "Path to the configuration file")
 	modePtr := flag.Int("mode", -1, "Replication mode to set (used with -imp repl)")
 	remotePathPtr := flag.String("remote-path", "", "Remote virtual directory path to upload the file to")
-	e2eeKeyPtr := flag.String("e2ee-key", "", "64-hex 256-bit E2EE master key for the S3 envelope encrypt/decrypt (client-held, never shared with the server)")
+	e2eeKeyPtr := flag.String("e2ee-key", "", "64-hex 256-bit E2EE master key for envelope encrypt/decrypt (client-held, never shared with the server); applies to native client mode and the S3 s3enc/s3dec impersonations")
 	e2eeKeyIDPtr := flag.String("e2ee-key-id", "", "Key identifier stored in the envelope (default: \"default\")")
 	outPathPtr := flag.String("out", "", "Output path for -imp s3enc / s3dec")
 	flag.Parse()
@@ -95,6 +95,15 @@ func Run() {
 
 		if serverId >= len(cfg.Daemons) || serverId < 0 {
 			log.Fatalf("index out of range")
+		}
+		// Envelope E2EE (zero-trust): client-held key for the native protocol.
+		// This overrides config values so the CLI flag is the source of truth;
+		// the key never leaves the client and is never persisted to the server.
+		if *e2eeKeyPtr != "" {
+			cfg.Global.E2EEKey = *e2eeKeyPtr
+		}
+		if *e2eeKeyIDPtr != "" {
+			cfg.Global.E2EEKeyID = *e2eeKeyIDPtr
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)


### PR DESCRIPTION
Resolves #780

## Summary
Extends the S3 client-side envelope-encryption model (issue #777) to the native momo-tcp/momo-quic client so the serving node never sees plaintext (zero-trust). Modeled on the AWS S3 Encryption Client v3: per-object data key, AES-256-GCM streaming, client-held wrapping key.

## What changed
- **client.Connect**: new `envelopeMode` when `e2ee_key` is set — content is wrapped via `crypto.EncryptEnvelope` (self-describing `MOMOENV1` envelope under a per-object data key) streamed to the temp spool; CAS/dedup hash = SHA-256 of ciphertext; wireName HMAC keyed off the client-held master key (DomainContent). Envelope mode is mutually exclusive with OPRF confidential dedup (rejected).
- **client.Download**: envelope dispatch — reads the envelope from the wire and decrypts with the client-held key (`DecryptEnvelope`); legacy shared-secret path unchanged.
- **config**: parse/validate `e2ee_key` (64-hex, 256-bit) and `e2ee_key_id` (default `"default"`); reject `e2ee_key` + `oprf_enabled` combos.
- **CLI**: native client honors `-e2ee-key` / `-e2ee-key-id` (same flags as s3enc/s3dec).
- **docs**: PROTOCOL.md Phase 4 envelope E2EE section.

## Why
The legacy `encryption_key` model is a shared secret: both client and server hold the same master key, so the server could decrypt in principle. Envelope E2EE keeps the key client-held only — the server stores opaque envelope bytes it can never unwrap.

## Changelog
- `5c0f3b8` — `feat: client-held envelope E2EE for native momo-tcp/quic protocols (#780)`

## Reviewer status
Awaiting review.

## Testing
- `TestConnect_EnvelopeStreamsToSpool` — wire payload is an envelope (magic prefix), plaintext never leaks, round-trip decrypts with the client key, spool cleaned up.
- `TestDownload_EnvelopeRoundTrip` — GET wire flow + envelope dispatch decrypts to plaintext.
- `TestDownload_EnvelopeWrongKey` — fail-closed with a wrong client-held key.
- `TestGetConfig_E2EE_*` — config parsing/validation matrix incl. OPRF mutual exclusion.
- `go build`, `go vet`, `gofmt`, full `go test ./...` all green.