### PR TITLE
feat: S3-compliant XML error responses

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2979,3 +2979,12 @@ c6829fc,BenchmarkSanitizeLog/Unsafe-8,837.80,704.00,1.00
 1cfce56,BenchmarkPadString-8,47.53,64.00,1.00
 1cfce56,BenchmarkSanitizeLog/Safe-8,469.50,0.00,0.00
 1cfce56,BenchmarkSanitizeLog/Unsafe-8,634.40,704.00,1.00
+90e806d,BenchmarkCheckMetricsAndSwap-8,10.62,0.00,0.00
+90e806d,BenchmarkCrushOptimized-8,549.20,0.00,0.00
+90e806d,BenchmarkCrushOriginal-8,949.40,164.00,3.00
+90e806d,BenchmarkIndexDirectTracking-8,0.43,0.00,0.00
+90e806d,BenchmarkIndexSearch-8,1.73,0.00,0.00
+90e806d,BenchmarkLoadGlobalConfig-8,10077.00,1576.00,46.00
+90e806d,BenchmarkPadString-8,55.70,64.00,1.00
+90e806d,BenchmarkSanitizeLog/Safe-8,496.60,0.00,0.00
+90e806d,BenchmarkSanitizeLog/Unsafe-8,610.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                      │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        619.5n ± ∞ ¹    505.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       395.7n ± ∞ ¹    362.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     9.134µ ± ∞ ¹    7.656µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            67.09n ± ∞ ¹    47.53n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     341.7n ± ∞ ¹    469.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   837.8n ± ∞ ¹    634.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.874n ± ∞ ¹    8.496n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.671n ± ∞ ¹    2.028n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3689n ± ∞ ¹   0.4093n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                85.15n          80.39n        -5.58%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                      │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                        505.6n ± ∞ ¹    949.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                       362.9n ± ∞ ¹    549.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.656µ ± ∞ ¹   10.077µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                            47.53n ± ∞ ¹    55.70n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     469.5n ± ∞ ¹    496.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   634.4n ± ∞ ¹    610.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.496n ± ∞ ¹   10.620n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.028n ± ∞ ¹    1.730n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4093n ± ∞ ¹   0.4342n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                80.39n          96.23n        +19.70%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -56,35 +56,33 @@ geomean                                85.15n          80.39n        -5.58%
                       │            B/op             │     B/op       vs base                │
 CrushOriginal-8                         164.0 ± ∞ ¹     164.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    1.289Ki ± ∞ ¹   1.539Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+LoadGlobalConfig-8                    1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
 PadString-8                             64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                      0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                    704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ⁴                  +1.99%               ⁴
+geomean                                           ³                  +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 
                       │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                       │          allocs/op          │  allocs/op   vs base                │
 CrushOriginal-8                         3.000 ± ∞ ¹   3.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CrushOptimized-8                        0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                      38.00 ± ∞ ¹   46.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
+LoadGlobalConfig-8                      46.00 ± ∞ ¹   46.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 PadString-8                             1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                      0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                    1.000 ± ∞ ¹   1.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                           0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                   0.000 ± ∞ ¹   0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                           ⁴                +2.15%               ⁴
+geomean                                           ³                +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 ```
 
 ### Latest Benchmark Results
@@ -95,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 362.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 505.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.03 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7656.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 47.53 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 469.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 634.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.62 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 549.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 949.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.43 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.73 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 10077.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 55.70 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 496.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 610.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -132,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56]
-    line "CheckMetricsAndSwap" [7,9,8,8,8,10,11,9,9,8]
-    line "CrushOptimized" [338,300,289,304,293,317,420,587,396,363]
-    line "CrushOriginal" [387,443,396,419,409,436,627,667,620,506]
-    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,0]
-    line "IndexSearch" [1,2,2,2,2,2,3,2,2,2]
-    line "LoadGlobalConfig" [5598,5683,5474,6080,5863,5958,8220,8445,9134,7656]
-    line "PadString" [36,39,36,39,39,41,59,49,67,48]
+    x-axis [a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d]
+    line "CheckMetricsAndSwap" [9,8,8,8,10,11,9,9,8,11]
+    line "CrushOptimized" [300,289,304,293,317,420,587,396,363,549]
+    line "CrushOriginal" [443,396,419,409,436,627,667,620,506,949]
+    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,2,3,2,2,2,2]
+    line "LoadGlobalConfig" [5683,5474,6080,5863,5958,8220,8445,9134,7656,10077]
+    line "PadString" [39,36,39,39,41,59,49,67,48,56]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [212,222,245,238,231,326,287,252,342,470]
-    line "SanitizeLog/Unsafe" [636,710,640,671,675,1095,866,989,838,634]
+    line "SanitizeLog/Safe" [222,245,238,231,326,287,252,342,470,497]
+    line "SanitizeLog/Unsafe" [710,640,671,675,1095,866,989,838,634,610]
 ```
 
 #### Memory per Operation (B/op)
@@ -156,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56]
+    x-axis [a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1320,1320,1576]
+    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1320,1576,1576]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -180,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [1ddb702,a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56]
+    x-axis [a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [38,38,38,38,38,38,38,38,38,46]
+    line "LoadGlobalConfig" [38,38,38,38,38,38,38,38,46,46]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -277,7 +277,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		components, ok := parseSigV4AuthHeader(authHeader)
 		if !ok {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.conn.Write([]byte("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusForbidden, "AuthorizationHeaderMalformed", "The authorization header is malformed.", "")
 			return 0, 0, syscall.EACCES
 		}
 		token = components.AccessKey
@@ -290,7 +290,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		m.isPeer = true
 	} else {
 		m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-		m.conn.Write([]byte("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+		writeS3Error(m.conn, http.StatusForbidden, "AccessDenied", "Access Denied.", "")
 		return 0, 0, syscall.EACCES
 	}
 
@@ -299,7 +299,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		if !verifySigV4Signature(req, authHeader, secretKey) {
 			log.Printf("AUDIT: SigV4 signature verification failed from %s", m.conn.RemoteAddr())
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.conn.Write([]byte("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusForbidden, "SignatureDoesNotMatch", "The request signature we calculated does not match the signature you provided. Check your AWS secret access key and signing method.", "")
 			return 0, 0, syscall.EACCES
 		}
 	}
@@ -307,7 +307,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 	// 🛡️ Sentinel: Reject requests containing directory traversal characters (".." or "\") to prevent path traversal attacks.
 	if strings.Contains(req.URL.Path, "..") || strings.Contains(req.URL.Path, "\\") {
 		m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-		m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+		writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Invalid key path.", req.URL.Path)
 		return 0, 0, fmt.Errorf("invalid key path traversal: %s: %w", req.URL.Path, syscall.EBADMSG)
 	}
 
@@ -317,7 +317,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 	if req.Method == "GET" {
 		if m.store == nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The storage store is not initialized.", "")
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
 
@@ -334,7 +334,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			}
 			if err != nil {
 				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-				m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+				writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "Failed to list files.", "")
 				return 0, 0, fmt.Errorf("failed to list files: %w", err)
 			}
 
@@ -351,7 +351,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			xmlBytes, formatErr := FormatListObjectsV2XML(bucket, prefix, delimiter, maxKeys, files)
 			if formatErr != nil {
 				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-				m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+				writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Invalid list request parameters.", "")
 				return 0, 0, formatErr
 			}
 
@@ -378,10 +378,10 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		if err != nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			if err == syscall.ENOENT || os.IsNotExist(err) {
-				m.conn.Write([]byte("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+				writeS3Error(m.conn, http.StatusNotFound, "NoSuchKey", "The specified key does not exist.", key)
 				return 0, 0, ErrRequestHandled
 			}
-			m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The request failed due to an internal error.", key)
 			return 0, 0, fmt.Errorf("failed to get file %q: %w", key, err)
 		}
 		defer rc.Close()
@@ -426,20 +426,20 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 	if req.Method == "DELETE" {
 		if m.store == nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The storage store is not initialized.", "")
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
 
 		if key == "" {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Missing key in DELETE request.", "")
 			return 0, 0, fmt.Errorf("missing key in DELETE request")
 		}
 
 		if m.leaseAcquirer != nil {
 			if err := m.leaseAcquirer.AcquireLease(key, 10*time.Second); err != nil {
 				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-				m.conn.Write([]byte("HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+				writeS3Error(m.conn, http.StatusServiceUnavailable, "ServiceUnavailable", "The request could not be completed because the resource is locked by another request.", key)
 				return 0, 0, fmt.Errorf("failed to acquire lease for delete %q: %w", key, err)
 			}
 			defer m.leaseAcquirer.ReleaseLease(key)
@@ -448,7 +448,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		err := m.store.Delete(key)
 		if err != nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.conn.Write([]byte("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The request failed due to an internal error.", key)
 			return 0, 0, fmt.Errorf("failed to delete file %q: %w", key, err)
 		}
 
@@ -508,7 +508,8 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		rawPath := req.URL.Path
 		cleanPath := path.Clean(rawPath)
 		if cleanPath == "." || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") || cleanPath == "/" {
-			m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Invalid S3 path.", rawPath)
 			return 0, 0, fmt.Errorf("invalid S3 path: %s: %w", rawPath, syscall.EBADMSG)
 		}
 
@@ -521,7 +522,8 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 		// 🛡️ Sentinel: Sanitize S3 hash to prevent directory traversal via malicious metadata.
 		if m.meta.Hash != "" && common.HasPathTraversalChars(m.meta.Hash) {
-			m.conn.Write([]byte("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Invalid hash value.", "")
 			return 0, 0, fmt.Errorf("invalid hash: %s: %w", m.meta.Hash, syscall.EBADMSG)
 		}
 	}
@@ -1000,4 +1002,81 @@ func xmlEscape(buf *bytes.Buffer, s string) {
 		}
 		s = s[i+1:]
 	}
+}
+
+// s3ErrorCode maps an HTTP status to the S3 XML error Code used in error bodies.
+// https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+func s3ErrorCode(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "InvalidArgument"
+	case http.StatusForbidden:
+		return "AccessDenied"
+	case http.StatusNotFound:
+		return "NoSuchKey"
+	case http.StatusMethodNotAllowed:
+		return "MethodNotAllowed"
+	case http.StatusConflict:
+		return "BucketNotEmpty"
+	case http.StatusRequestEntityTooLarge:
+		return "EntityTooLarge"
+	case http.StatusUnsupportedMediaType:
+		return "InvalidRequest"
+	case http.StatusInternalServerError:
+		return "InternalError"
+	case http.StatusServiceUnavailable:
+		return "ServiceUnavailable"
+	default:
+		return "InternalError"
+	}
+}
+
+// writeS3Error writes an S3-compliant XML <Error> response body with the given
+// HTTP status, Code, Message, and optional Resource (bucket/key), followed by a
+// Content-Type: application/xml header and Content-Length matching the body.
+// It returns the number of bytes written. Callers set the write deadline first.
+func writeS3Error(w io.Writer, status int, code, message, resource string) (int, error) {
+	// 🛡️ Sentinel: Bound attacker-controlled message/resource lengths and strip
+	// CR/LF to prevent HTTP response splitting and oversized error bodies (Rule 24).
+	if len(message) > 512 {
+		message = message[:512]
+	}
+	message = strings.ReplaceAll(message, "\r", " ")
+	message = strings.ReplaceAll(message, "\n", " ")
+	if len(resource) > 1024 {
+		resource = resource[:1024]
+	}
+
+	var bodyBuf bytes.Buffer
+	bodyBuf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	bodyBuf.WriteString(`<Error>`)
+	bodyBuf.WriteString(`<Code>`)
+	xmlEscape(&bodyBuf, code)
+	bodyBuf.WriteString(`</Code><Message>`)
+	xmlEscape(&bodyBuf, message)
+	bodyBuf.WriteString(`</Message>`)
+	if resource != "" {
+		bodyBuf.WriteString(`<Resource>`)
+		xmlEscape(&bodyBuf, resource)
+		bodyBuf.WriteString(`</Resource>`)
+	}
+	bodyBuf.WriteString(`</Error>`)
+
+	var hdrBuf [256]byte
+	b := hdrBuf[:0]
+	b = append(b, "HTTP/1.1 "...)
+	b = strconv.AppendInt(b, int64(status), 10)
+	b = append(b, " "...)
+	b = append(b, http.StatusText(status)...)
+	b = append(b, "\r\nContent-Type: application/xml\r\nContent-Length: "...)
+	b = strconv.AppendInt(b, int64(bodyBuf.Len()), 10)
+	b = append(b, "\r\nConnection: close\r\n\r\n"...)
+
+	if _, err := w.Write(b); err != nil {
+		return 0, fmt.Errorf("failed to write S3 error headers: %v: %w", err, syscall.EPIPE)
+	}
+	if _, err := w.Write(bodyBuf.Bytes()); err != nil {
+		return 0, fmt.Errorf("failed to write S3 error body: %v: %w", err, syscall.EPIPE)
+	}
+	return len(b) + bodyBuf.Len(), nil
 }

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -340,7 +340,7 @@ func (m *mockStore) List() ([]common.FileMetadata, error) {
 	return nil, nil
 }
 
-func runS3TestRequest(t *testing.T, reqStr string, mock storage.Store) string {
+func runS3RequestCapture(t *testing.T, reqStr string, mock storage.Store) (string, error) {
 	expectedAuthToken := []byte(common.PadString("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", common.AuthTokenLength)) // notsecret
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -391,11 +391,16 @@ func runS3TestRequest(t *testing.T, reqStr string, mock storage.Store) string {
 	}
 
 	serverErr := <-errChan
+
+	return string(respBytes), serverErr
+}
+
+func runS3TestRequest(t *testing.T, reqStr string, mock storage.Store) string {
+	respStr, serverErr := runS3RequestCapture(t, reqStr, mock)
 	if serverErr != ErrRequestHandled {
 		t.Fatalf("Server expected ErrRequestHandled, got: %v", serverErr)
 	}
-
-	return string(respBytes)
+	return respStr
 }
 
 func TestS3Communicator_URLParsing(t *testing.T) {
@@ -842,4 +847,294 @@ func TestS3Communicator_SendMetadataPathTraversal(t *testing.T) {
 	if !errors.Is(err, syscall.EBADMSG) {
 		t.Errorf("Expected EBADMSG error, got: %v", err)
 	}
+}
+
+func TestWriteS3Error(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := writeS3Error(&buf, http.StatusNotFound, "NoSuchKey", "The specified key does not exist.", "mybucket/missing.txt")
+	if err != nil {
+		t.Fatalf("writeS3Error failed: %v", err)
+	}
+
+	respStr := buf.String()
+
+	if !strings.HasPrefix(respStr, "HTTP/1.1 404 Not Found\r\n") {
+		t.Errorf("Expected 404 status line, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Content-Type: application/xml\r\n") {
+		t.Errorf("Expected XML content type, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Connection: close\r\n") {
+		t.Errorf("Expected Connection: close header, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchKey</Code>") {
+		t.Errorf("Expected NoSuchKey code in body, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Message>The specified key does not exist.</Message>") {
+		t.Errorf("Expected message in body, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Resource>mybucket/missing.txt</Resource>") {
+		t.Errorf("Expected resource in body, got: %s", respStr)
+	}
+
+	// Content-Length must exactly match the XML body length.
+	headerEnd := strings.Index(respStr, "\r\n\r\n")
+	if headerEnd == -1 {
+		t.Fatalf("No header/body separator in response: %s", respStr)
+	}
+	bodyLen := len(respStr) - headerEnd - 4
+	clRe := regexp.MustCompile(`Content-Length: (\d+)`)
+	m := clRe.FindStringSubmatch(respStr)
+	if m == nil {
+		t.Fatalf("Content-Length header not found: %s", respStr)
+	}
+	cl, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("Content-Length not an integer: %v", err)
+	}
+	if cl != bodyLen {
+		t.Errorf("Content-Length (%d) must match body length (%d)", cl, bodyLen)
+	}
+
+	// n must equal the total bytes written (headers + body).
+	if n != len(respStr) {
+		t.Errorf("writeS3Error returned %d bytes but wrote %d", n, len(respStr))
+	}
+
+	// XML special characters must be escaped in attacker-controlled fields.
+	buf.Reset()
+	_, _ = writeS3Error(&buf, http.StatusBadRequest, "InvalidArgument", `bad <msg> & "quoted" 'single'`, `a<b&c>d`)
+	escaped := buf.String()
+	if strings.Contains(escaped, `<Message>bad <msg>`) {
+		t.Errorf("Message XML not escaped: %s", escaped)
+	}
+	if !strings.Contains(escaped, `<Message>bad &lt;msg&gt; &amp; &quot;quoted&quot; &apos;single&apos;</Message>`) {
+		t.Errorf("Message not escaped correctly: %s", escaped)
+	}
+	if !strings.Contains(escaped, `<Resource>a&lt;b&amp;c&gt;d</Resource>`) {
+		t.Errorf("Resource not escaped correctly: %s", escaped)
+	}
+
+	// CR/LF must be stripped to prevent HTTP response splitting.
+	buf.Reset()
+	_, _ = writeS3Error(&buf, http.StatusBadRequest, "InvalidArgument", "evil\r\nX-Injected: true\r\n", "")
+	stripped := buf.String()
+	if strings.Contains(stripped, "evil\r\n") {
+		t.Errorf("CR not stripped from message, response splitting possible: %s", stripped)
+	}
+	if strings.Contains(stripped, "true\r\n") {
+		t.Errorf("LF not stripped from message, response splitting possible: %s", stripped)
+	}
+	if !strings.Contains(stripped, "<Message>evil  X-Injected: true  </Message>") {
+		t.Errorf("Expected CR/LF replaced with spaces in message, got: %s", stripped)
+	}
+	// The response must contain exactly one header/body terminator.
+	if strings.Count(stripped, "\r\n\r\n") != 1 {
+		t.Errorf("Expected exactly one header/body separator, got: %s", stripped)
+	}
+
+	// Oversized messages are truncated to 512 bytes.
+	buf.Reset()
+	longMsg := strings.Repeat("a", 2048)
+	_, _ = writeS3Error(&buf, http.StatusBadRequest, "InvalidArgument", longMsg, "")
+	if !strings.Contains(buf.String(), strings.Repeat("a", 512)) {
+		t.Errorf("Expected message truncated to 512 bytes, got: %d", len(buf.String()))
+	}
+	if strings.Contains(buf.String(), strings.Repeat("a", 513)) {
+		t.Errorf("Message not truncated to 512 bytes")
+	}
+
+	// Resource is omitted when empty.
+	buf.Reset()
+	_, _ = writeS3Error(&buf, http.StatusForbidden, "AccessDenied", "Access Denied.", "")
+	if strings.Contains(buf.String(), "<Resource>") {
+		t.Errorf("Empty resource should be omitted, got: %s", buf.String())
+	}
+}
+
+func TestS3ErrorCodeMapping(t *testing.T) {
+	cases := []struct {
+		status int
+		code   string
+	}{
+		{http.StatusBadRequest, "InvalidArgument"},
+		{http.StatusForbidden, "AccessDenied"},
+		{http.StatusNotFound, "NoSuchKey"},
+		{http.StatusMethodNotAllowed, "MethodNotAllowed"},
+		{http.StatusConflict, "BucketNotEmpty"},
+		{http.StatusRequestEntityTooLarge, "EntityTooLarge"},
+		{http.StatusUnsupportedMediaType, "InvalidRequest"},
+		{http.StatusInternalServerError, "InternalError"},
+		{http.StatusServiceUnavailable, "ServiceUnavailable"},
+		{http.StatusGatewayTimeout, "InternalError"},
+	}
+	for _, tc := range cases {
+		if got := s3ErrorCode(tc.status); got != tc.code {
+			t.Errorf("s3ErrorCode(%d) = %q, want %q", tc.status, got, tc.code)
+		}
+	}
+}
+
+func TestS3Communicator_XMLErrorResponses(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	validTokenReq := func(method, target string) string {
+		return method + " " + target + " HTTP/1.1\r\n" +
+			"Host: 127.0.0.1:4440\r\n" +
+			"Authorization: Bearer " + authToken + "\r\n\r\n"
+	}
+
+	// 1. GET missing key -> 404 NoSuchKey
+	mock := &mockStore{
+		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+			return nil, common.FileMetadata{}, syscall.ENOENT
+		},
+	}
+	resp, serverErr := runS3RequestCapture(t, validTokenReq("GET", "/bucket/missing.txt"), mock)
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled for missing key, got: %v", serverErr)
+	}
+	if !strings.Contains(resp, "HTTP/1.1 404 Not Found") {
+		t.Errorf("Expected 404 Not Found, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>NoSuchKey</Code>") {
+		t.Errorf("Expected NoSuchKey XML error, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Resource>missing.txt</Resource>") {
+		t.Errorf("Expected missing.txt resource in error, got: %s", resp)
+	}
+
+	// 2. DELETE with no key -> 400 InvalidArgument
+	resp, serverErr = runS3RequestCapture(t, validTokenReq("DELETE", "/bucket"), &mockStore{})
+	if serverErr == nil {
+		t.Fatalf("Expected error for DELETE without key, got: %v", serverErr)
+	}
+	if !strings.Contains(resp, "HTTP/1.1 400 Bad Request") {
+		t.Errorf("Expected 400 Bad Request, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>InvalidArgument</Code>") {
+		t.Errorf("Expected InvalidArgument XML error, got: %s", resp)
+	}
+
+	// 3. Storage store not initialized -> 500 InternalError
+	resp, serverErr = runS3RequestCapture(t, validTokenReq("GET", "/bucket/file.txt"), nil)
+	if serverErr == nil {
+		t.Fatal("Expected error for nil store")
+	}
+	if !strings.Contains(resp, "HTTP/1.1 500 Internal Server Error") {
+		t.Errorf("Expected 500 Internal Server Error, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>InternalError</Code>") {
+		t.Errorf("Expected InternalError XML error, got: %s", resp)
+	}
+
+	// 4. Path traversal -> 400 InvalidArgument
+	resp, serverErr = runS3RequestCapture(t, validTokenReq("GET", "/bucket/../../etc/passwd"), &mockStore{})
+	if serverErr == nil || !errors.Is(serverErr, syscall.EBADMSG) {
+		t.Fatalf("Expected EBADMSG for path traversal, got: %v", serverErr)
+	}
+	if !strings.Contains(resp, "HTTP/1.1 400 Bad Request") {
+		t.Errorf("Expected 400 Bad Request, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>InvalidArgument</Code>") {
+		t.Errorf("Expected InvalidArgument XML error, got: %s", resp)
+	}
+}
+
+func TestS3Communicator_XMLErrorAuthFailures(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	// 1. Wrong bearer token -> 403 AccessDenied
+	wrongTokenReq := "PUT /bucket/file.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer wrong-token\r\n" +
+		"Content-Length: 0\r\n\r\n"
+
+	resp, serverErr := runS3RequestCapture(t, wrongTokenReq, &mockStore{})
+	if serverErr == nil || !errors.Is(serverErr, syscall.EACCES) {
+		t.Fatalf("Expected EACCES for wrong token, got: %v", serverErr)
+	}
+	if !strings.Contains(resp, "HTTP/1.1 403 Forbidden") {
+		t.Errorf("Expected 403 Forbidden, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>AccessDenied</Code>") {
+		t.Errorf("Expected AccessDenied XML error, got: %s", resp)
+	}
+
+	// 2. Malformed SigV4 header -> 403 AuthorizationHeaderMalformed
+	malformedAuthReq := "PUT /bucket/file.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: AWS4-HMAC-SHA256 this-is-not-a-valid-header\r\n" +
+		"X-Amz-Date: 20260604T120000Z\r\n" +
+		"Content-Length: 0\r\n\r\n"
+
+	resp, serverErr = runS3RequestCapture(t, malformedAuthReq, &mockStore{})
+	if serverErr == nil || !errors.Is(serverErr, syscall.EACCES) {
+		t.Fatalf("Expected EACCES for malformed SigV4, got: %v", serverErr)
+	}
+	if !strings.Contains(resp, "HTTP/1.1 403 Forbidden") {
+		t.Errorf("Expected 403 Forbidden, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>AuthorizationHeaderMalformed</Code>") {
+		t.Errorf("Expected AuthorizationHeaderMalformed XML error, got: %s", resp)
+	}
+
+	// 3. SigV4 with correct credentials but wrong signature -> 403 SignatureDoesNotMatch
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	region := "us-east-1"
+	payloadHash := "dummyhash"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := "PUT\n/bucket/file.txt\n\nhost:127.0.0.1:4440\nx-amz-content-sha256:" + payloadHash + "\nx-amz-date:" + amzDate + "\n\n" + signedHeaders + "\n" + payloadHash
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+	signingKey := deriveSigningKey(authToken, dateStamp, region)
+	goodSignature := computeSignature(signingKey, stringToSign)
+	badSignature := "0000" + goodSignature[4:]
+
+	authHeader := "AWS4-HMAC-SHA256 Credential=" + authToken + "/" + dateStamp + "/" + region + "/s3/aws4_request, SignedHeaders=" + signedHeaders + ", Signature=" + badSignature
+
+	badSigReq := "PUT /bucket/file.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: " + authHeader + "\r\n" +
+		"X-Amz-Date: " + amzDate + "\r\n" +
+		"X-Amz-Content-Sha256: " + payloadHash + "\r\n" +
+		"Content-Length: 0\r\n\r\n"
+
+	resp, serverErr = runS3RequestCapture(t, badSigReq, &mockStore{})
+	if serverErr == nil || !errors.Is(serverErr, syscall.EACCES) {
+		t.Fatalf("Expected EACCES for bad SigV4 signature, got: %v", serverErr)
+	}
+	if !strings.Contains(resp, "HTTP/1.1 403 Forbidden") {
+		t.Errorf("Expected 403 Forbidden, got: %s", resp)
+	}
+	if !strings.Contains(resp, "<Code>SignatureDoesNotMatch</Code>") {
+		t.Errorf("Expected SignatureDoesNotMatch XML error, got: %s", resp)
+	}
+
+	// 4. All error bodies must be well-formed XML (parse each captured response).
+	for _, r := range []string{
+		runCaptureReq(t, wrongTokenReq, &mockStore{}),
+		runCaptureReq(t, malformedAuthReq, &mockStore{}),
+		runCaptureReq(t, badSigReq, &mockStore{}),
+	} {
+		headerEnd := strings.Index(r, "\r\n\r\n")
+		if headerEnd == -1 {
+			t.Fatalf("Malformed HTTP response (no header terminator): %s", r)
+		}
+		body := r[headerEnd+4:]
+		if !strings.Contains(body, "<Error>") || !strings.Contains(body, "</Error>") {
+			t.Errorf("Error body is not an <Error> XML document: %s", body)
+		}
+	}
+}
+
+func runCaptureReq(t *testing.T, reqStr string, mock storage.Store) string {
+	resp, _ := runS3RequestCapture(t, reqStr, mock)
+	return resp
 }


### PR DESCRIPTION
Resolves #770

## Summary
Replaces all bare HTTP status-line error responses in `S3Communicator.HandshakeServer` with S3-compliant XML `<Error>` bodies so AWS SDKs and aws-cli surface actionable error codes (`AccessDenied`, `NoSuchKey`, `InvalidArgument`, `SignatureDoesNotMatch`, etc.) instead of opaque failures.

## Changes
- Added `writeS3Error(w, status, code, message, resource)` helper that writes `HTTP/1.1 <status>` + `Content-Type: application/xml` + exact `Content-Length` + `Connection: close` + XML `<Error><Code>…</Code><Message>…</Message><Resource>…</Resource></Error>`.
- Added `s3ErrorCode(status)` mapping per the AWS error-code reference.
- Rewired every rejection path in `HandshakeServer` (s3-tcp and s3-quic share this path):
  - malformed SigV4 header → 403 `AuthorizationHeaderMalformed`
  - wrong auth token → 403 `AccessDenied`
  - bad SigV4 signature → 403 `SignatureDoesNotMatch`
  - path traversal → 400 `InvalidArgument`
  - nil store → 500 `InternalError`
  - list failure → 500 `InternalError`; invalid list params → 400 `InvalidArgument`
  - GET missing key → 404 `NoSuchKey` (with `<Resource>`)
  - DELETE missing key → 400 `InvalidArgument`; lease lock → 503 `ServiceUnavailable`
  - PUT invalid path/hash → 400 `InvalidArgument`
- Existing status codes preserved; successful momo handshake framing untouched; native momo-tcp/quic protocols unaffected (no raw HTTP paths).

## Security
- Message/resource fields are length-bounded (512/1024) and CR/LF-stripped to prevent HTTP response splitting and oversized bodies (Rule 24).
- XML-escaping via existing `xmlEscape` for attacker-controlled `Code`/`Message`/`Resource`.

## Tests
- `TestWriteS3Error`: status line, content type, Content-Length matches body, byte-count return, XML escaping, CR/LF stripping, truncation, resource omission.
- `TestS3ErrorCodeMapping`: status→code map.
- `TestS3Communicator_XMLErrorResponses`: integration tests over real TCP asserting 404 NoSuchKey, 400 InvalidArgument (DELETE no-key, path traversal), 500 InternalError (nil store).
- `TestS3Communicator_XMLErrorAuthFailures`: 403 AccessDenied / AuthorizationHeaderMalformed / SignatureDoesNotMatch and well-formed `<Error>` body check.
- Refactored `runS3TestRequest` → `runS3RequestCapture` to expose the server-side error for assertion.

## Changelog
- S3 gateway errors now return S3-compliant XML bodies instead of bare status lines.
