### PR TITLE
feat: S3 HeadObject and HeadBucket support (HEAD requests)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2997,3 +2997,12 @@ c6829fc,BenchmarkSanitizeLog/Unsafe-8,837.80,704.00,1.00
 935577d,BenchmarkPadString-8,63.72,64.00,1.00
 935577d,BenchmarkSanitizeLog/Safe-8,474.70,0.00,0.00
 935577d,BenchmarkSanitizeLog/Unsafe-8,595.60,704.00,1.00
+97aec32,BenchmarkCheckMetricsAndSwap-8,8.56,0.00,0.00
+97aec32,BenchmarkCrushOptimized-8,370.40,0.00,0.00
+97aec32,BenchmarkCrushOriginal-8,506.70,164.00,3.00
+97aec32,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+97aec32,BenchmarkIndexSearch-8,2.06,0.00,0.00
+97aec32,BenchmarkLoadGlobalConfig-8,7642.00,1576.00,46.00
+97aec32,BenchmarkPadString-8,43.47,64.00,1.00
+97aec32,BenchmarkSanitizeLog/Safe-8,496.80,0.00,0.00
+97aec32,BenchmarkSanitizeLog/Unsafe-8,596.70,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -2988,3 +2988,12 @@ c6829fc,BenchmarkSanitizeLog/Unsafe-8,837.80,704.00,1.00
 90e806d,BenchmarkPadString-8,55.70,64.00,1.00
 90e806d,BenchmarkSanitizeLog/Safe-8,496.60,0.00,0.00
 90e806d,BenchmarkSanitizeLog/Unsafe-8,610.40,704.00,1.00
+935577d,BenchmarkCheckMetricsAndSwap-8,10.39,0.00,0.00
+935577d,BenchmarkCrushOptimized-8,426.30,0.00,0.00
+935577d,BenchmarkCrushOriginal-8,663.00,164.00,3.00
+935577d,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+935577d,BenchmarkIndexSearch-8,1.68,0.00,0.00
+935577d,BenchmarkLoadGlobalConfig-8,9618.00,1576.00,46.00
+935577d,BenchmarkPadString-8,63.72,64.00,1.00
+935577d,BenchmarkSanitizeLog/Safe-8,474.70,0.00,0.00
+935577d,BenchmarkSanitizeLog/Unsafe-8,595.60,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        949.4n ± ∞ ¹    663.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       549.2n ± ∞ ¹    426.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                    10.077µ ± ∞ ¹    9.618µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            55.70n ± ∞ ¹    63.72n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     496.6n ± ∞ ¹    474.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   610.4n ± ∞ ¹    595.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  10.62n ± ∞ ¹    10.39n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.730n ± ∞ ¹    1.683n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4342n ± ∞ ¹   0.3399n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                96.23n          87.19n        -9.40%
+CrushOriginal-8                        663.0n ± ∞ ¹    506.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       426.3n ± ∞ ¹    370.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     9.618µ ± ∞ ¹    7.642µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            63.72n ± ∞ ¹    43.47n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     474.7n ± ∞ ¹    496.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   595.6n ± ∞ ¹    596.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                 10.390n ± ∞ ¹    8.556n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.683n ± ∞ ¹    2.062n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3399n ± ∞ ¹   0.3778n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                87.19n          79.24n        -9.11%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 426.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 663.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.68 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9618.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 63.72 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 474.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 595.60 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.56 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 370.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 506.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7642.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 43.47 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 496.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 596.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d]
-    line "CheckMetricsAndSwap" [8,8,8,10,11,9,9,8,11,10]
-    line "CrushOptimized" [289,304,293,317,420,587,396,363,549,426]
-    line "CrushOriginal" [396,419,409,436,627,667,620,506,949,663]
-    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,3,2,2,2,2,2]
-    line "LoadGlobalConfig" [5474,6080,5863,5958,8220,8445,9134,7656,10077,9618]
-    line "PadString" [36,39,39,41,59,49,67,48,56,64]
+    x-axis [6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32]
+    line "CheckMetricsAndSwap" [8,8,10,11,9,9,8,11,10,9]
+    line "CrushOptimized" [304,293,317,420,587,396,363,549,426,370]
+    line "CrushOriginal" [419,409,436,627,667,620,506,949,663,507]
+    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,3,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [6080,5863,5958,8220,8445,9134,7656,10077,9618,7642]
+    line "PadString" [39,39,41,59,49,67,48,56,64,43]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [245,238,231,326,287,252,342,470,497,475]
-    line "SanitizeLog/Unsafe" [640,671,675,1095,866,989,838,634,610,596]
+    line "SanitizeLog/Safe" [238,231,326,287,252,342,470,497,475,497]
+    line "SanitizeLog/Unsafe" [671,675,1095,866,989,838,634,610,596,597]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d]
+    x-axis [6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1576,1576,1576]
+    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1576,1576,1576,1576]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d]
+    x-axis [6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [38,38,38,38,38,38,38,46,46,46]
+    line "LoadGlobalConfig" [38,38,38,38,38,38,46,46,46,46]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,18 +37,18 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                      │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                        505.6n ± ∞ ¹    949.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                       362.9n ± ∞ ¹    549.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.656µ ± ∞ ¹   10.077µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                            47.53n ± ∞ ¹    55.70n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     469.5n ± ∞ ¹    496.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   634.4n ± ∞ ¹    610.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.496n ± ∞ ¹   10.620n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.028n ± ∞ ¹    1.730n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.4093n ± ∞ ¹   0.4342n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                80.39n          96.23n        +19.70%
+                      │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                      │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                        949.4n ± ∞ ¹    663.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       549.2n ± ∞ ¹    426.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                    10.077µ ± ∞ ¹    9.618µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            55.70n ± ∞ ¹    63.72n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     496.6n ± ∞ ¹    474.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   610.4n ± ∞ ¹    595.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  10.62n ± ∞ ¹    10.39n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.730n ± ∞ ¹    1.683n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4342n ± ∞ ¹   0.3399n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                96.23n          87.19n        -9.40%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 10.62 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 549.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 949.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.43 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.73 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 10077.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 55.70 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 496.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 610.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.39 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 426.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 663.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.68 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9618.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 63.72 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 474.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 595.60 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d]
-    line "CheckMetricsAndSwap" [9,8,8,8,10,11,9,9,8,11]
-    line "CrushOptimized" [300,289,304,293,317,420,587,396,363,549]
-    line "CrushOriginal" [443,396,419,409,436,627,667,620,506,949]
-    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,3,2,2,2,2]
-    line "LoadGlobalConfig" [5683,5474,6080,5863,5958,8220,8445,9134,7656,10077]
-    line "PadString" [39,36,39,39,41,59,49,67,48,56]
+    x-axis [bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d]
+    line "CheckMetricsAndSwap" [8,8,8,10,11,9,9,8,11,10]
+    line "CrushOptimized" [289,304,293,317,420,587,396,363,549,426]
+    line "CrushOriginal" [396,419,409,436,627,667,620,506,949,663]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
+    line "IndexSearch" [2,2,2,2,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [5474,6080,5863,5958,8220,8445,9134,7656,10077,9618]
+    line "PadString" [36,39,39,41,59,49,67,48,56,64]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [222,245,238,231,326,287,252,342,470,497]
-    line "SanitizeLog/Unsafe" [710,640,671,675,1095,866,989,838,634,610]
+    line "SanitizeLog/Safe" [245,238,231,326,287,252,342,470,497,475]
+    line "SanitizeLog/Unsafe" [640,671,675,1095,866,989,838,634,610,596]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d]
+    x-axis [bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1320,1576,1576]
+    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1320,1576,1576,1576]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [a8e6bbc,bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d]
+    x-axis [bd016ee,6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [38,38,38,38,38,38,38,38,46,46]
+    line "LoadGlobalConfig" [38,38,38,38,38,38,38,46,46,46]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -422,6 +422,55 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		return 0, 0, ErrRequestHandled
 	}
 
+	// Intercept HEAD requests (HeadObject or HeadBucket). HEAD is a read-only
+	// metadata operation and must bypass momo framing (issue #765).
+	if req.Method == "HEAD" {
+		if m.store == nil {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The storage store is not initialized.", "")
+			return 0, 0, fmt.Errorf("storage store not initialized")
+		}
+
+		if key == "" {
+			// HEAD / -> endpoint/liveness check; HEAD /bucket -> HeadBucket.
+			// momo uses a bucket-less model (no bucket registry yet, issue #767),
+			// so a configured store implies the bucket exists.
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			m.conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
+			return 0, 0, ErrRequestHandled
+		}
+
+		// HeadObject: reuse store.Get metadata so HEAD and GET agree on ETag/Last-Modified.
+		rc, meta, err := m.store.Get(key)
+		if err != nil {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if err == syscall.ENOENT || os.IsNotExist(err) {
+				writeS3Error(m.conn, http.StatusNotFound, "NoSuchKey", "The specified key does not exist.", key)
+				return 0, 0, ErrRequestHandled
+			}
+			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The request failed due to an internal error.", key)
+			return 0, 0, fmt.Errorf("failed to head file %q: %w", key, err)
+		}
+		rc.Close()
+
+		// ⚡ Bolt: stack-buffer direct write for the header-only response (no body).
+		var buf [256]byte
+		b := buf[:0]
+		b = append(b, "HTTP/1.1 200 OK\r\nETag: \""...)
+		b = append(b, meta.Hash...)
+		b = append(b, "\"\r\nContent-Length: "...)
+		b = strconv.AppendInt(b, meta.Size, 10)
+		b = append(b, "\r\nLast-Modified: "...)
+		b = append(b, formatHTTPLastModified(meta.ModTime)...)
+		b = append(b, "\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n"...)
+
+		if _, err := m.conn.Write(b); err != nil {
+			return 0, 0, fmt.Errorf("failed to write HEAD response: %v: %w", err, syscall.EPIPE)
+		}
+
+		return 0, 0, ErrRequestHandled
+	}
+
 	// Intercept DELETE requests
 	if req.Method == "DELETE" {
 		if m.store == nil {
@@ -860,6 +909,14 @@ func extractS3BucketAndKey(req *http.Request) (bucket string, key string) {
 // A zero timestamp (unknown/modern fallback) renders as the Unix epoch.
 func formatLastModified(modTime int64) string {
 	return time.Unix(0, modTime).UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+// formatHTTPLastModified renders a Unix-nano modification time as an
+// HTTP IMF-fixdate header value (RFC 7231), which AWS SDKs and aws-cli
+// parse for the Last-Modified response header. A zero timestamp renders
+// as the Unix epoch.
+func formatHTTPLastModified(modTime int64) string {
+	return time.Unix(0, modTime).UTC().Format(http.TimeFormat)
 }
 
 // FormatListObjectsV2XML constructs an S3-compliant ListObjectsV2 XML response

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -425,6 +425,14 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 	// Intercept HEAD requests (HeadObject or HeadBucket). HEAD is a read-only
 	// metadata operation and must bypass momo framing (issue #765).
 	if req.Method == "HEAD" {
+		// 🛡️ Rule 37: Zero-Crash recovery for the HEAD interception block.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("CRITICAL: Panic recovered in S3 HEAD interceptor: %v", r)
+				err = fmt.Errorf("internal S3 HEAD panic: %w", syscall.EIO)
+			}
+		}()
+
 		if m.store == nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "The storage store is not initialized.", "")

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -714,6 +714,192 @@ func TestS3Communicator_DELETE(t *testing.T) {
 	}
 }
 
+func TestS3Communicator_HEAD_HeadObject(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	reqStr := "HEAD /bucket/hello.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	fileContent := []byte("hello s3 download!")
+	modTime := int64(1700000000123456789)
+	mock := &mockStore{
+		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+			if name != "hello.txt" {
+				return nil, common.FileMetadata{}, syscall.ENOENT
+			}
+			return io.NopCloser(bytes.NewReader(fileContent)), common.FileMetadata{
+				Name:    "hello.txt",
+				Hash:    "abc123def456",
+				Size:    int64(len(fileContent)),
+				ModTime: modTime,
+			}, nil
+		},
+	}
+
+	respStr := runS3TestRequest(t, reqStr, mock)
+
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "ETag: \"abc123def456\"") {
+		t.Errorf("Expected quoted ETag, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Content-Length: 18") {
+		t.Errorf("Expected Content-Length matching object size, got: %s", respStr)
+	}
+	// Last-Modified must be IMF-fixdate (RFC 7231) so aws-cli/SDKs can parse it.
+	if !strings.Contains(respStr, "Last-Modified: Tue, 14 Nov 2023 22:13:20 GMT") {
+		t.Errorf("Expected IMF-fixdate Last-Modified, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Content-Type: application/octet-stream") {
+		t.Errorf("Expected Content-Type header, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Connection: close") {
+		t.Errorf("Expected Connection: close, got: %s", respStr)
+	}
+
+	// HEAD must be header-only: no message body after the header terminator.
+	headerEnd := strings.Index(respStr, "\r\n\r\n")
+	if headerEnd == -1 {
+		t.Fatalf("Malformed HTTP response: %s", respStr)
+	}
+	if body := respStr[headerEnd+4:]; body != "" {
+		t.Errorf("HEAD must have no body, got: %q", body)
+	}
+
+	// ETag formatting must match GetObject exactly (same metadata source).
+	// Both quoted with the hash from store.Get.
+	etagMatch := regexp.MustCompile(`ETag: "([^"]*)"`).FindStringSubmatch(respStr)
+	if etagMatch == nil || etagMatch[1] != "abc123def456" {
+		t.Errorf("Expected ETag to equal store hash, got: %v", etagMatch)
+	}
+}
+
+func TestS3Communicator_HEAD_MissingObject(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	reqStr := "HEAD /bucket/missing.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	mock := &mockStore{
+		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+			return nil, common.FileMetadata{}, syscall.ENOENT
+		},
+	}
+
+	respStr := runS3TestRequest(t, reqStr, mock)
+
+	if !strings.Contains(respStr, "HTTP/1.1 404 Not Found") {
+		t.Errorf("Expected 404 Not Found, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchKey</Code>") {
+		t.Errorf("Expected NoSuchKey XML error, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Resource>missing.txt</Resource>") {
+		t.Errorf("Expected missing.txt resource, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_HEAD_HeadBucket(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	// HeadBucket via path-style (key empty).
+	reqStr := "HEAD /mybucket HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	respStr := runS3TestRequest(t, reqStr, &mockStore{})
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK for HeadBucket, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Content-Length: 0") {
+		t.Errorf("Expected zero-length body for HeadBucket, got: %s", respStr)
+	}
+
+	// Endpoint liveness check: HEAD / with empty bucket.
+	reqStrRoot := "HEAD / HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	respStrRoot := runS3TestRequest(t, reqStrRoot, &mockStore{})
+	if !strings.Contains(respStrRoot, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK for HEAD /, got: %s", respStrRoot)
+	}
+
+	// Nil store -> 500 InternalError.
+	respErr, serverErr := runS3RequestCapture(t, reqStr, nil)
+	if serverErr == nil {
+		t.Fatal("Expected error for nil store")
+	}
+	if !strings.Contains(respErr, "HTTP/1.1 500 Internal Server Error") {
+		t.Errorf("Expected 500 for nil store, got: %s", respErr)
+	}
+	if !strings.Contains(respErr, "<Code>InternalError</Code>") {
+		t.Errorf("Expected InternalError XML error, got: %s", respErr)
+	}
+}
+
+func TestS3Communicator_HEAD_SigV4Auth(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	region := "us-east-1"
+	payloadHash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" // sha256("")
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := "HEAD\n/bucket/hello.txt\n\nhost:127.0.0.1:4440\nx-amz-content-sha256:" + payloadHash + "\nx-amz-date:" + amzDate + "\n\n" + signedHeaders + "\n" + payloadHash
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+	signingKey := deriveSigningKey(authToken, dateStamp, region)
+	signature := computeSignature(signingKey, stringToSign)
+
+	authHeader := "AWS4-HMAC-SHA256 Credential=" + authToken + "/" + dateStamp + "/" + region + "/s3/aws4_request, SignedHeaders=" + signedHeaders + ", Signature=" + signature
+
+	reqBody := "HEAD /bucket/hello.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: " + authHeader + "\r\n" +
+		"X-Amz-Date: " + amzDate + "\r\n" +
+		"X-Amz-Content-Sha256: " + payloadHash + "\r\n\r\n"
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		clientConn.Write([]byte(reqBody))
+		buf := make([]byte, 1024)
+		for {
+			_, err := clientConn.Read(buf)
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	mock := &mockStore{
+		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+			return io.NopCloser(bytes.NewReader([]byte("data"))), common.FileMetadata{Name: "hello.txt", Hash: "hash1", Size: 4}, nil
+		},
+	}
+
+	comm := NewS3Communicator(serverConn)
+	comm.SetStore(mock)
+	_, _, err := comm.HandshakeServer(expectedAuthToken)
+	if err != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled for HEAD with SigV4, got: %v", err)
+	}
+}
+
 func TestS3Communicator_HandshakeClient_CRLFInjection(t *testing.T) {
 	defer verifyNoLeaks(t)
 


### PR DESCRIPTION
Resolves #765

## Summary
Adds a `HEAD` interception branch to `S3Communicator.HandshakeServer` (between the GET and DELETE branches) so aws-cli `ls`/`stat`/`sync` and SDK HeadObject/HeadBucket/preflight calls work instead of falling through to momo PUT framing.

## Changes
- `HEAD /bucket/key` → HeadObject: header-only `200 OK` with `ETag: "<hash>"`, `Content-Length: <size>`, `Last-Modified`, `Content-Type: application/octet-stream`, `Connection: close`, no body.
- `HEAD /bucket` → HeadBucket: `200 OK` (bucket-less model; store configured implies bucket exists — real registry lands in #767).
- `HEAD /` → endpoint/liveness check: `200 OK`.
- Missing object → `404 Not Found` with S3 XML `NoSuchKey` body (reusing #770's `writeS3Error`); nil store → `500 InternalError`.
- HeadObject reuses `store.Get` metadata so HEAD and GET agree on ETag/Last-Modified; reader is closed immediately (metadata-only).
- Added `formatHTTPLastModified` (IMF-fixdate / RFC 7231) for the `Last-Modified` HTTP header — required for aws-cli/SDK date parsing (the S3 XML `formatLastModified` form would break botocore parsing).
- HEAD uses the intercept-and-respond path (bypasses momo framing, returns `ErrRequestHandled`) and is identical on s3-tcp and s3-quic.

## Tests
- `TestS3Communicator_HEAD_HeadObject`: 200, quoted ETag, size, IMF-fixdate Last-Modified, header-only (no body).
- `TestS3Communicator_HEAD_MissingObject`: 404 + `NoSuchKey` XML.
- `TestS3Communicator_HEAD_HeadBucket`: path-style bucket, `HEAD /` liveness, nil store → 500.
- `TestS3Communicator_HEAD_SigV4Auth`: HEAD signed with AWS SigV4 is accepted.

## Changelog
- Added HeadObject and HeadBucket support via S3 HEAD requests.
