### PR TITLE
feat: S3 bucket management operations

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3006,3 +3006,12 @@ c6829fc,BenchmarkSanitizeLog/Unsafe-8,837.80,704.00,1.00
 97aec32,BenchmarkPadString-8,43.47,64.00,1.00
 97aec32,BenchmarkSanitizeLog/Safe-8,496.80,0.00,0.00
 97aec32,BenchmarkSanitizeLog/Unsafe-8,596.70,704.00,1.00
+a2c936b,BenchmarkCheckMetricsAndSwap-8,8.45,0.00,0.00
+a2c936b,BenchmarkCrushOptimized-8,350.30,0.00,0.00
+a2c936b,BenchmarkCrushOriginal-8,478.60,164.00,3.00
+a2c936b,BenchmarkIndexDirectTracking-8,0.40,0.00,0.00
+a2c936b,BenchmarkIndexSearch-8,2.00,0.00,0.00
+a2c936b,BenchmarkLoadGlobalConfig-8,7622.00,1576.00,46.00
+a2c936b,BenchmarkPadString-8,59.75,64.00,1.00
+a2c936b,BenchmarkSanitizeLog/Safe-8,537.10,0.00,0.00
+a2c936b,BenchmarkSanitizeLog/Unsafe-8,732.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        663.0n ± ∞ ¹    506.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       426.3n ± ∞ ¹    370.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     9.618µ ± ∞ ¹    7.642µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            63.72n ± ∞ ¹    43.47n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     474.7n ± ∞ ¹    496.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   595.6n ± ∞ ¹    596.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                 10.390n ± ∞ ¹    8.556n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          1.683n ± ∞ ¹    2.062n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3399n ± ∞ ¹   0.3778n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                87.19n          79.24n        -9.11%
+CrushOriginal-8                        506.7n ± ∞ ¹    478.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       370.4n ± ∞ ¹    350.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.642µ ± ∞ ¹    7.622µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            43.47n ± ∞ ¹    59.75n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     496.8n ± ∞ ¹    537.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   596.7n ± ∞ ¹    732.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.556n ± ∞ ¹    8.453n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          2.062n ± ∞ ¹    1.997n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.3778n ± ∞ ¹   0.4009n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                79.24n          83.77n        +5.72%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 370.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 506.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.06 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7642.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 43.47 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 496.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 596.70 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.45 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 350.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 478.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7622.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 59.75 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 537.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 732.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32]
-    line "CheckMetricsAndSwap" [8,8,10,11,9,9,8,11,10,9]
-    line "CrushOptimized" [304,293,317,420,587,396,363,549,426,370]
-    line "CrushOriginal" [419,409,436,627,667,620,506,949,663,507]
-    line "IndexDirectTracking" [0,0,0,1,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,3,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [6080,5863,5958,8220,8445,9134,7656,10077,9618,7642]
-    line "PadString" [39,39,41,59,49,67,48,56,64,43]
+    x-axis [8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b]
+    line "CheckMetricsAndSwap" [8,10,11,9,9,8,11,10,9,8]
+    line "CrushOptimized" [293,317,420,587,396,363,549,426,370,350]
+    line "CrushOriginal" [409,436,627,667,620,506,949,663,507,479]
+    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,2,3,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [5863,5958,8220,8445,9134,7656,10077,9618,7642,7622]
+    line "PadString" [39,41,59,49,67,48,56,64,43,60]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [238,231,326,287,252,342,470,497,475,497]
-    line "SanitizeLog/Unsafe" [671,675,1095,866,989,838,634,610,596,597]
+    line "SanitizeLog/Safe" [231,326,287,252,342,470,497,475,497,537]
+    line "SanitizeLog/Unsafe" [675,1095,866,989,838,634,610,596,597,732]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32]
+    x-axis [8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1320,1576,1576,1576,1576]
+    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1576,1576,1576,1576,1576]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6e7bf28,8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32]
+    x-axis [8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [38,38,38,38,38,38,46,46,46,46]
+    line "LoadGlobalConfig" [38,38,38,38,38,46,46,46,46,46]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -288,7 +288,11 @@ When a standard S3 tool connects to Momo, it communicates via raw, standard S3 H
 **Step-by-step Flow:**
 1.  **Request Arrival:** The standard client makes an S3 request (e.g., `GET /?list-type=2` for listing, `GET /bucket/file.txt` for downloads, or `DELETE /bucket/file.txt` for deletion) containing standard AWS-HMAC-SHA256 headers.
 2.  **Handshake Interception:** The server accepts the socket and calls `comm.HandshakeServer(expectedAuthToken)`. S3Communicator reads the HTTP request, parses and validates the token.
-3.  **REST Query Routing:** Because the request method is `GET` or `DELETE`, S3Communicator detects it as a REST query and **bypasses standard Momo framing**:
+3.  **REST Query Routing:** Because the request method is `GET`, `HEAD`, or `DELETE`, S3Communicator detects it as a REST query and **bypasses standard Momo framing**:
+    -   **ListBuckets:** `GET /` queries the configured single bucket (from the `[storage] s3_bucket` setting) and returns an S3-compliant `<ListAllMyBucketsResult>`. With no bucket configured (legacy flat mode), it returns an empty bucket list.
+    -   **HeadBucket / HeadObject:** `HEAD /bucket` returns `200 OK` (or `404 NoSuchBucket` outside the configured bucket); `HEAD /bucket/key` returns headers-only `200 OK` with `ETag`, `Content-Length`, and `Last-Modified`, or `404 NoSuchKey`.
+    -   **CreateBucket / DeleteBucket:** `PUT /bucket` returns `200 OK` with a `<LocationConstraint>` body for the configured bucket (bucket semantics require `s3_bucket` to be set); `DELETE /bucket` returns `204 No Content` when the store is empty or `409 BucketNotEmpty` otherwise.
+    -   **GetBucketLocation:** `GET /bucket?location` returns `200 OK` with a `<LocationConstraint/>` body.
     -   **ListObjectsV2:** Queries `store.List()`, formats the file list into S3-compliant XML using a high-performance allocation-free `bytes.Buffer`, writes `200 OK` back to the client, and returns `ErrRequestHandled`.
     -   **GetObject:** Queries `store.Get(key)`, streams the binary content directly to the client, and returns `ErrRequestHandled`.
     -   **DeleteObject:** Invokes `store.Delete(key)` on BoltDB, writes a `204 No Content` response, and returns `ErrRequestHandled`.

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -197,6 +197,11 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				s3Comm.SetStore(store)
 			}
 
+			// Inject the configured S3 bucket name for bucket-management operations
+			if bcComm, ok := comm.(interface{ SetConfiguredBucket(string) }); ok {
+				bcComm.SetConfiguredBucket(cfg.Storage.S3Bucket)
+			}
+
 			// Inject metrics hook for download/delete/error instrumentation
 			if mhComm, ok := comm.(interface{ SetMetricsHook(transport.MetricsHook) }); ok {
 				mhComm.SetMetricsHook(metricsCollector)

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -74,6 +74,11 @@ type S3Communicator struct {
 	// Storage store for list, get, and delete operations
 	store storage.Store
 
+	// configuredBucket is the single bucket name exposed by the S3 gateway for
+	// bucket-management operations (issue #767). Empty means legacy flat
+	// namespace mode where no bucket semantics are enforced.
+	configuredBucket string
+
 	// GlobalLister for scatter-gather list queries (optional)
 	globalLister GlobalLister
 	// LeaseAcquirer for lease-based consensus on deletes (optional)
@@ -98,6 +103,29 @@ func NewS3Communicator(conn net.Conn) *S3Communicator {
 
 func (m *S3Communicator) SetStore(store storage.Store) {
 	m.store = store
+}
+
+// SetConfiguredBucket sets the single bucket name exposed by the S3 gateway for
+// bucket-management operations (issue #767). An empty value disables bucket
+// semantics (legacy flat namespace mode).
+func (m *S3Communicator) SetConfiguredBucket(bucket string) {
+	m.configuredBucket = bucket
+}
+
+// validBucket reports whether the addressed bucket name is acceptable under the
+// single-bucket policy. When no bucket is configured (legacy flat mode), any
+// bucket name is accepted.
+func (m *S3Communicator) validBucket(bucket string) bool {
+	return m.configuredBucket == "" || bucket == m.configuredBucket
+}
+
+// listFiles returns the files in the store, using scatter-gather when available
+// so DeleteBucket emptiness checks agree with ListObjectsV2.
+func (m *S3Communicator) listFiles(timeout time.Duration) ([]common.FileMetadata, error) {
+	if m.globalLister != nil {
+		return m.globalLister.GlobalList(timeout)
+	}
+	return m.store.List()
 }
 
 // SetGlobalLister sets the scatter-gather list capability.
@@ -313,7 +341,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 	bucket, key := extractS3BucketAndKey(req)
 
-	// Intercept GET requests (for ListObjectsV2 or GetObject)
+	// Intercept GET requests (for ListObjectsV2, ListBuckets, GetBucketLocation, or GetObject)
 	if req.Method == "GET" {
 		if m.store == nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
@@ -321,17 +349,63 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			return 0, 0, fmt.Errorf("storage store not initialized")
 		}
 
-		// ListObjectsV2 (is list if key is empty, or if list-type query is 2)
 		q := req.URL.Query()
+
+		// GET / -> ListBuckets (root, no bucket addressed, no list-type).
+		// ?list-type=2 on root keeps the legacy flat-namespace list-all path.
+		if bucket == "" && q.Get("list-type") == "" {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			var buf [256]byte
+			b := buf[:0]
+			xmlBytes := FormatListBucketsXML(m.configuredBucket)
+			b = append(b, "HTTP/1.1 200 OK\r\nContent-Type: application/xml\r\nContent-Length: "...)
+			b = strconv.AppendInt(b, int64(len(xmlBytes)), 10)
+			b = append(b, "\r\nConnection: close\r\n\r\n"...)
+			if _, err := m.conn.Write(b); err != nil {
+				return 0, 0, fmt.Errorf("failed to write ListBuckets headers: %v: %w", err, syscall.EPIPE)
+			}
+			if _, err := m.conn.Write(xmlBytes); err != nil {
+				return 0, 0, fmt.Errorf("failed to write ListBuckets body: %v: %w", err, syscall.EPIPE)
+			}
+			return 0, 0, ErrRequestHandled
+		}
+
+		// GET /bucket?location -> GetBucketLocation (bucket root, location param present).
+		if key == "" {
+			if _, hasLocation := q["location"]; hasLocation {
+				if !m.validBucket(bucket) {
+					m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+					writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+					return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+				}
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				var buf [256]byte
+				b := buf[:0]
+				xmlBytes := FormatGetBucketLocationXML("")
+				b = append(b, "HTTP/1.1 200 OK\r\nContent-Type: application/xml\r\nContent-Length: "...)
+				b = strconv.AppendInt(b, int64(len(xmlBytes)), 10)
+				b = append(b, "\r\nConnection: close\r\n\r\n"...)
+				if _, err := m.conn.Write(b); err != nil {
+					return 0, 0, fmt.Errorf("failed to write GetBucketLocation headers: %v: %w", err, syscall.EPIPE)
+				}
+				if _, err := m.conn.Write(xmlBytes); err != nil {
+					return 0, 0, fmt.Errorf("failed to write GetBucketLocation body: %v: %w", err, syscall.EPIPE)
+				}
+				return 0, 0, ErrRequestHandled
+			}
+		}
+
+		// ListObjectsV2 (is list if key is empty, or if list-type query is 2)
 		isList := (key == "") || (q.Get("list-type") == "2")
 
 		if isList {
-			var files []common.FileMetadata
-			if m.globalLister != nil {
-				files, err = m.globalLister.GlobalList(5 * time.Second)
-			} else {
-				files, err = m.store.List()
+			if !m.validBucket(bucket) {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+				return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
 			}
+
+			files, err := m.listFiles(5 * time.Second)
 			if err != nil {
 				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "Failed to list files.", "")
@@ -374,6 +448,11 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		}
 
 		// GetObject (file download)
+		if !m.validBucket(bucket) {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+			return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+		}
 		rc, meta, err := m.store.Get(key)
 		if err != nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
@@ -443,12 +522,22 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			// HEAD / -> endpoint/liveness check; HEAD /bucket -> HeadBucket.
 			// momo uses a bucket-less model (no bucket registry yet, issue #767),
 			// so a configured store implies the bucket exists.
+			if bucket != "" && !m.validBucket(bucket) {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+				return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+			}
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			m.conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"))
 			return 0, 0, ErrRequestHandled
 		}
 
 		// HeadObject: reuse store.Get metadata so HEAD and GET agree on ETag/Last-Modified.
+		if !m.validBucket(bucket) {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+			return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+		}
 		rc, meta, err := m.store.Get(key)
 		if err != nil {
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
@@ -488,9 +577,40 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		}
 
 		if key == "" {
+			if m.configuredBucket == "" {
+				// Legacy flat mode: no bucket semantics, preserve existing behavior.
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Missing key in DELETE request.", "")
+				return 0, 0, fmt.Errorf("missing key in DELETE request")
+			}
+
+			// Bucket mode: DeleteBucket (204, or 409 BucketNotEmpty if the
+			// store still holds objects). Honest single-bucket semantics.
+			if !m.validBucket(bucket) {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+				return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+			}
+			files, err := m.listFiles(5 * time.Second)
+			if err != nil {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusInternalServerError, "InternalError", "Failed to list files.", "")
+				return 0, 0, fmt.Errorf("failed to list files for DeleteBucket: %w", err)
+			}
+			if len(files) > 0 {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusConflict, "BucketNotEmpty", "The bucket you tried to delete is not empty.", bucket)
+				return 0, 0, fmt.Errorf("bucket %q is not empty: %w", bucket, syscall.ENOTEMPTY)
+			}
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Missing key in DELETE request.", "")
-			return 0, 0, fmt.Errorf("missing key in DELETE request")
+			m.conn.Write([]byte("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"))
+			return 0, 0, ErrRequestHandled
+		}
+
+		if !m.validBucket(bucket) {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+			return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
 		}
 
 		if m.leaseAcquirer != nil {
@@ -561,6 +681,40 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 	// Parse Metadata if it's a PUT request
 	if req.Method == "PUT" {
+		// CreateBucket: PUT to a bucket root (key empty) in bucket mode.
+		// Legacy flat mode (no configured bucket) keeps the upload behavior.
+		if m.configuredBucket != "" && key == "" {
+			if !m.validBucket(bucket) {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+				return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+			}
+			// CreateBucket succeeds for the configured bucket: 200 + LocationConstraint.
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			var buf [256]byte
+			b := buf[:0]
+			xmlBytes := FormatGetBucketLocationXML("")
+			b = append(b, "HTTP/1.1 200 OK\r\nLocation: /"...)
+			b = append(b, m.configuredBucket...)
+			b = append(b, "\r\nContent-Type: application/xml\r\nContent-Length: "...)
+			b = strconv.AppendInt(b, int64(len(xmlBytes)), 10)
+			b = append(b, "\r\nConnection: close\r\n\r\n"...)
+			if _, err := m.conn.Write(b); err != nil {
+				return 0, 0, fmt.Errorf("failed to write CreateBucket headers: %v: %w", err, syscall.EPIPE)
+			}
+			if _, err := m.conn.Write(xmlBytes); err != nil {
+				return 0, 0, fmt.Errorf("failed to write CreateBucket body: %v: %w", err, syscall.EPIPE)
+			}
+			return 0, 0, ErrRequestHandled
+		}
+
+		// Object upload: enforce the single-bucket policy when configured.
+		if !m.validBucket(bucket) {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusNotFound, "NoSuchBucket", "The specified bucket does not exist.", bucket)
+			return 0, 0, fmt.Errorf("unknown bucket %q: %w", bucket, syscall.ENOENT)
+		}
+
 		// 🛡️ Sentinel: Sanitize S3 path to prevent traversal attacks.
 		rawPath := req.URL.Path
 		cleanPath := path.Clean(rawPath)
@@ -570,7 +724,14 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			return 0, 0, fmt.Errorf("invalid S3 path: %s: %w", rawPath, syscall.EBADMSG)
 		}
 
-		m.meta.Name = strings.TrimPrefix(cleanPath, "/")
+		// Object name: in bucket mode store the bucket-relative key so GET/HEAD/DELETE
+		// (which extract the key without the bucket) resolve the same object. Legacy
+		// flat mode keeps the full cleaned path as the object name.
+		if m.configuredBucket != "" {
+			m.meta.Name = key
+		} else {
+			m.meta.Name = strings.TrimPrefix(cleanPath, "/")
+		}
 		m.meta.Size = req.ContentLength
 		m.meta.Hash = req.Header.Get("X-Amz-Content-Sha256")
 		if m.meta.Hash == "" {
@@ -925,6 +1086,34 @@ func formatLastModified(modTime int64) string {
 // as the Unix epoch.
 func formatHTTPLastModified(modTime int64) string {
 	return time.Unix(0, modTime).UTC().Format(http.TimeFormat)
+}
+
+// FormatListBucketsXML constructs an S3-compliant ListBuckets
+// (ListAllMyBucketsResult) XML response listing the configured single bucket.
+// An empty configuredBucket yields an empty bucket list (legacy flat mode).
+func FormatListBucketsXML(configuredBucket string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	buf.WriteString(`<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>momo</ID><DisplayName>momo</DisplayName></Owner><Buckets>`)
+	if configuredBucket != "" {
+		buf.WriteString(`<Bucket><Name>`)
+		xmlEscape(&buf, configuredBucket)
+		buf.WriteString(`</Name><CreationDate>2024-01-01T00:00:00.000Z</CreationDate></Bucket>`)
+	}
+	buf.WriteString(`</Buckets></ListAllMyBucketsResult>`)
+	return buf.Bytes()
+}
+
+// FormatGetBucketLocationXML constructs an S3-compliant GetBucketLocation
+// response. An empty region (us-east-1) is represented by an empty
+// LocationConstraint element.
+func FormatGetBucketLocationXML(region string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	buf.WriteString(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
+	xmlEscape(&buf, region)
+	buf.WriteString(`</LocationConstraint>`)
+	return buf.Bytes()
 }
 
 // FormatListObjectsV2XML constructs an S3-compliant ListObjectsV2 XML response

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -341,6 +341,10 @@ func (m *mockStore) List() ([]common.FileMetadata, error) {
 }
 
 func runS3RequestCapture(t *testing.T, reqStr string, mock storage.Store) (string, error) {
+	return runS3RequestCaptureBucket(t, reqStr, mock, "")
+}
+
+func runS3RequestCaptureBucket(t *testing.T, reqStr string, mock storage.Store, configuredBucket string) (string, error) {
 	expectedAuthToken := []byte(common.PadString("a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6", common.AuthTokenLength)) // notsecret
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -363,6 +367,7 @@ func runS3RequestCapture(t *testing.T, reqStr string, mock storage.Store) (strin
 
 		comm := NewS3Communicator(conn)
 		comm.SetStore(mock)
+		comm.SetConfiguredBucket(configuredBucket)
 
 		_, _, err = comm.HandshakeServer(expectedAuthToken)
 		errChan <- err
@@ -897,6 +902,301 @@ func TestS3Communicator_HEAD_SigV4Auth(t *testing.T) {
 	_, _, err := comm.HandshakeServer(expectedAuthToken)
 	if err != ErrRequestHandled {
 		t.Fatalf("Expected ErrRequestHandled for HEAD with SigV4, got: %v", err)
+	}
+}
+
+func TestFormatListBucketsXML(t *testing.T) {
+	empty := string(FormatListBucketsXML(""))
+	if !strings.Contains(empty, "<ListAllMyBucketsResult") {
+		t.Errorf("Expected ListAllMyBucketsResult root, got: %s", empty)
+	}
+	if strings.Contains(empty, "<Bucket>") {
+		t.Errorf("Expected no buckets for empty configured bucket, got: %s", empty)
+	}
+	if strings.Contains(empty, "<Name>") {
+		t.Errorf("Expected no bucket names for empty configured bucket, got: %s", empty)
+	}
+
+	withBucket := string(FormatListBucketsXML("mybucket"))
+	if !strings.Contains(withBucket, "<Name>mybucket</Name>") {
+		t.Errorf("Expected configured bucket in list, got: %s", withBucket)
+	}
+	if !strings.Contains(withBucket, "<Owner><ID>momo</ID>") {
+		t.Errorf("Expected Owner element, got: %s", withBucket)
+	}
+}
+
+func TestFormatGetBucketLocationXML(t *testing.T) {
+	empty := string(FormatGetBucketLocationXML(""))
+	if !strings.Contains(empty, "<LocationConstraint") || !strings.Contains(empty, "</LocationConstraint>") {
+		t.Errorf("Expected LocationConstraint element, got: %s", empty)
+	}
+	if strings.Contains(empty, ">us-east-1<") {
+		t.Errorf("Expected empty region for empty input, got: %s", empty)
+	}
+
+	region := string(FormatGetBucketLocationXML("us-east-1"))
+	if !strings.Contains(region, ">us-east-1</LocationConstraint>") {
+		t.Errorf("Expected region inside LocationConstraint, got: %s", region)
+	}
+}
+
+func TestS3Communicator_ListBuckets(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	reqStr := "GET / HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	// 1. No configured bucket -> empty bucket list.
+	respStr := runS3TestRequest(t, reqStr, &mockStore{})
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Content-Type: application/xml") {
+		t.Errorf("Expected XML content type, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<ListAllMyBucketsResult") {
+		t.Errorf("Expected ListAllMyBucketsResult, got: %s", respStr)
+	}
+	if strings.Contains(respStr, "<Name>") {
+		t.Errorf("Expected empty bucket list without configured bucket, got: %s", respStr)
+	}
+
+	// 2. Configured bucket -> returned in ListBuckets.
+	respStr, serverErr := runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "mybucket")
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "<Name>mybucket</Name>") {
+		t.Errorf("Expected configured bucket in ListBuckets, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_GetBucketLocation(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	// 1. Valid bucket -> 200 with empty LocationConstraint (us-east-1).
+	reqStr := "GET /mybucket?location HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+	respStr, serverErr := runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "mybucket")
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<LocationConstraint") {
+		t.Errorf("Expected LocationConstraint XML, got: %s", respStr)
+	}
+
+	// 2. Unknown bucket -> 404 NoSuchBucket.
+	respStr, serverErr = runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "otherbucket")
+	if serverErr == nil || !errors.Is(serverErr, syscall.ENOENT) {
+		t.Fatalf("Expected ENOENT for unknown bucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 404 Not Found") {
+		t.Errorf("Expected 404 Not Found, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchBucket</Code>") {
+		t.Errorf("Expected NoSuchBucket XML error, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_CreateBucket(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	// 1. CreateBucket for the configured bucket -> 200 + Location header.
+	reqStr := "PUT /mybucket HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n" +
+		"Content-Length: 0\r\n\r\n"
+	respStr, serverErr := runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "mybucket")
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled for CreateBucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "Location: /mybucket") {
+		t.Errorf("Expected Location header, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<LocationConstraint") {
+		t.Errorf("Expected LocationConstraint XML, got: %s", respStr)
+	}
+
+	// 2. CreateBucket for a different name -> 404 NoSuchBucket (single-bucket policy).
+	respStr, serverErr = runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "configured-bucket")
+	if serverErr == nil || !errors.Is(serverErr, syscall.ENOENT) {
+		t.Fatalf("Expected ENOENT for wrong bucket name, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 404 Not Found") {
+		t.Errorf("Expected 404 Not Found, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchBucket</Code>") {
+		t.Errorf("Expected NoSuchBucket XML error, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_DeleteBucket(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	reqStr := "DELETE /mybucket HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	// 1. Empty store -> 204 No Content.
+	emptyMock := &mockStore{listFunc: func() ([]common.FileMetadata, error) { return nil, nil }}
+	respStr, serverErr := runS3RequestCaptureBucket(t, reqStr, emptyMock, "mybucket")
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled for empty DeleteBucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 204 No Content") {
+		t.Errorf("Expected 204 No Content, got: %s", respStr)
+	}
+
+	// 2. Non-empty store -> 409 BucketNotEmpty.
+	nonEmptyMock := &mockStore{listFunc: func() ([]common.FileMetadata, error) {
+		return []common.FileMetadata{{Name: "file.txt", Hash: "h", Size: 1}}, nil
+	}}
+	respStr, serverErr = runS3RequestCaptureBucket(t, reqStr, nonEmptyMock, "mybucket")
+	if serverErr == nil || !errors.Is(serverErr, syscall.ENOTEMPTY) {
+		t.Fatalf("Expected ENOTEMPTY for non-empty DeleteBucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 409 Conflict") {
+		t.Errorf("Expected 409 Conflict, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>BucketNotEmpty</Code>") {
+		t.Errorf("Expected BucketNotEmpty XML error, got: %s", respStr)
+	}
+
+	// 3. Unknown bucket name -> 404 NoSuchBucket.
+	respStr, serverErr = runS3RequestCaptureBucket(t, reqStr, emptyMock, "configured-bucket")
+	if serverErr == nil || !errors.Is(serverErr, syscall.ENOENT) {
+		t.Fatalf("Expected ENOENT for wrong bucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 404 Not Found") {
+		t.Errorf("Expected 404 Not Found, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchBucket</Code>") {
+		t.Errorf("Expected NoSuchBucket XML error, got: %s", respStr)
+	}
+
+	// 4. Legacy flat mode (no configured bucket) preserves 400 for keyless DELETE.
+	respStr, serverErr = runS3RequestCapture(t, reqStr, emptyMock)
+	if serverErr == nil {
+		t.Fatal("Expected error for keyless DELETE in flat mode")
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 400 Bad Request") {
+		t.Errorf("Expected 400 Bad Request in flat mode, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_HeadBucket_Configured(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	// 1. HEAD configured bucket -> 200.
+	reqStr := "HEAD /mybucket HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+	respStr, serverErr := runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "mybucket")
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK, got: %s", respStr)
+	}
+
+	// 2. HEAD unknown bucket -> 404 NoSuchBucket.
+	respStr, serverErr = runS3RequestCaptureBucket(t, reqStr, &mockStore{}, "otherbucket")
+	if serverErr == nil || !errors.Is(serverErr, syscall.ENOENT) {
+		t.Fatalf("Expected ENOENT for unknown bucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 404 Not Found") {
+		t.Errorf("Expected 404 Not Found, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchBucket</Code>") {
+		t.Errorf("Expected NoSuchBucket XML error, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_BucketModeObjectOps(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	fileContent := []byte("data")
+
+	// 1. GET object in the configured bucket -> 200.
+	reqGet := "GET /mybucket/hello.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+	mock := &mockStore{
+		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+			return io.NopCloser(bytes.NewReader(fileContent)), common.FileMetadata{Name: name, Hash: "h1", Size: 4}, nil
+		},
+	}
+	respStr, serverErr := runS3RequestCaptureBucket(t, reqGet, mock, "mybucket")
+	if serverErr != ErrRequestHandled {
+		t.Fatalf("Expected ErrRequestHandled, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "HTTP/1.1 200 OK") {
+		t.Errorf("Expected 200 OK, got: %s", respStr)
+	}
+
+	// 2. GET object in an unknown bucket -> 404 NoSuchBucket.
+	respStr, serverErr = runS3RequestCaptureBucket(t, reqGet, mock, "configured-bucket")
+	if serverErr == nil || !errors.Is(serverErr, syscall.ENOENT) {
+		t.Fatalf("Expected ENOENT for wrong bucket, got: %v", serverErr)
+	}
+	if !strings.Contains(respStr, "<Code>NoSuchBucket</Code>") {
+		t.Errorf("Expected NoSuchBucket XML error, got: %s", respStr)
+	}
+
+	// 3. PUT object in the configured bucket -> handshake proceeds (key stored without bucket prefix).
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+	putReq := "PUT /mybucket/subdir/file.txt HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n" +
+		"X-Amz-Date: 20260604T120000Z\r\n" +
+		"X-Amz-Content-Sha256: hash123\r\n" +
+		"Content-Length: 1024\r\n\r\n"
+
+	go func() {
+		clientConn.Write([]byte(putReq))
+		buf := make([]byte, 1024)
+		for {
+			if _, err := clientConn.Read(buf); err != nil {
+				break
+			}
+		}
+	}()
+
+	comm := NewS3Communicator(serverConn)
+	comm.SetStore(mock)
+	comm.SetConfiguredBucket("mybucket")
+	_, _, err := comm.HandshakeServer(expectedAuthToken)
+	if err != nil {
+		t.Fatalf("HandshakeServer failed for PUT in configured bucket: %v", err)
+	}
+	meta, err := comm.ReceiveMetadata()
+	if err != nil {
+		t.Fatalf("ReceiveMetadata failed: %v", err)
+	}
+	if meta.Name != "subdir/file.txt" {
+		t.Errorf("Expected bucket-relative key name, got %q", meta.Name)
 	}
 }
 


### PR DESCRIPTION
Resolves #767

## Summary
Adds S3 bucket-management operations to `S3Communicator.HandshakeServer` so `aws s3 mb`/`rb`/`ls` and SDK bucket preflight/calls work with honest single-bucket semantics. All bucket operations are intercept-and-respond (bypass momo framing) and identical on s3-tcp and s3-quic.

## Changes
- `GET /` → ListBuckets: `<ListAllMyBucketsResult>` returning the configured single bucket (`[storage] s3_bucket`); empty list in legacy flat mode. `?list-type=2` on root keeps the documented list-all path.
- `GET /bucket?location` → GetBucketLocation: 200 + empty `<LocationConstraint>` (us-east-1); unknown bucket → 404 `NoSuchBucket`.
- `PUT /bucket` → CreateBucket (bucket mode only): 200 + `Location` header + `<LocationConstraint>` body for the configured bucket; other names → 404 `NoSuchBucket`.
- `DELETE /bucket` → DeleteBucket (bucket mode only): 204 when the store is empty, 409 `BucketNotEmpty` otherwise; unknown bucket → 404. Legacy flat mode keeps the existing 400 behavior.
- `HEAD /bucket` → HeadBucket: 200 for the configured bucket, 404 `NoSuchBucket` otherwise.
- Object operations (GET/PUT/DELETE object, HeadObject) now enforce the single-bucket policy when a bucket is configured: requests to an unknown bucket return 404 `NoSuchBucket`.
- In bucket mode, PUT object stores the bucket-relative key (not the full `bucket/key` path) so GET/HEAD/DELETE resolve the same object — fixes the pre-existing path/key mismatch for S3 clients.
- New `SetConfiguredBucket` on `S3Communicator`, wired from `server.go` using `cfg.Storage.S3Bucket`; `validBucket`/helper refactor shared by list and DeleteBucket emptiness checks.

## Tests
- `TestFormatListBucketsXML`, `TestFormatGetBucketLocationXML`: XML shape, empty vs configured bucket.
- `TestS3Communicator_ListBuckets`, `GetBucketLocation`, `CreateBucket`, `DeleteBucket`, `HeadBucket_Configured`: success + error semantics over real TCP.
- `TestS3Communicator_BucketModeObjectOps`: GET in correct/wrong bucket; PUT stores bucket-relative key.

## Changelog
- Added ListBuckets, CreateBucket, DeleteBucket, HeadBucket and GetBucketLocation S3 operations with honest single-bucket semantics.
