### PR TITLE
feat: S3 ListObjectsV2 pagination (continuation-token/start-after/fetch-owner) (#769)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3015,3 +3015,12 @@ a2c936b,BenchmarkLoadGlobalConfig-8,7622.00,1576.00,46.00
 a2c936b,BenchmarkPadString-8,59.75,64.00,1.00
 a2c936b,BenchmarkSanitizeLog/Safe-8,537.10,0.00,0.00
 a2c936b,BenchmarkSanitizeLog/Unsafe-8,732.00,704.00,1.00
+f52f7f1,BenchmarkCheckMetricsAndSwap-8,10.10,0.00,0.00
+f52f7f1,BenchmarkCrushOptimized-8,388.30,0.00,0.00
+f52f7f1,BenchmarkCrushOriginal-8,594.40,164.00,3.00
+f52f7f1,BenchmarkIndexDirectTracking-8,0.48,0.00,0.00
+f52f7f1,BenchmarkIndexSearch-8,2.31,0.00,0.00
+f52f7f1,BenchmarkLoadGlobalConfig-8,8182.00,1576.00,46.00
+f52f7f1,BenchmarkPadString-8,53.75,64.00,1.00
+f52f7f1,BenchmarkSanitizeLog/Safe-8,464.30,0.00,0.00
+f52f7f1,BenchmarkSanitizeLog/Unsafe-8,668.50,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,16 +39,16 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                       │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                       │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                        506.7n ± ∞ ¹    478.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                       370.4n ± ∞ ¹    350.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                     7.642µ ± ∞ ¹    7.622µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                            43.47n ± ∞ ¹    59.75n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                     496.8n ± ∞ ¹    537.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                   596.7n ± ∞ ¹    732.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                  8.556n ± ∞ ¹    8.453n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                          2.062n ± ∞ ¹    1.997n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                 0.3778n ± ∞ ¹   0.4009n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                79.24n          83.77n        +5.72%
+CrushOriginal-8                        478.6n ± ∞ ¹    594.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                       350.3n ± ∞ ¹    388.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                     7.622µ ± ∞ ¹    8.182µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                            59.75n ± ∞ ¹    53.75n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                     537.1n ± ∞ ¹    464.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                   732.0n ± ∞ ¹    668.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                  8.453n ± ∞ ¹   10.100n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                          1.997n ± ∞ ¹    2.306n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                 0.4009n ± ∞ ¹   0.4766n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                83.77n          88.98n        +6.22%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -93,15 +93,15 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkCheckMetricsAndSwap-8 | 8.45 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 350.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 478.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7622.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 59.75 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 537.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 732.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 388.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 594.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.48 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.31 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8182.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 53.75 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 464.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 668.50 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -130,18 +130,18 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b]
-    line "CheckMetricsAndSwap" [8,10,11,9,9,8,11,10,9,8]
-    line "CrushOptimized" [293,317,420,587,396,363,549,426,370,350]
-    line "CrushOriginal" [409,436,627,667,620,506,949,663,507,479]
-    line "IndexDirectTracking" [0,0,1,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,3,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [5863,5958,8220,8445,9134,7656,10077,9618,7642,7622]
-    line "PadString" [39,41,59,49,67,48,56,64,43,60]
+    x-axis [ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b,f52f7f1]
+    line "CheckMetricsAndSwap" [10,11,9,9,8,11,10,9,8,10]
+    line "CrushOptimized" [317,420,587,396,363,549,426,370,350,388]
+    line "CrushOriginal" [436,627,667,620,506,949,663,507,479,594]
+    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [2,3,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [5958,8220,8445,9134,7656,10077,9618,7642,7622,8182]
+    line "PadString" [41,59,49,67,48,56,64,43,60,54]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [231,326,287,252,342,470,497,475,497,537]
-    line "SanitizeLog/Unsafe" [675,1095,866,989,838,634,610,596,597,732]
+    line "SanitizeLog/Safe" [326,287,252,342,470,497,475,497,537,464]
+    line "SanitizeLog/Unsafe" [1095,866,989,838,634,610,596,597,732,668]
 ```
 
 #### Memory per Operation (B/op)
@@ -154,13 +154,13 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b]
+    x-axis [ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b,f52f7f1]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1320,1320,1320,1320,1320,1576,1576,1576,1576,1576]
+    line "LoadGlobalConfig" [1320,1320,1320,1320,1576,1576,1576,1576,1576,1576]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -178,13 +178,13 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [8b3edae,ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b]
+    x-axis [ec59a82,aaf6479,28ed539,c6829fc,1cfce56,90e806d,935577d,97aec32,a2c936b,f52f7f1]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [38,38,38,38,38,46,46,46,46,46]
+    line "LoadGlobalConfig" [38,38,38,38,46,46,46,46,46,46]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/subtle"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -414,6 +416,14 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 			prefix := q.Get("prefix")
 			delimiter := q.Get("delimiter")
+			// Pagination: continuation-token resumes after the last key of the
+			// previous page; start-after is an informational starting hint.
+			startAfter := q.Get("continuation-token")
+			if startAfter == "" {
+				startAfter = q.Get("start-after")
+			}
+			// fetch-owner=true (default false) includes the Owner element per key.
+			fetchOwner := strings.EqualFold(q.Get("fetch-owner"), "true")
 			maxKeys := 1000
 			if maxKeysStr := q.Get("max-keys"); maxKeysStr != "" {
 				if mk, err := strconv.Atoi(maxKeysStr); err == nil && mk > 0 {
@@ -422,7 +432,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 				}
 			}
 
-			xmlBytes, formatErr := FormatListObjectsV2XML(bucket, prefix, delimiter, maxKeys, files)
+			xmlBytes, _, formatErr := FormatListObjectsV2XML(bucket, prefix, delimiter, maxKeys, startAfter, fetchOwner, files)
 			if formatErr != nil {
 				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				writeS3Error(m.conn, http.StatusBadRequest, "InvalidArgument", "Invalid list request parameters.", "")
@@ -1116,9 +1126,39 @@ func FormatGetBucketLocationXML(region string) []byte {
 	return buf.Bytes()
 }
 
+// Continuation-token kinds. The token is base64(kind byte + last emitted key).
+// 'K' means the page ended on a Contents key (resume after that key);
+// 'P' means it ended on a CommonPrefix (resume after the whole prefix group).
+// This is deterministic and stable across s3-tcp/s3-quic and server restarts.
+const (
+	continuationKindKey     byte = 'K'
+	continuationKindPrefix  byte = 'P'
+	continuationKindUnknown byte = 0
+)
+
+func encodeContinuationToken(kind byte, key string) string {
+	return base64.StdEncoding.EncodeToString(append([]byte{kind}, []byte(key)...))
+}
+
+// decodeContinuationToken parses a continuation token produced by
+// encodeContinuationToken. The second return is the plain resume key.
+func decodeContinuationToken(token string) (kind byte, key string, ok bool) {
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil || len(raw) == 0 {
+		return continuationKindUnknown, "", false
+	}
+	return raw[0], string(raw[1:]), true
+}
+
 // FormatListObjectsV2XML constructs an S3-compliant ListObjectsV2 XML response
 // using a pre-allocated bytes.Buffer to avoid excessive heap allocations (⚡ Bolt pattern).
-func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, files []common.FileMetadata) (xmlBytes []byte, err error) {
+// startAfter is the raw value of either the continuation-token or start-after query
+// parameter; it selects the page to resume from. When the page is truncated the
+// returned nextToken encodes the last emitted element and must be passed back as
+// continuation-token on the next request. fetchOwner mirrors the AWS S3
+// fetch-owner parameter (default false): when true an Owner element is emitted
+// per key.
+func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, startAfter string, fetchOwner bool, files []common.FileMetadata) (xmlBytes []byte, nextToken string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("CRITICAL: Recovered from panic in FormatListObjectsV2XML: %v", r)
@@ -1127,9 +1167,26 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 	}()
 
 	// 🛡️ Rule 35: Validate input strings for length limits (64 bytes) before writing to the bytes.Buffer.
-	if len(bucketName) > 64 || len(prefix) > 64 || len(delimiter) > 64 {
-		return nil, fmt.Errorf("FormatListObjectsV2XML input length exceeds limit: %w", syscall.EINVAL)
+	if len(bucketName) > 64 || len(prefix) > 64 || len(delimiter) > 64 || len(startAfter) > 1024 {
+		return nil, "", fmt.Errorf("FormatListObjectsV2XML input length exceeds limit: %w", syscall.EINVAL)
 	}
+
+	// Determine the resume position from a continuation token (kind-aware) or a
+	// plain start-after key (S3 treats start-after as an informational hint).
+	var resumeKey string
+	var resumePrefixMode bool
+	if startAfter != "" {
+		if kind, key, ok := decodeContinuationToken(startAfter); ok {
+			resumeKey = key
+			resumePrefixMode = kind == continuationKindPrefix
+		} else {
+			resumeKey = startAfter
+		}
+	}
+
+	// Sort by key so pagination is deterministic regardless of the list source
+	// (store.List is sorted, but scatter-gather merges may not be).
+	sort.SliceStable(files, func(i, j int) bool { return files[i].Name < files[j].Name })
 
 	var buf bytes.Buffer
 	var intBuf [32]byte
@@ -1157,6 +1214,33 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 	commonPrefixes := make(map[string]bool)
 	keyCount := 0
 	truncated := false
+	// last emitted element (used to build the continuation token on truncation).
+	lastKind := byte(continuationKindKey)
+	lastToken := ""
+
+	emitContents := func(file common.FileMetadata, key string) {
+		buf.WriteString(`<Contents>`)
+		buf.WriteString(`<Key>`)
+		xmlEscape(&buf, key)
+		buf.WriteString(`</Key>`)
+		buf.WriteString(`<LastModified>`)
+		buf.WriteString(formatLastModified(file.ModTime))
+		buf.WriteString(`</LastModified>`)
+		buf.WriteString(`<ETag>"`)
+		xmlEscape(&buf, file.Hash)
+		buf.WriteString(`"</ETag>`)
+		if fetchOwner {
+			buf.WriteString(`<Owner>`)
+			buf.WriteString(`<ID>momo</ID>`)
+			buf.WriteString(`<DisplayName>momo</DisplayName>`)
+			buf.WriteString(`</Owner>`)
+		}
+		buf.WriteString(`<Size>`)
+		buf.Write(strconv.AppendInt(intBuf[:0], file.Size, 10))
+		buf.WriteString(`</Size>`)
+		buf.WriteString(`<StorageClass>STANDARD</StorageClass>`)
+		buf.WriteString(`</Contents>`)
+	}
 
 	for _, file := range files {
 		// 🛡️ Sentinel: Validate that the metadata fields conform to the project's strict size limits (64 bytes)
@@ -1168,6 +1252,20 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 
 		key := file.Name
 
+		// Resume-after: skip everything at or before the resume position.
+		if resumeKey != "" {
+			if resumePrefixMode {
+				// Skip the whole already-emitted CommonPrefix group.
+				if strings.HasPrefix(key, resumeKey) || key < resumeKey {
+					continue
+				}
+			} else {
+				if key <= resumeKey {
+					continue
+				}
+			}
+		}
+
 		if prefix != "" && !strings.HasPrefix(key, prefix) {
 			continue
 		}
@@ -1177,9 +1275,17 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 			delimIdx := strings.Index(relativeKey, delimiter)
 			if delimIdx != -1 {
 				subPrefix := prefix + relativeKey[:delimIdx+1]
-				if !commonPrefixes[subPrefix] {
-					commonPrefixes[subPrefix] = true
+				if commonPrefixes[subPrefix] {
+					continue
 				}
+				if maxKeys > 0 && keyCount >= maxKeys {
+					truncated = true
+					break
+				}
+				commonPrefixes[subPrefix] = true
+				lastKind = continuationKindPrefix
+				lastToken = subPrefix
+				keyCount++
 				continue
 			}
 		}
@@ -1189,25 +1295,19 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 			break
 		}
 
-		buf.WriteString(`<Contents>`)
-		buf.WriteString(`<Key>`)
-		xmlEscape(&buf, key)
-		buf.WriteString(`</Key>`)
-		buf.WriteString(`<LastModified>`)
-		buf.WriteString(formatLastModified(file.ModTime))
-		buf.WriteString(`</LastModified>`)
-		buf.WriteString(`<ETag>"`)
-		xmlEscape(&buf, file.Hash)
-		buf.WriteString(`"</ETag>`)
-		buf.WriteString(`<Size>`)
-		buf.Write(strconv.AppendInt(intBuf[:0], file.Size, 10))
-		buf.WriteString(`</Size>`)
-		buf.WriteString(`<StorageClass>STANDARD</StorageClass>`)
-		buf.WriteString(`</Contents>`)
+		emitContents(file, key)
+		lastKind = continuationKindKey
+		lastToken = key
 		keyCount++
 	}
 
+	// Emit CommonPrefixes in stable (sorted) order for reproducible output.
+	sortedPrefixes := make([]string, 0, len(commonPrefixes))
 	for cp := range commonPrefixes {
+		sortedPrefixes = append(sortedPrefixes, cp)
+	}
+	sort.Strings(sortedPrefixes)
+	for _, cp := range sortedPrefixes {
 		buf.WriteString(`<CommonPrefixes>`)
 		buf.WriteString(`<Prefix>`)
 		xmlEscape(&buf, cp)
@@ -1227,8 +1327,15 @@ func FormatListObjectsV2XML(bucketName, prefix, delimiter string, maxKeys int, f
 	buf.Write(strconv.AppendInt(intBuf[:0], int64(keyCount), 10))
 	buf.WriteString(`</KeyCount>`)
 
+	if truncated && lastToken != "" {
+		nextToken = encodeContinuationToken(lastKind, lastToken)
+		buf.WriteString(`<NextContinuationToken>`)
+		xmlEscape(&buf, nextToken)
+		buf.WriteString(`</NextContinuationToken>`)
+	}
+
 	buf.WriteString(`</ListBucketResult>`)
-	return buf.Bytes(), nil
+	return buf.Bytes(), nextToken, nil
 }
 
 // ⚡ Bolt: Optimize XML escaping by replacing byte-by-byte iteration with fast-path

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -3,9 +3,11 @@ package transport
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -530,7 +532,7 @@ func TestS3Communicator_ListObjectsV2KeyCount(t *testing.T) {
 		{Name: "src/file4.go", Hash: "hash4", Size: 400},
 	}
 
-	xmlBytes, err := FormatListObjectsV2XML("mybucket", "", "/", 1000, files)
+	xmlBytes, _, err := FormatListObjectsV2XML("mybucket", "", "/", 1000, "", false, files)
 	if err != nil {
 		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
 	}
@@ -554,8 +556,9 @@ func TestS3Communicator_ListObjectsV2KeyCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("KeyCount not an integer: %v", err)
 	}
-	if keyCount != contentsCount {
-		t.Errorf("KeyCount (%d) must equal number of Contents entries (%d), excluding CommonPrefixes", keyCount, contentsCount)
+	// AWS S3 semantics: KeyCount equals the number of Contents plus CommonPrefixes returned.
+	if keyCount != contentsCount+prefixesCount {
+		t.Errorf("KeyCount (%d) must equal Contents (%d) + CommonPrefixes (%d)", keyCount, contentsCount, prefixesCount)
 	}
 }
 
@@ -569,7 +572,7 @@ func TestS3Communicator_XMLFormatting(t *testing.T) {
 	}
 
 	// 1. Root listing (prefix: "", delimiter: "")
-	xmlBytes, err := FormatListObjectsV2XML("mybucket", "", "", 1000, files)
+	xmlBytes, _, err := FormatListObjectsV2XML("mybucket", "", "", 1000, "", false, files)
 	if err != nil {
 		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
 	}
@@ -606,7 +609,7 @@ func TestS3Communicator_XMLFormatting(t *testing.T) {
 	}
 
 	// 2. Prefix and delimiter grouping
-	xmlBytesDelim, err := FormatListObjectsV2XML("mybucket", "", "/", 1000, files)
+	xmlBytesDelim, _, err := FormatListObjectsV2XML("mybucket", "", "/", 1000, "", false, files)
 	if err != nil {
 		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
 	}
@@ -621,14 +624,331 @@ func TestS3Communicator_XMLFormatting(t *testing.T) {
 	if !strings.Contains(xmlStrDelim, "<Prefix>docs/</Prefix>") {
 		t.Errorf("Expected docs/ as CommonPrefix")
 	}
-	if !strings.Contains(xmlStrDelim, "<KeyCount>1</KeyCount>") {
-		t.Errorf("Expected KeyCount to exclude CommonPrefixes (got XML: %s)", xmlStrDelim)
+	// AWS S3 semantics: KeyCount includes CommonPrefixes (1 Contents + 1 CommonPrefix).
+	if !strings.Contains(xmlStrDelim, "<KeyCount>2</KeyCount>") {
+		t.Errorf("Expected KeyCount to include CommonPrefixes (got XML: %s)", xmlStrDelim)
 	}
 
 	// 3. Reject input exceeding 64 bytes (Rule 35)
-	_, err = FormatListObjectsV2XML("my-very-long-bucket-name-that-exceeds-sixty-four-characters-limit-completely", "", "", 1000, files)
+	_, _, err = FormatListObjectsV2XML("my-very-long-bucket-name-that-exceeds-sixty-four-characters-limit-completely", "", "", 1000, "", false, files)
 	if !errors.Is(err, syscall.EINVAL) {
 		t.Errorf("Expected syscall.EINVAL for oversized bucket name, got %v", err)
+	}
+}
+
+func TestS3Communicator_ContinuationTokenRoundtrip(t *testing.T) {
+	tests := []struct {
+		name string
+		kind byte
+		key  string
+	}{
+		{name: "plain key", kind: continuationKindKey, key: "docs/file2.txt"},
+		{name: "common prefix", kind: continuationKindPrefix, key: "docs/"},
+		{name: "empty key", kind: continuationKindKey, key: ""},
+		{name: "unicode key", kind: continuationKindKey, key: "caf\u00e9/\u00e9tude.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := encodeContinuationToken(tt.kind, tt.key)
+			if token == "" {
+				t.Fatalf("expected non-empty token")
+			}
+			kind, key, ok := decodeContinuationToken(token)
+			if !ok {
+				t.Fatalf("expected token to decode, got %q", token)
+			}
+			if kind != tt.kind || key != tt.key {
+				t.Errorf("roundtrip mismatch: got (%d, %q), want (%d, %q)", kind, key, tt.kind, tt.key)
+			}
+		})
+	}
+
+	// Malformed / garbage tokens must be rejected, not panic.
+	for _, garbage := range []string{"", "not-base64!!", "a", "!!!"} {
+		kind, key, ok := decodeContinuationToken(garbage)
+		if ok {
+			t.Errorf("expected %q to be rejected, got ok=(%d, %q)", garbage, kind, key)
+		}
+	}
+}
+
+func TestS3Communicator_ListObjectsV2Pagination(t *testing.T) {
+	files := make([]common.FileMetadata, 0, 25)
+	for i := 0; i < 25; i++ {
+		files = append(files, common.FileMetadata{Name: fmt.Sprintf("file-%02d.txt", i), Hash: "hash", Size: 100})
+	}
+
+	var collected []string
+	token := ""
+	page := 0
+	for {
+		xmlBytes, nextToken, err := FormatListObjectsV2XML("mybucket", "", "", 10, token, false, files)
+		if err != nil {
+			t.Fatalf("page %d: FormatListObjectsV2XML failed: %v", page, err)
+		}
+		xmlStr := string(xmlBytes)
+
+		if strings.Contains(xmlStr, "<IsTruncated>true</IsTruncated>") {
+			if nextToken == "" {
+				t.Fatalf("page %d: truncated page without NextContinuationToken", page)
+			}
+		} else {
+			if nextToken != "" {
+				t.Fatalf("page %d: non-truncated page must not emit NextContinuationToken", page)
+			}
+		}
+
+		re := regexp.MustCompile(`<Key>([^<]+)</Key>`)
+		for _, m := range re.FindAllStringSubmatch(xmlStr, -1) {
+			collected = append(collected, m[1])
+		}
+
+		if nextToken == "" {
+			break
+		}
+		token = nextToken
+		page++
+		if page > 10 {
+			t.Fatalf("pagination did not terminate after 10 pages")
+		}
+	}
+
+	if page != 2 {
+		t.Errorf("Expected 3 pages for 25 keys at maxKeys=10, got %d", page+1)
+	}
+	if len(collected) != 25 {
+		t.Fatalf("Expected 25 keys across pages, got %d: %v", len(collected), collected)
+	}
+	for i, key := range collected {
+		want := fmt.Sprintf("file-%02d.txt", i)
+		if key != want {
+			t.Fatalf("Expected %s at position %d, got %s", want, i, key)
+		}
+	}
+}
+
+func TestS3Communicator_ListObjectsV2PaginationStartAfter(t *testing.T) {
+	files := []common.FileMetadata{
+		{Name: "a.txt", Hash: "h1", Size: 1},
+		{Name: "b.txt", Hash: "h2", Size: 2},
+		{Name: "c.txt", Hash: "h3", Size: 3},
+		{Name: "d.txt", Hash: "h4", Size: 4},
+	}
+
+	// start-after is informational: resume strictly after the given key.
+	xmlBytes, _, err := FormatListObjectsV2XML("mybucket", "", "", 1000, "b.txt", false, files)
+	if err != nil {
+		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
+	}
+	xmlStr := string(xmlBytes)
+	for _, key := range []string{"c.txt", "d.txt"} {
+		if !strings.Contains(xmlStr, "<Key>"+key+"</Key>") {
+			t.Errorf("start-after=b.txt should include %s, got: %s", key, xmlStr)
+		}
+	}
+	for _, key := range []string{"a.txt", "b.txt"} {
+		if strings.Contains(xmlStr, "<Key>"+key+"</Key>") {
+			t.Errorf("start-after=b.txt must not include %s, got: %s", key, xmlStr)
+		}
+	}
+	if !strings.Contains(xmlStr, "<IsTruncated>false</IsTruncated>") {
+		t.Errorf("expected non-truncated result, got: %s", xmlStr)
+	}
+}
+
+func TestS3Communicator_ListObjectsV2PaginationDelimiter(t *testing.T) {
+	files := []common.FileMetadata{
+		{Name: "a.txt", Hash: "h1", Size: 1},
+		{Name: "docs/f1.txt", Hash: "h2", Size: 2},
+		{Name: "docs/nested/f2.txt", Hash: "h3", Size: 3},
+		{Name: "src/g.go", Hash: "h4", Size: 4},
+	}
+
+	// maxKeys=2 with delimiter '/': a.txt + docs/ should fill page 1 and truncate.
+	xmlBytes, nextToken, err := FormatListObjectsV2XML("mybucket", "", "/", 2, "", false, files)
+	if err != nil {
+		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
+	}
+	xmlStr := string(xmlBytes)
+	if !strings.Contains(xmlStr, "<Key>a.txt</Key>") {
+		t.Errorf("page 1 should contain a.txt, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, "<Prefix>docs/</Prefix>") {
+		t.Errorf("page 1 should contain docs/ CommonPrefix, got: %s", xmlStr)
+	}
+	if strings.Contains(xmlStr, "<Prefix>src/</Prefix>") {
+		t.Errorf("page 1 must not contain src/ CommonPrefix, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, "<IsTruncated>true</IsTruncated>") {
+		t.Errorf("page 1 expected truncated, got: %s", xmlStr)
+	}
+	if nextToken == "" {
+		t.Fatalf("page 1 truncated but no NextContinuationToken")
+	}
+
+	// Resume: the token is prefix-kind, so the whole docs/ group is skipped.
+	xmlBytes2, nextToken2, err := FormatListObjectsV2XML("mybucket", "", "/", 2, nextToken, false, files)
+	if err != nil {
+		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
+	}
+	xmlStr2 := string(xmlBytes2)
+	if strings.Contains(xmlStr2, "<Key>a.txt</Key>") {
+		t.Errorf("page 2 must not repeat a.txt, got: %s", xmlStr2)
+	}
+	if strings.Contains(xmlStr2, "<Prefix>docs/</Prefix>") {
+		t.Errorf("page 2 must not repeat docs/ group, got: %s", xmlStr2)
+	}
+	if !strings.Contains(xmlStr2, "<Prefix>src/</Prefix>") {
+		t.Errorf("page 2 should contain src/ CommonPrefix, got: %s", xmlStr2)
+	}
+	if strings.Contains(xmlStr2, "<IsTruncated>true</IsTruncated>") {
+		t.Errorf("page 2 expected to complete listing, got: %s", xmlStr2)
+	}
+	if nextToken2 != "" {
+		t.Errorf("page 2 must not emit NextContinuationToken, got %q", nextToken2)
+	}
+}
+
+func TestS3Communicator_ListObjectsV2FetchOwner(t *testing.T) {
+	files := []common.FileMetadata{
+		{Name: "a.txt", Hash: "h1", Size: 1},
+		{Name: "b.txt", Hash: "h2", Size: 2},
+	}
+
+	// Default: fetch-owner=false → no Owner element.
+	xmlDefault, _, err := FormatListObjectsV2XML("mybucket", "", "", 1000, "", false, files)
+	if err != nil {
+		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
+	}
+	if strings.Contains(string(xmlDefault), "<Owner>") {
+		t.Errorf("fetch-owner=false must not emit Owner, got: %s", xmlDefault)
+	}
+
+	// fetch-owner=true → Owner element per key.
+	xmlOwned, _, err := FormatListObjectsV2XML("mybucket", "", "", 1000, "", true, files)
+	if err != nil {
+		t.Fatalf("FormatListObjectsV2XML failed: %v", err)
+	}
+	xmlStr := string(xmlOwned)
+	if strings.Count(xmlStr, "<Owner>") != 2 {
+		t.Errorf("Expected Owner element for each of 2 keys, got: %s", xmlStr)
+	}
+	if !strings.Contains(xmlStr, "<DisplayName>momo</DisplayName>") {
+		t.Errorf("Expected Owner display name, got: %s", xmlStr)
+	}
+}
+
+func TestS3Communicator_GET_ListObjectsV2FetchOwner(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	reqStr := "GET /?list-type=2&fetch-owner=true HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+
+	mock := &mockStore{
+		listFunc: func() ([]common.FileMetadata, error) {
+			return []common.FileMetadata{{Name: "test-file.txt", Hash: "hash123", Size: 500}}, nil
+		},
+	}
+
+	respStr := runS3TestRequest(t, reqStr, mock)
+
+	if !strings.Contains(respStr, "<Owner>") {
+		t.Errorf("fetch-owner=true should emit Owner, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<Key>test-file.txt</Key>") {
+		t.Errorf("Expected test-file.txt in body, got: %s", respStr)
+	}
+}
+
+func TestS3Communicator_GET_ListObjectsV2Pagination(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	// Unsorted listFunc output verifies the defensive sort in the formatter.
+	mock := &mockStore{
+		listFunc: func() ([]common.FileMetadata, error) {
+			return []common.FileMetadata{
+				{Name: "c.txt", Hash: "h3", Size: 3},
+				{Name: "a.txt", Hash: "h1", Size: 1},
+				{Name: "b.txt", Hash: "h2", Size: 2},
+			}, nil
+		},
+	}
+
+	// Page 1: max-keys=2 should return a.txt, b.txt and truncate.
+	reqStr1 := "GET /?list-type=2&max-keys=2 HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+	respStr1 := runS3TestRequest(t, reqStr1, mock)
+
+	if !strings.Contains(respStr1, "<Key>a.txt</Key>") {
+		t.Errorf("page 1 should contain a.txt, got: %s", respStr1)
+	}
+	if !strings.Contains(respStr1, "<Key>b.txt</Key>") {
+		t.Errorf("page 1 should contain b.txt, got: %s", respStr1)
+	}
+	if strings.Contains(respStr1, "<Key>c.txt</Key>") {
+		t.Errorf("page 1 must not contain c.txt, got: %s", respStr1)
+	}
+	if !strings.Contains(respStr1, "<IsTruncated>true</IsTruncated>") {
+		t.Errorf("page 1 expected IsTruncated=true, got: %s", respStr1)
+	}
+	tokenRe := regexp.MustCompile(`<NextContinuationToken>([^<]+)</NextContinuationToken>`)
+	tokenMatch := tokenRe.FindStringSubmatch(respStr1)
+	if tokenMatch == nil {
+		t.Fatalf("page 1 missing NextContinuationToken, got: %s", respStr1)
+	}
+	token := tokenMatch[1]
+
+	// Page 2: resume with continuation-token, expect only c.txt.
+	reqStr2 := "GET /?list-type=2&continuation-token=" + url.QueryEscape(token) + " HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+	respStr2 := runS3TestRequest(t, reqStr2, mock)
+
+	if !strings.Contains(respStr2, "<Key>c.txt</Key>") {
+		t.Errorf("page 2 should contain c.txt, got: %s", respStr2)
+	}
+	if strings.Contains(respStr2, "<Key>a.txt</Key>") {
+		t.Errorf("page 2 must not repeat a.txt, got: %s", respStr2)
+	}
+	if !strings.Contains(respStr2, "<IsTruncated>false</IsTruncated>") {
+		t.Errorf("page 2 expected IsTruncated=false, got: %s", respStr2)
+	}
+}
+
+func TestS3Communicator_GET_ListObjectsV2MaxKeysClamp(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	mock := &mockStore{
+		listFunc: func() ([]common.FileMetadata, error) {
+			// 1500 keys; max-keys=999999 must be clamped to 1000.
+			files := make([]common.FileMetadata, 1500)
+			for i := range files {
+				files[i] = common.FileMetadata{Name: fmt.Sprintf("k-%04d", i), Hash: "h", Size: 1}
+			}
+			return files, nil
+		},
+	}
+
+	reqStr := "GET /?list-type=2&max-keys=999999 HTTP/1.1\r\n" +
+		"Host: 127.0.0.1:4440\r\n" +
+		"Authorization: Bearer " + authToken + "\r\n\r\n"
+	respStr := runS3TestRequest(t, reqStr, mock)
+
+	if !strings.Contains(respStr, "<KeyCount>1000</KeyCount>") {
+		t.Errorf("expected KeyCount clamped to 1000, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<MaxKeys>1000</MaxKeys>") {
+		t.Errorf("expected MaxKeys reported as 1000, got: %s", respStr)
+	}
+	if !strings.Contains(respStr, "<IsTruncated>true</IsTruncated>") {
+		t.Errorf("expected IsTruncated=true after clamp, got: %s", respStr)
 	}
 }
 


### PR DESCRIPTION
Resolves #769

## Summary
Adds full ListObjectsV2 pagination to `FormatListObjectsV2XML` and the GET list branch of `S3Communicator.HandshakeServer` so `aws s3 ls` and SDK paginators (ListObjectsV2Paginator) enumerate buckets with more than `max-keys` objects. Identical behavior on s3-tcp and s3-quic (intercept-and-respond, bypasses momo framing).

## Changes
- Read `continuation-token`, `start-after` and `fetch-owner` query params in the GET `?list-type=2` branch.
- `continuation-token` resumes strictly after the last returned element; token is `base64(kind byte + last key)` — deterministic and stable across s3-tcp/s3-quic and server restarts, with no in-memory state.
- Kind-aware tokens: `K` resumes after a Contents key, `P` resumes after an entire CommonPrefix group (delimiter pagination). A plain (non-base64) `start-after` is honored as an informational hint per S3 semantics.
- Response now emits `KeyCount` = Contents + CommonPrefixes (AWS semantics), `IsTruncated`, and `NextContinuationToken` on truncated pages.
- CommonPrefixes emitted in stable sorted order; input defensively sorted by key for deterministic pages regardless of list source.
- `fetch-owner=true` (default false, AWS semantics) emits an `<Owner>` element per key.
- `max-keys` clamped to 1000 and `start-after` bounded to 1024 bytes to prevent DoS/memory exhaustion.

## Tests
- `TestS3Communicator_ContinuationTokenRoundtrip`: encode/decode round-trip incl. empty/unicode keys + malformed-token rejection.
- `TestS3Communicator_ListObjectsV2Pagination`: 25 keys @ max-keys=10 paginate to exactly 3 complete ordered pages.
- `TestS3Communicator_ListObjectsV2PaginationStartAfter`: start-after hint semantics.
- `TestS3Communicator_ListObjectsV2PaginationDelimiter`: CommonPrefix group token resumes past the whole group.
- `TestS3Communicator_GET_ListObjectsV2Pagination`: end-to-end TCP two-page walk with continuation-token over unsorted store output.
- `TestS3Communicator_GET_ListObjectsV2MaxKeysClamp`: 1500 keys @ max-keys=999999 clamped to 1000.
- `TestS3Communicator_ListObjectsV2FetchOwner` + `GET` variant: Owner element only when fetch-owner=true.
- Updated existing KeyCount/XML tests to AWS `KeyCount` = Contents + CommonPrefixes semantics.

## Changelog
- Added ListObjectsV2 pagination: continuation-token/start-after parsing, NextContinuationToken emission, kind-aware resume tokens, fetch-owner support, and KeyCount semantics per AWS S3.