### PR TITLE
feat: enforce HTTPS (or gated insecure) for S3 storage backend endpoint

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3102,3 +3102,14 @@ e07261e,BenchmarkSanitizeLog/Unsafe-8,825.70,704.00,1.00
 32c0290,BenchmarkPadString-8,53.49,64.00,1.00
 32c0290,BenchmarkSanitizeLog/Safe-8,439.80,0.00,0.00
 32c0290,BenchmarkSanitizeLog/Unsafe-8,668.70,704.00,1.00
+1e21e2b,BenchmarkAWSChunkedReaderSigned-8,623314.00,106.78,11320.00
+1e21e2b,BenchmarkAWSChunkedReaderUnsigned-8,637133.00,104.47,78612.00
+1e21e2b,BenchmarkCheckMetricsAndSwap-8,13.11,0.00,0.00
+1e21e2b,BenchmarkCrushOptimized-8,419.30,0.00,0.00
+1e21e2b,BenchmarkCrushOriginal-8,628.00,164.00,3.00
+1e21e2b,BenchmarkIndexDirectTracking-8,0.52,0.00,0.00
+1e21e2b,BenchmarkIndexSearch-8,3.37,0.00,0.00
+1e21e2b,BenchmarkLoadGlobalConfig-8,11680.00,1576.00,46.00
+1e21e2b,BenchmarkPadString-8,63.97,64.00,1.00
+1e21e2b,BenchmarkSanitizeLog/Safe-8,585.00,0.00,0.00
+1e21e2b,BenchmarkSanitizeLog/Unsafe-8,793.90,704.00,1.00

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -333,6 +333,11 @@ This section controls the Content-Addressable Storage (CAS) engine, including ba
     -   **Type:** Boolean
     -   **Default:** `true`
 
+-   **`s3_insecure`**
+    -   **Description:** Allow an `http://` (cleartext) S3 endpoint. Defaults to `false`, in which case a non-`https://` endpoint is rejected at startup with an `EINVAL` config error so credentials and blob content are never sent in cleartext. When `true`, the endpoint may use `http://` and a prominent warning is logged at startup. `https://` endpoints are always accepted regardless of this flag.
+    -   **Type:** Boolean
+    -   **Default:** `false`
+
 -   **`raw_device_path`**
     -   **Description:** Path to the raw block device for blob storage (e.g., `/dev/sda1`). Overrides `daemon.drive` if set. Only used when `backend = raw`.
     -   **Type:** String

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             686.0n ± ∞ ¹    549.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            380.8n ± ∞ ¹    352.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                         10.925µ ± ∞ ¹    8.352µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 66.44n ± ∞ ¹    53.49n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          673.0n ± ∞ ¹    439.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                       1502.0n ± ∞ ¹    668.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   2838.2µ ± ∞ ¹    493.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  617.9µ ± ∞ ¹    518.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                      15.800n ± ∞ ¹    9.750n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.796n ± ∞ ¹    1.783n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.5283n ± ∞ ¹   0.4888n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     643.6n          410.2n        -36.26%
+CrushOriginal-8                             549.3n ± ∞ ¹    628.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            352.6n ± ∞ ¹    419.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.352µ ± ∞ ¹   11.680µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 53.49n ± ∞ ¹    63.97n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          439.8n ± ∞ ¹    585.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        668.7n ± ∞ ¹    793.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    493.3µ ± ∞ ¹    623.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  518.6µ ± ∞ ¹    637.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       9.750n ± ∞ ¹   13.110n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.783n ± ∞ ¹    3.365n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4888n ± ∞ ¹   0.5215n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     410.2n          525.0n        +27.98%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.43Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.77Ki ± ∞ ¹   76.75Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.05Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.75Ki ± ∞ ¹   76.77Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.33%               ⁴
+geomean                                                ⁴                  +0.03%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt        │
-                           │             B/s             │      B/s        vs base                  │
-AWSChunkedReaderSigned-8                   22.36Mi ± ∞ ¹   128.67Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 102.7Mi ± ∞ ¹    122.4Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
-geomean                                    47.93Mi          125.5Mi        +161.82%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s       vs base                 │
+AWSChunkedReaderSigned-8                   128.7Mi ± ∞ ¹   101.8Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                122.39Mi ± ∞ ¹   99.63Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    125.5Mi         100.7Mi        -19.74%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 493329.00 ns/op | 134.92 B/op | 11290.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 518620.00 ns/op | 128.34 B/op | 78594.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 9.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 352.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 549.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.49 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.78 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8352.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 53.49 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 439.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 668.70 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 623314.00 ns/op | 106.78 B/op | 11320.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 637133.00 ns/op | 104.47 B/op | 78612.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 13.11 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 419.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 628.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.52 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 11680.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 63.97 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 585.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 793.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [a2c936b,f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290]
-    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,0,584226,2838201,493329]
-    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,0,631654,617880,518620]
-    line "CheckMetricsAndSwap" [8,10,9,10,9,10,10,9,16,10]
-    line "CrushOptimized" [350,388,436,307,344,355,415,439,381,353]
-    line "CrushOriginal" [479,594,516,557,494,491,570,664,686,549]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,3,2]
-    line "LoadGlobalConfig" [7622,8182,9158,7310,7930,8102,9075,10900,10925,8352]
-    line "PadString" [60,54,52,40,46,49,53,64,66,53]
+    x-axis [f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b]
+    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,584226,2838201,493329,623314]
+    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,631654,617880,518620,637133]
+    line "CheckMetricsAndSwap" [10,9,10,9,10,10,9,16,10,13]
+    line "CrushOptimized" [388,436,307,344,355,415,439,381,353,419]
+    line "CrushOriginal" [594,516,557,494,491,570,664,686,549,628]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,1]
+    line "IndexSearch" [2,2,2,2,2,2,2,3,2,3]
+    line "LoadGlobalConfig" [8182,9158,7310,7930,8102,9075,10900,10925,8352,11680]
+    line "PadString" [54,52,40,46,49,53,64,66,53,64]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [537,464,500,456,475,487,537,496,673,440]
-    line "SanitizeLog/Unsafe" [732,668,782,686,592,720,762,826,1502,669]
+    line "SanitizeLog/Safe" [464,500,456,475,487,537,496,673,440,585]
+    line "SanitizeLog/Unsafe" [668,782,686,592,720,762,826,1502,669,794]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [a2c936b,f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290]
-    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,0,114,23,135]
-    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,0,105,108,128]
+    x-axis [f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b]
+    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,114,23,135,107]
+    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,105,108,128,104]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [a2c936b,f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290]
-    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,0,11316,11705,11290]
-    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,0,78590,78616,78594]
+    x-axis [f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b]
+    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,11316,11705,11290,11320]
+    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,78590,78616,78594,78612]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -496,6 +496,25 @@ Client → [E2EE encryption] → Server → EncryptedBlobStore → Underlying Bl
 - **Delete passthrough:** `DeleteBlob` delegates directly to the underlying store — encryption does not affect deletion semantics.
 - **S3 metadata (filenames) remain plaintext** — only blob content is encrypted at rest.
 
+### Outbound TLS to the S3 storage backend (issue #774)
+
+The `S3BlobStore` (outbound client to a real S3/MinIO endpoint) enforces TLS on the storage endpoint. In `NewS3BlobStore` the `s3_endpoint` scheme is validated before any request is issued:
+
+- `https://` — always accepted (default posture).
+- `http://` — **rejected with an `EINVAL` config error unless `s3_insecure = true`** is explicitly set, in which case a prominent warning is logged at startup. This prevents silent cleartext transmission of SigV4 credentials, blob payloads, and object metadata.
+- Missing or unsupported schemes (e.g. `ftp://`) are rejected with `EINVAL`.
+
+This enforcement is orthogonal to the inbound gateway framing (s3-tcp/s3-quic/momo-tcp/momo-quic): the `S3BlobStore` sits below the storage layer, so behavior is identical regardless of which inbound protocol served the data. TLS here protects the wire in *addition to* the AES-GCM-256 at-rest ciphertext.
+
+### Layered confidentiality model
+
+The "real E2EE boundary" is a stack of independent protections:
+
+1. **Inbound gateway TLS** — TLS 1.3 for QUIC protocols (s3-quic/momo-quic); TLS 1.2+ for TCP protocols (s3-tcp/momo-tcp) when `tls_cert`/`tls_key` are configured (see [Transport TLS](#transport-tls-phase-1--e2ee)); s3-tcp refuses cleartext S3 serving without an explicit insecure override.
+2. **Client-side E2EE** — when `encryption_enabled = true`, the client encrypts content before it ever reaches the server.
+3. **At-rest encryption** — `EncryptedBlobStore` AES-GCM-256 wraps whatever the underlying backend is.
+4. **Outbound storage TLS** — when the backend is S3, `S3BlobStore` requires HTTPS (or an explicit `s3_insecure` override) so replication to the S3 endpoint is never silently downgraded to cleartext.
+
 ### Configuration
 
 ```ini

--- a/openspec/changes/s3-https-enforcement/proposal.md
+++ b/openspec/changes/s3-https-enforcement/proposal.md
@@ -1,0 +1,19 @@
+# Change: S3 — enforce HTTPS (or gated insecure) for the S3 storage backend endpoint
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/774
+
+## Why
+The S3 backend client (`S3BlobStore.S3Endpoint`) accepts any scheme (`http://` or `https://`) without validation, sending SigV4 credentials, blob content, and object metadata in cleartext when the endpoint is `http://`. AWS requires TLS for S3; the current highest practice is HTTPS-only plus bucket encryption at rest.
+
+## What Changes
+- **`NewS3BlobStore` validates the endpoint scheme.** Before any request is issued:
+  - `https://` — always accepted.
+  - `http://` — **rejected with an `EINVAL` config error** unless the new `s3_insecure = true` config flag is set, in which case a prominent `WARNING` is logged at startup.
+  - Missing scheme or unsupported schemes (e.g. `ftp://`, no scheme) — rejected with `EINVAL`.
+- **New config knob `s3_insecure`.** Added to `ConfigurationStorage` struct and parsed from the `s3_insecure` INI key. Defaults to `false`.
+- **Documentation updates:** Config guide (`docs/CONFIGURATION.md`) documents `s3_insecure`; protocol doc (`docs/PROTOCOL.md`) documents the layered confidentiality model (at-rest AES-GCM-256 + outbound TLS + inbound gateway TLS).
+
+## Non-Goals
+- No change to inbound gateway TLS enforcement (separate issue #775).
+- No change to the momo wire protocol or storage layer internals — only the outbound endpoint scheme is validated.
+

--- a/openspec/changes/s3-https-enforcement/specs/s3-https-enforcement/spec.md
+++ b/openspec/changes/s3-https-enforcement/specs/s3-https-enforcement/spec.md
@@ -1,0 +1,40 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/774
+
+# S3 — HTTPS Enforcement Specification
+
+## Purpose
+This specification requires TLS on the S3 storage backend endpoint to prevent silent cleartext transmission of SigV4 credentials, blob content, and object metadata when the endpoint is configured as `http://`.
+
+## ADDED Requirements
+
+### Requirement: Endpoint scheme validation on startup
+`NewS3BlobStore` SHALL validate the `s3_endpoint` URL scheme before returning. If the scheme is anything other than `https://` or `http://`, or if no scheme is present, the constructor SHALL return an `EINVAL` error.
+
+#### Scenario: https endpoint accepted
+- **GIVEN** an `s3_endpoint` with the `https://` scheme
+- **WHEN** `NewS3BlobStore` is called
+- **THEN** the store is created successfully
+
+#### Scenario: http endpoint rejected without insecure flag
+- **GIVEN** an `s3_endpoint` with the `http://` scheme and `s3_insecure = false` (default)
+- **WHEN** `NewS3BlobStore` is called
+- **THEN** the constructor returns an `EINVAL` error
+
+#### Scenario: http endpoint accepted with explicit insecure flag
+- **GIVEN** an `s3_endpoint` with the `http://` scheme and `s3_insecure = true`
+- **WHEN** `NewS3BlobStore` is called
+- **THEN** the store is created and a prominent `WARNING` is logged
+
+#### Scenario: missing scheme rejected
+- **GIVEN** an `s3_endpoint` without a scheme (e.g., `s3.amazonaws.com`)
+- **WHEN** `NewS3BlobStore` is called
+- **THEN** the constructor returns an `EINVAL` error
+
+#### Scenario: unsupported scheme rejected
+- **GIVEN** an `s3_endpoint` with an unsupported scheme (e.g., `ftp://`)
+- **WHEN** `NewS3BlobStore` is called
+- **THEN** the constructor returns an `EINVAL` error
+
+### Requirement: Prominent warning when insecure is enabled
+When `s3_insecure = true` and the endpoint uses `http://`, the SHALL log a prominent warning message indicating that credentials and blob content are transmitted without TLS.
+

--- a/openspec/changes/s3-https-enforcement/tasks.md
+++ b/openspec/changes/s3-https-enforcement/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: S3 — enforce HTTPS (or gated insecure) for the S3 storage backend endpoint (issue #774)
+
+## 1. Phase 1: Config + endpoint scheme validation
+- [x] 1.1 Add `S3Insecure bool` field to `ConfigurationStorage` in `src/common/struct.go`.
+- [x] 1.2 Parse `s3_insecure` from INI `[storage]` section in `src/common/config.go` `loadStorageConfig`.
+- [x] 1.3 In `NewS3BlobStore`: validate `s3_endpoint` scheme. Require `https://`; allow `http://` only when `S3Insecure` is true (with `log.Printf` warning); reject missing/unsupported scheme with `EINVAL`.
+
+## 2. Phase 2: Tests
+- [x] 2.1 Update all existing tests that use `httptest.NewServer` (plain HTTP) to set `S3Insecure: true`.
+- [x] 2.2 Add `TestS3BlobStore_TLSEnforcement` with subtables: https accepted, http rejected without insecure, http accepted with insecure, missing scheme rejected, unsupported scheme rejected.
+
+## 3. Phase 3: Docs
+- [x] 3.1 Update `docs/CONFIGURATION.md` — document `s3_insecure` knob.
+- [x] 3.2 Update `docs/PROTOCOL.md` — add outbound TLS enforcement section and layered confidentiality model.
+- [x] 3.3 Create `openspec/changes/s3-https-enforcement/` (proposal, tasks) with `Resolves #774` links.
+
+## 4. Validation
+- [ ] 4.1 Run `gofmt`, `go vet`, and the full per-module test suites (`src/root`, `common`, `transport` incl. `-race`, `client`, `server`, `storage`, `metrics`, `crypto`, `p2p`).
+- [ ] 4.2 Verify `go work vendor` produces no diff (Rule 25).
+- [ ] 4.3 Commit (pre-commit hook syncs `docs/PERFORMANCE.md` / `.github/data/benchmark_history.csv`), Rule 58 branch check, push.
+- [ ] 4.4 Open PR with `Resolves #774`, wait for checks, address the `github-actions` review, merge `--merge --delete-branch`, close the issue, run the Rule 71 master gate.
+

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -502,6 +502,11 @@ func loadStorageConfig(section *ini.Section) (ConfigurationStorage, error) {
 		cfg.S3PathStyle = true
 	}
 
+	cfg.S3Insecure, err = section.Key("s3_insecure").Bool()
+	if err != nil {
+		cfg.S3Insecure = false
+	}
+
 	cfg.RawDevicePath = section.Key("raw_device_path").String()
 
 	return cfg, nil

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -179,6 +179,11 @@ type ConfigurationStorage struct {
 	S3SecretKey string
 	// S3PathStyle uses path-style addressing (bucket in URL path) instead of virtual-host style.
 	S3PathStyle bool
+	// S3Insecure allows an http:// S3 endpoint (cleartext). Defaults to false;
+	// when false, an http:// endpoint is rejected to prevent silent credential
+	// and payload disclosure. When true, a prominent warning is logged at
+	// startup. https:// endpoints are always accepted regardless of this flag.
+	S3Insecure bool
 	// RawDevicePath is the path to the raw block device for blob storage.
 	// Overrides Daemon.Drive if set.
 	RawDevicePath string

--- a/src/storage/backends_e2e_test.go
+++ b/src/storage/backends_e2e_test.go
@@ -57,6 +57,7 @@ func s3TestStores(t *testing.T, n int) ([]Store, *httptest.Server, func()) {
 		cfg := common.ConfigurationStorage{
 			Backend:            "s3",
 			S3Endpoint:         server.URL,
+			S3Insecure:         true,
 			S3Region:           "us-east-1",
 			S3Bucket:           "e2e-bucket",
 			S3AccessKey:        "AKIAIOSFODNN7EXAMPLE",                     // notsecret

--- a/src/storage/s3_blobstore.go
+++ b/src/storage/s3_blobstore.go
@@ -54,6 +54,25 @@ func NewS3BlobStore(cfg common.ConfigurationStorage) (*S3BlobStore, error) {
 		return nil, fmt.Errorf("s3_secret_key is required: %w", syscall.EINVAL)
 	}
 
+	endpoint := strings.TrimRight(cfg.S3Endpoint, "/")
+	parsed, parseErr := url.Parse(endpoint)
+	if parseErr != nil {
+		return nil, fmt.Errorf("s3_endpoint is not a valid URL: %v: %w", parseErr, syscall.EINVAL)
+	}
+	switch parsed.Scheme {
+	case "https":
+		// TLS always allowed.
+	case "http":
+		if !cfg.S3Insecure {
+			return nil, fmt.Errorf("s3_endpoint uses cleartext http://; require https:// or set s3_insecure=true to allow insecure plaintext transport: %w", syscall.EINVAL)
+		}
+		log.Printf("WARNING: s3_insecure=true: S3 endpoint %q uses cleartext http://; credentials and blob content are transmitted without TLS", endpoint)
+	case "":
+		return nil, fmt.Errorf("s3_endpoint must include a scheme (https:// or http://): %w", syscall.EINVAL)
+	default:
+		return nil, fmt.Errorf("s3_endpoint scheme %q is unsupported; use https:// (or http:// with s3_insecure=true): %w", parsed.Scheme, syscall.EINVAL)
+	}
+
 	region := cfg.S3Region
 	if region == "" {
 		region = "us-east-1"
@@ -76,7 +95,7 @@ func NewS3BlobStore(cfg common.ConfigurationStorage) (*S3BlobStore, error) {
 		client: &http.Client{
 			Transport: transport,
 		},
-		endpoint:  strings.TrimRight(cfg.S3Endpoint, "/"),
+		endpoint:  endpoint,
 		region:    region,
 		bucket:    cfg.S3Bucket,
 		accessKey: cfg.S3AccessKey,

--- a/src/storage/s3_blobstore_test.go
+++ b/src/storage/s3_blobstore_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"crypto/hmac"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -68,6 +70,7 @@ func TestS3BlobStore_PutGetDelete(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -124,6 +127,7 @@ func TestS3BlobStore_DeleteMissing(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -151,6 +155,7 @@ func TestS3BlobStore_GetMissing(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -200,6 +205,7 @@ func TestS3BlobStore_NoOverallClientTimeout(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -245,6 +251,7 @@ func TestS3BlobStore_NoOverallClientTimeout(t *testing.T) {
 	cfg2 := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server2.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -271,6 +278,76 @@ func TestS3BlobStore_NoOverallClientTimeout(t *testing.T) {
 	}
 }
 
+func TestS3BlobStore_TLSEnforcement(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	base := common.ConfigurationStorage{
+		Backend:     "s3",
+		S3Region:    "us-east-1",
+		S3Bucket:    "test-bucket",
+		S3AccessKey: s3TestAccessKey,
+		S3SecretKey: s3TestSecretKey,
+		S3PathStyle: true,
+	}
+
+	t.Run("https accepted by default", func(t *testing.T) {
+		cfg := base
+		cfg.S3Endpoint = "https://s3.amazonaws.com"
+		store, err := NewS3BlobStore(cfg)
+		if err != nil {
+			t.Fatalf("https endpoint must be accepted without s3_insecure, got: %v", err)
+		}
+		defer store.Close()
+	})
+
+	t.Run("http rejected without insecure gate", func(t *testing.T) {
+		cfg := base
+		cfg.S3Endpoint = "http://localhost:9000"
+		_, err := NewS3BlobStore(cfg)
+		if err == nil {
+			t.Fatalf("cleartext http endpoint must be rejected unless s3_insecure=true")
+		}
+		if !errors.Is(err, syscall.EINVAL) {
+			t.Errorf("expected EINVAL, got: %v", err)
+		}
+	})
+
+	t.Run("http accepted with insecure gate", func(t *testing.T) {
+		cfg := base
+		cfg.S3Endpoint = "http://localhost:9000"
+		cfg.S3Insecure = true
+		store, err := NewS3BlobStore(cfg)
+		if err != nil {
+			t.Fatalf("http endpoint must be accepted with s3_insecure=true, got: %v", err)
+		}
+		defer store.Close()
+	})
+
+	t.Run("missing scheme rejected", func(t *testing.T) {
+		cfg := base
+		cfg.S3Endpoint = "s3.amazonaws.com"
+		_, err := NewS3BlobStore(cfg)
+		if err == nil {
+			t.Fatalf("endpoint without scheme must be rejected")
+		}
+		if !errors.Is(err, syscall.EINVAL) {
+			t.Errorf("expected EINVAL, got: %v", err)
+		}
+	})
+
+	t.Run("unsupported scheme rejected", func(t *testing.T) {
+		cfg := base
+		cfg.S3Endpoint = "ftp://s3.amazonaws.com"
+		_, err := NewS3BlobStore(cfg)
+		if err == nil {
+			t.Fatalf("unsupported scheme must be rejected")
+		}
+		if !errors.Is(err, syscall.EINVAL) {
+			t.Errorf("expected EINVAL, got: %v", err)
+		}
+	})
+}
+
 func TestS3BlobStore_DefaultRegion(t *testing.T) {
 	server, _ := mockS3Server(t)
 	defer server.Close()
@@ -278,6 +355,7 @@ func TestS3BlobStore_DefaultRegion(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
 		S3SecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // notsecret
@@ -309,6 +387,7 @@ func TestNewStore_S3Backend(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:            "s3",
 		S3Endpoint:         server.URL,
+		S3Insecure:         true,
 		S3Region:           "us-east-1",
 		S3Bucket:           "test-bucket",
 		S3AccessKey:        "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -354,6 +433,7 @@ func TestS3BlobStore_PutLargeBlob(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "AKIAIOSFODNN7EXAMPLE",                     // notsecret
@@ -399,6 +479,7 @@ func TestNewRequest_PathTraversal(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Bucket:    "test-bucket",
 		S3AccessKey: "test", // notsecret
 		S3SecretKey: "test", // notsecret
@@ -599,6 +680,7 @@ func TestS3BlobStore_PutBlob_UsesRealPayloadHash(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: s3TestAccessKey,
@@ -635,6 +717,7 @@ func TestS3BlobStore_PutBlob_SignedPayload(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: s3TestAccessKey,
@@ -675,6 +758,7 @@ func TestS3BlobStore_SignatureBindsContent(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: s3TestAccessKey,
@@ -717,6 +801,7 @@ func TestS3BlobStore_UNSIGNEDPayloadStillTolerated(t *testing.T) {
 	cfg := common.ConfigurationStorage{
 		Backend:     "s3",
 		S3Endpoint:  server.URL,
+		S3Insecure:  true,
 		S3Region:    "us-east-1",
 		S3Bucket:    "test-bucket",
 		S3AccessKey: s3TestAccessKey,


### PR DESCRIPTION
Resolves #774

## Implementation

- Added `S3Insecure bool` field to `ConfigurationStorage` in `src/common/struct.go`.
- Parsed `s3_insecure` from INI `[storage]` section in `src/common/config.go`.
- In `NewS3BlobStore`: validates the `s3_endpoint` URL scheme on startup:
  - `https://` — always accepted.
  - `http://` — rejected with `EINVAL` unless `s3_insecure=true` is set (prominent warning logged).
  - Missing or unsupported scheme — rejected with `EINVAL`.
- Updated all existing mock-server tests (plain HTTP) to set `S3Insecure: true`.
- Added `TestS3BlobStore_TLSEnforcement` with subtables: https accepted, http rejected without insecure, http accepted with insecure, missing scheme rejected, unsupported scheme rejected.
- Updated `docs/CONFIGURATION.md` (new `s3_insecure` knob) and `docs/PROTOCOL.md` (outbound TLS enforcement + layered confidentiality model).

## Changelog

- `src/common/struct.go`: Added `S3Insecure` field to `ConfigurationStorage`.
- `src/common/config.go`: Parse `s3_insecure` from INI.
- `src/storage/s3_blobstore.go`: Scheme validation in `NewS3BlobStore`; reject non-HTTPS without insecure gate.
- `src/storage/s3_blobstore_test.go`: `S3Insecure: true` on mock-server tests; new `TestS3BlobStore_TLSEnforcement`.
- `src/storage/backends_e2e_test.go`: `S3Insecure: true` on shared mock server.
- `docs/CONFIGURATION.md`: Document `s3_insecure`.
- `docs/PROTOCOL.md`: Outbound TLS enforcement section + layered confidentiality model.
- `openspec/changes/s3-https-enforcement/`: Proposal, spec, tasks documenting the change.

## Validation
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -count=1 ./...` across all 9 modules (root, common, storage, transport `-race`, client, server, metrics, crypto, p2p) ✓
- `go work vendor` produces no diff (Rule 25) ✓
- `gofmt -l` clean on all touched files ✓
- Pre-commit hook synced `docs/PERFORMANCE.md` ✓