### PR TITLE
feat: require TLS (or explicit insecure) for s3-tcp inbound gateway

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3113,3 +3113,14 @@ e07261e,BenchmarkSanitizeLog/Unsafe-8,825.70,704.00,1.00
 1e21e2b,BenchmarkPadString-8,63.97,64.00,1.00
 1e21e2b,BenchmarkSanitizeLog/Safe-8,585.00,0.00,0.00
 1e21e2b,BenchmarkSanitizeLog/Unsafe-8,793.90,704.00,1.00
+66be498,BenchmarkAWSChunkedReaderSigned-8,485586.00,137.07,11284.00
+66be498,BenchmarkAWSChunkedReaderUnsigned-8,458443.00,145.19,78570.00
+66be498,BenchmarkCheckMetricsAndSwap-8,8.59,0.00,0.00
+66be498,BenchmarkCrushOptimized-8,354.70,0.00,0.00
+66be498,BenchmarkCrushOriginal-8,459.40,164.00,3.00
+66be498,BenchmarkIndexDirectTracking-8,0.47,0.00,0.00
+66be498,BenchmarkIndexSearch-8,3.06,0.00,0.00
+66be498,BenchmarkLoadGlobalConfig-8,7877.00,1576.00,46.00
+66be498,BenchmarkPadString-8,43.27,64.00,1.00
+66be498,BenchmarkSanitizeLog/Safe-8,443.90,0.00,0.00
+66be498,BenchmarkSanitizeLog/Unsafe-8,567.90,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             549.3n ± ∞ ¹    628.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            352.6n ± ∞ ¹    419.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.352µ ± ∞ ¹   11.680µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 53.49n ± ∞ ¹    63.97n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          439.8n ± ∞ ¹    585.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        668.7n ± ∞ ¹    793.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    493.3µ ± ∞ ¹    623.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  518.6µ ± ∞ ¹    637.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       9.750n ± ∞ ¹   13.110n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.783n ± ∞ ¹    3.365n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4888n ± ∞ ¹   0.5215n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     410.2n          525.0n        +27.98%
+CrushOriginal-8                             628.0n ± ∞ ¹    459.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            419.3n ± ∞ ¹    354.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         11.680µ ± ∞ ¹    7.877µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 63.97n ± ∞ ¹    43.27n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          585.0n ± ∞ ¹    443.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        793.9n ± ∞ ¹    567.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    623.3µ ± ∞ ¹    485.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  637.1µ ± ∞ ¹    458.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      13.110n ± ∞ ¹    8.592n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.365n ± ∞ ¹    3.060n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.5215n ± ∞ ¹   0.4734n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     525.0n          397.2n        -24.35%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.05Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.75Ki ± ∞ ¹   76.77Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.05Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.77Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.03%               ⁴
+geomean                                                ⁴                  -0.03%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   128.7Mi ± ∞ ¹   101.8Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                122.39Mi ± ∞ ¹   99.63Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    125.5Mi         100.7Mi        -19.74%
+                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s        vs base                 │
+AWSChunkedReaderSigned-8                   101.8Mi ± ∞ ¹    130.7Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 99.63Mi ± ∞ ¹   138.46Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    100.7Mi          134.5Mi        +33.57%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 623314.00 ns/op | 106.78 B/op | 11320.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 637133.00 ns/op | 104.47 B/op | 78612.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 13.11 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 419.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 628.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 11680.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 63.97 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 585.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 793.90 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 485586.00 ns/op | 137.07 B/op | 11284.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 458443.00 ns/op | 145.19 B/op | 78570.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.59 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 354.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 459.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.06 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7877.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 43.27 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 443.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 567.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b]
-    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,584226,2838201,493329,623314]
-    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,631654,617880,518620,637133]
-    line "CheckMetricsAndSwap" [10,9,10,9,10,10,9,16,10,13]
-    line "CrushOptimized" [388,436,307,344,355,415,439,381,353,419]
-    line "CrushOriginal" [594,516,557,494,491,570,664,686,549,628]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,1]
-    line "IndexSearch" [2,2,2,2,2,2,2,3,2,3]
-    line "LoadGlobalConfig" [8182,9158,7310,7930,8102,9075,10900,10925,8352,11680]
-    line "PadString" [54,52,40,46,49,53,64,66,53,64]
+    x-axis [4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b,66be498]
+    line "AWSChunkedReaderSigned" [0,0,0,0,0,584226,2838201,493329,623314,485586]
+    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,631654,617880,518620,637133,458443]
+    line "CheckMetricsAndSwap" [9,10,9,10,10,9,16,10,13,9]
+    line "CrushOptimized" [436,307,344,355,415,439,381,353,419,355]
+    line "CrushOriginal" [516,557,494,491,570,664,686,549,628,459]
+    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,1,0]
+    line "IndexSearch" [2,2,2,2,2,2,3,2,3,3]
+    line "LoadGlobalConfig" [9158,7310,7930,8102,9075,10900,10925,8352,11680,7877]
+    line "PadString" [52,40,46,49,53,64,66,53,64,43]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [464,500,456,475,487,537,496,673,440,585]
-    line "SanitizeLog/Unsafe" [668,782,686,592,720,762,826,1502,669,794]
+    line "SanitizeLog/Safe" [500,456,475,487,537,496,673,440,585,444]
+    line "SanitizeLog/Unsafe" [782,686,592,720,762,826,1502,669,794,568]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b]
-    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,114,23,135,107]
-    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,105,108,128,104]
+    x-axis [4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b,66be498]
+    line "AWSChunkedReaderSigned" [0,0,0,0,0,114,23,135,107,137]
+    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,105,108,128,104,145]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [f52f7f1,4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b]
-    line "AWSChunkedReaderSigned" [0,0,0,0,0,0,11316,11705,11290,11320]
-    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,0,78590,78616,78594,78612]
+    x-axis [4368e6e,a2dd35a,651be22,3a22811,323877d,e07261e,9de7002,32c0290,1e21e2b,66be498]
+    line "AWSChunkedReaderSigned" [0,0,0,0,0,11316,11705,11290,11320,11284]
+    line "AWSChunkedReaderUnsigned" [0,0,0,0,0,78590,78616,78594,78612,78570]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -18,6 +18,14 @@ When `tls_cert` and `tls_key` are configured, TCP-based protocols (`momo-tcp`, `
 
 QUIC peer verification defaults to strict: either `ca_cert` must be configured or `tls_insecure = true` must be explicitly set. This prevents accidental MitM vulnerabilities.
 
+### S3 inbound gateway TLS requirements (issue #775)
+
+The `s3-tcp` protocol **requires** TLS. When no `tls_cert`/`tls_key` are configured, `Listen` returns an `EINVAL` error unless `tls_insecure = true` is explicitly set (in which case a prominent startup warning is emitted and the gateway serves S3 over cleartext HTTP). This mirrors the AWS standard of TLS-only S3.
+
+The `momo-tcp` protocol is unaffected — it carries its own authentication via the momo handshake and does not require TLS.
+
+QUIC protocols (`s3-quic`, `momo-quic`) always use TLS 1.3 via QUIC. When no `tls_cert`/`tls_key` are configured, a self-signed certificate is generated and a warning is logged noting that the connection is encrypted but the server identity is unauthenticated.
+
 When TLS is enabled, the momo handshake uses **challenge-response authentication** instead of sending the auth token in plaintext.
 
 ## Handshake

--- a/openspec/changes/s3-inbound-tls-enforcement/proposal.md
+++ b/openspec/changes/s3-inbound-tls-enforcement/proposal.md
@@ -1,0 +1,19 @@
+# Change: S3 — require TLS (or explicit insecure) for the s3-tcp inbound gateway
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/775
+
+## Why
+The `s3-tcp` inbound gateway serves S3 REST requests over raw TCP. Without a configured TLS cert/key pair, the entire S3 exchange — object payload, SigV4 headers, credentials material — travels in cleartext. Only `s3-quic` is encrypted-by-default (TLS 1.3). For "real end-to-end encryption" the inbound S3 gateway must either require TLS or loudly refuse to serve sensitive traffic without it.
+
+## What Changes
+- **`s3-tcp` `Listen` enforces TLS.** When `f.tlsConfig == nil` (no `tls_cert`/`tls_key` configured):
+  - If `tls_insecure` is not set → return `EINVAL` error ("s3-tcp requires TLS").
+  - If `tls_insecure = true` → log prominent warning and accept cleartext.
+- **`momo-tcp` unchanged.** The momo protocol carries its own authentication and does not require TLS.
+- **QUIC self-signed fallback warning added.** For `momo-quic`/`s3-quic` without configured certs, log a warning that the connection is encrypted but the server identity is unauthenticated.
+- **`docs/PROTOCOL.md` updated.** Documents the inbound gateway TLS requirements per protocol.
+
+## Non-Goals
+- No change to `momo-tcp`/`momo-quic` clients (their auth is independent of TLS).
+- No change to the outbound S3 storage enforcement (already handled in #774).
+

--- a/openspec/changes/s3-inbound-tls-enforcement/specs/s3-inbound-tls-enforcement/spec.md
+++ b/openspec/changes/s3-inbound-tls-enforcement/specs/s3-inbound-tls-enforcement/spec.md
@@ -1,0 +1,33 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/775
+
+# S3 — Inbound TLS Enforcement Specification
+
+## Purpose
+This specification requires TLS on the `s3-tcp` inbound gateway to prevent silent cleartext serving of S3 REST requests (object payloads, SigV4 headers, credentials material) when no TLS certificate is configured.
+
+## ADDED Requirements
+
+### Requirement: s3-tcp TLS enforcement on listen
+`Listen` SHALL reject `s3-tcp` without a configured TLS certificate unless `tls_insecure = true` is explicitly set. When rejected, the error SHALL carry `EINVAL`.
+
+#### Scenario: s3-tcp without TLS rejected by default
+- **GIVEN** `protocol = s3-tcp` with no `tls_cert`/`tls_key` and `tls_insecure = false` (default)
+- **WHEN** `Listen` is called
+- **THEN** it returns an `EINVAL` error
+
+#### Scenario: s3-tcp with TLSInsecure accepted with warning
+- **GIVEN** `protocol = s3-tcp` with no `tls_cert`/`tls_key` and `tls_insecure = true`
+- **WHEN** `Listen` is called
+- **THEN** it succeeds and a prominent warning is logged
+
+#### Scenario: s3-tcp with TLS config accepted
+- **GIVEN** `protocol = s3-tcp` with `tls_cert`/`tls_key` configured
+- **WHEN** `Listen` is called
+- **THEN** it succeeds with a TLS-wrapped listener
+
+### Requirement: momo-tcp unchanged
+The `momo-tcp` protocol SHALL NOT be affected by the s3-tcp enforcement — it carries its own authentication and does not require TLS. `Listen` for `momo-tcp` without TLS SHALL succeed as before.
+
+### Requirement: QUIC self-signed fallback warning
+When `momo-quic` or `s3-quic` falls back to a self-signed certificate (no `tls_cert`/`tls_key` configured), a SHALL log a warning that the connection is encrypted but the server identity is unauthenticated.
+

--- a/openspec/changes/s3-inbound-tls-enforcement/tasks.md
+++ b/openspec/changes/s3-inbound-tls-enforcement/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: S3 — require TLS (or explicit insecure) for the s3-tcp inbound gateway (issue #775)
+
+## 1. Phase 1: `Listen()` TLS enforcement for s3-tcp
+- [x] 1.1 Split `momo-tcp`/`s3-tcp` cases in `Listen()`.
+- [x] 1.2 For `s3-tcp`: if `f.tlsConfig == nil` and `!TLSInsecure` → return `EINVAL` error.
+- [x] 1.3 For `s3-tcp`: if `f.tlsConfig == nil` and `TLSInsecure` → log warning, accept cleartext.
+- [x] 1.4 For `momo-tcp`: unchanged (never fails on missing TLS config).
+- [x] 1.5 For QUIC self-signed fallback: log warning about unauthenticated identity.
+
+## 2. Phase 2: Tests
+- [x] 2.1 `TestProtocolFactory_Listen_S3TCP_TLSEnforcement`: s3-tcp without TLS rejected by default.
+- [x] 2.2 s3-tcp with `TLSInsecure=true` accepted.
+- [x] 2.3 momo-tcp without TLS still accepted (unchanged).
+- [x] 2.4 Fix `TestS3Communicator_FullFlow` (uses s3-tcp without TLS) to set `TLSInsecure: true`.
+
+## 3. Phase 3: Docs
+- [x] 3.1 Update `docs/PROTOCOL.md` — document s3-tcp TLS requirement and QUIC self-signed warning.
+- [x] 3.2 Create `openspec/changes/s3-inbound-tls-enforcement/` (proposal, tasks) with `Resolves #775` links.
+
+## 4. Validation
+- [ ] 4.1 Run `gofmt`, `go vet`, and the full per-module test suites.
+- [ ] 4.2 Verify `go work vendor` produces no diff (Rule 25).
+- [ ] 4.3 Commit (pre-commit hook syncs `docs/PERFORMANCE.md`), Rule 58 branch check, push.
+- [ ] 4.4 Open PR with `Resolves #775`, wait for checks, address review, merge, close issue, Rule 71 gate.
+

--- a/src/transport/factory.go
+++ b/src/transport/factory.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/alsotoes/momo/src/common"
@@ -119,13 +120,27 @@ func (f *ProtocolFactory) Dial(address string) (Communicator, error) {
 // Listen starts a listener for the configured protocol.
 func (f *ProtocolFactory) Listen(address string) (MomoListener, error) {
 	switch f.cfg.Global.Protocol {
-	case "momo-tcp", "s3-tcp":
+	case "momo-tcp":
 		l, err := net.Listen("tcp", address)
 		if err != nil {
 			return nil, err
 		}
 		if f.tlsConfig != nil {
 			l = tls.NewListener(l, f.tlsConfig)
+		}
+		return &TCPListener{Listener: l, factory: f}, nil
+	case "s3-tcp":
+		if f.tlsConfig == nil && !f.cfg.Global.TLSInsecure {
+			return nil, fmt.Errorf("s3-tcp requires TLS (configure tls_cert/tls_key) or set tls_insecure=true to allow cleartext S3 serving: %w", syscall.EINVAL)
+		}
+		l, err := net.Listen("tcp", address)
+		if err != nil {
+			return nil, err
+		}
+		if f.tlsConfig != nil {
+			l = tls.NewListener(l, f.tlsConfig)
+		} else {
+			log.Printf("WARNING: s3-tcp without TLS (tls_insecure=true); S3 credentials and blob content travel in cleartext")
 		}
 		return &TCPListener{Listener: l, factory: f}, nil
 	case "momo-quic", "s3-quic":
@@ -147,6 +162,7 @@ func (f *ProtocolFactory) Listen(address string) (MomoListener, error) {
 				return nil, fmt.Errorf("failed to generate cert: %w", err)
 			}
 			tlsConf.Certificates = []tls.Certificate{cert}
+			log.Printf("WARNING: %s using self-signed TLS certificate (encrypted but unauthenticated); configure tls_cert/tls_key for verified identity", f.cfg.Global.Protocol)
 		}
 		l, err := quic.ListenAddr(address, tlsConf, nil)
 		if err != nil {

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -13,6 +14,56 @@ import (
 	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/storage"
 )
+
+func TestProtocolFactory_Listen_S3TCP_TLSEnforcement(t *testing.T) {
+	t.Run("s3-tcp without TLS rejected by default", func(t *testing.T) {
+		cfg := common.Configuration{
+			Global: common.ConfigurationGlobal{
+				Protocol: "s3-tcp",
+			},
+		}
+		factory := NewProtocolFactory(cfg)
+		_, err := factory.Listen("127.0.0.1:0")
+		if err == nil {
+			t.Fatalf("s3-tcp without TLS must be rejected unless tls_insecure=true")
+		}
+		if !errors.Is(err, syscall.EINVAL) {
+			t.Errorf("expected EINVAL, got: %v", err)
+		}
+	})
+
+	t.Run("s3-tcp with TLSInsecure accepted", func(t *testing.T) {
+		cfg := common.Configuration{
+			Global: common.ConfigurationGlobal{
+				Protocol:    "s3-tcp",
+				TLSInsecure: true,
+			},
+		}
+		factory := NewProtocolFactory(cfg)
+		l, err := factory.Listen("127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("s3-tcp with tls_insecure must be accepted, got: %v", err)
+		}
+		defer l.Close()
+		if _, ok := l.(*TCPListener); !ok {
+			t.Errorf("Expected *TCPListener, got %T", l)
+		}
+	})
+
+	t.Run("momo-tcp without TLS still accepted", func(t *testing.T) {
+		cfg := common.Configuration{
+			Global: common.ConfigurationGlobal{
+				Protocol: "momo-tcp",
+			},
+		}
+		factory := NewProtocolFactory(cfg)
+		l, err := factory.Listen("127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("momo-tcp without TLS must remain accepted, got: %v", err)
+		}
+		defer l.Close()
+	})
+}
 
 func TestProtocolFactory_Listen_TCP(t *testing.T) {
 	cfg := common.Configuration{

--- a/src/transport/s3_communicator_extra_test.go
+++ b/src/transport/s3_communicator_extra_test.go
@@ -24,8 +24,9 @@ func TestS3Communicator_FullFlow(t *testing.T) {
 
 	cfg := common.Configuration{
 		Global: common.ConfigurationGlobal{
-			Protocol:  "s3-tcp",
-			AuthToken: authToken,
+			Protocol:    "s3-tcp",
+			AuthToken:   authToken,
+			TLSInsecure: true,
 		},
 	}
 	factory := NewProtocolFactory(cfg)


### PR DESCRIPTION
Resolves #775

## Implementation

## Implementation

- Split `momo-tcp` and `s3-tcp` cases in `Listen()`.
- For `s3-tcp`: if no TLS cert/key configured and `tls_insecure` is not set, return `EINVAL` error.
- For `s3-tcp`: if no TLS cert/key configured but `tls_insecure=true`, log prominent warning and accept cleartext.
- For `momo-tcp`: unchanged (never requires TLS).
- For `s3-quic`/`momo-quic`: log warning when using self-signed fallback (encrypted but unauthenticated).
- Updated `docs/PROTOCOL.md` to document per-protocol TLS requirements.

## Changelog

- `src/transport/factory.go`: Split momo-tcp/s3-tcp cases; s3-tcp TLS enforcement; QUIC self-signed warning.
- `src/transport/factory_test.go`: New `TestProtocolFactory_Listen_S3TCP_TLSEnforcement` (3 subtests).
- `src/transport/s3_communicator_extra_test.go`: Added `TLSInsecure: true` to `TestS3Communicator_FullFlow`.
- `docs/PROTOCOL.md`: Document s3-tcp TLS requirement and QUIC self-signed warning.
- `openspec/changes/s3-inbound-tls-enforcement/`: Proposal, spec, tasks documenting the change.

## Validation
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -race -count=1 ./...` transport ✓ (incl. new TLS enforcement tests)
- All 9 modules (root, common, storage, transport `-race`, client, server, metrics, crypto, p2p) ✓
- `go work vendor` no diff ✓
- `gofmt -l` clean ✓