### PR TITLE
fix: bound replication forwarding wait with a hard timeout (#628)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3179,3 +3179,14 @@ b81faa4,BenchmarkSanitizeLog/Unsafe-8,616.50,704.00,1.00
 98d8518,BenchmarkPadString-8,53.59,64.00,1.00
 98d8518,BenchmarkSanitizeLog/Safe-8,468.30,0.00,0.00
 98d8518,BenchmarkSanitizeLog/Unsafe-8,677.30,704.00,1.00
+fcd41b1,BenchmarkAWSChunkedReaderSigned-8,593420.00,112.16,11301.00
+fcd41b1,BenchmarkAWSChunkedReaderUnsigned-8,539873.00,123.29,78579.00
+fcd41b1,BenchmarkCheckMetricsAndSwap-8,10.63,0.00,0.00
+fcd41b1,BenchmarkCrushOptimized-8,358.30,0.00,0.00
+fcd41b1,BenchmarkCrushOriginal-8,559.60,164.00,3.00
+fcd41b1,BenchmarkIndexDirectTracking-8,0.43,0.00,0.00
+fcd41b1,BenchmarkIndexSearch-8,3.42,0.00,0.00
+fcd41b1,BenchmarkLoadGlobalConfig-8,9076.00,1576.00,46.00
+fcd41b1,BenchmarkPadString-8,51.13,64.00,1.00
+fcd41b1,BenchmarkSanitizeLog/Safe-8,492.90,0.00,0.00
+fcd41b1,BenchmarkSanitizeLog/Unsafe-8,712.50,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             443.5n ± ∞ ¹    518.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            356.9n ± ∞ ¹    365.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          7.311µ ± ∞ ¹    8.381µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 40.79n ± ∞ ¹    53.59n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          440.5n ± ∞ ¹    468.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        544.4n ± ∞ ¹    677.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    474.5µ ± ∞ ¹    547.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  470.9µ ± ∞ ¹    542.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.937n ± ∞ ¹    8.536n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.807n ± ∞ ¹    3.051n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4224n ± ∞ ¹   0.4143n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     379.9n          427.3n        +12.46%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                             530.7n ± ∞ ¹    559.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            417.8n ± ∞ ¹    358.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         11.385µ ± ∞ ¹    9.076µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 47.26n ± ∞ ¹    51.13n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          465.5n ± ∞ ¹    492.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        634.9n ± ∞ ¹    712.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    533.6µ ± ∞ ¹    593.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  495.4µ ± ∞ ¹    539.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.826n ± ∞ ¹   10.630n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.238n ± ∞ ¹    3.420n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4541n ± ∞ ¹   0.4326n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     440.4n          452.9n        +2.84%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.05Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.04Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.02%               ⁴
+geomean                                                ⁴                  +0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   133.8Mi ± ∞ ¹   115.9Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 134.8Mi ± ∞ ¹   117.0Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    134.3Mi         116.5Mi        -13.27%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │             B/s             │      B/s       vs base                │
+AWSChunkedReaderSigned-8                   119.0Mi ± ∞ ¹   107.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 128.1Mi ± ∞ ¹   117.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    123.5Mi         112.1Mi        -9.16%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 547638.00 ns/op | 121.54 B/op | 11316.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 542477.00 ns/op | 122.70 B/op | 78586.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.54 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 365.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 518.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.05 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8381.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 53.59 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 468.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 677.30 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 593420.00 ns/op | 112.16 B/op | 11301.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 539873.00 ns/op | 123.29 B/op | 78579.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.63 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 358.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 559.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.43 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9076.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 51.13 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 492.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 712.50 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e07261e,9de7002,32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518]
-    line "AWSChunkedReaderSigned" [584226,2838201,493329,623314,485586,428699,494161,536055,474487,547638]
-    line "AWSChunkedReaderUnsigned" [631654,617880,518620,637133,458443,420916,489488,535372,470934,542477]
-    line "CheckMetricsAndSwap" [9,16,10,13,9,8,8,11,8,9]
-    line "CrushOptimized" [439,381,353,419,355,342,351,359,357,366]
-    line "CrushOriginal" [664,686,549,628,459,465,587,501,444,519]
-    line "IndexDirectTracking" [0,1,0,1,0,0,0,0,0,0]
-    line "IndexSearch" [2,3,2,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [10900,10925,8352,11680,7877,7811,8699,9154,7311,8381]
-    line "PadString" [64,66,53,64,43,49,49,50,41,54]
+    x-axis [9de7002,32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1]
+    line "AWSChunkedReaderSigned" [2838201,493329,623314,485586,428699,494161,536055,474487,547638,593420]
+    line "AWSChunkedReaderUnsigned" [617880,518620,637133,458443,420916,489488,535372,470934,542477,539873]
+    line "CheckMetricsAndSwap" [16,10,13,9,8,8,11,8,9,11]
+    line "CrushOptimized" [381,353,419,355,342,351,359,357,366,358]
+    line "CrushOriginal" [686,549,628,459,465,587,501,444,519,560]
+    line "IndexDirectTracking" [1,0,1,0,0,0,0,0,0,0]
+    line "IndexSearch" [3,2,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [10925,8352,11680,7877,7811,8699,9154,7311,8381,9076]
+    line "PadString" [66,53,64,43,49,49,50,41,54,51]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [496,673,440,585,444,426,532,520,440,468]
-    line "SanitizeLog/Unsafe" [826,1502,669,794,568,519,657,616,544,677]
+    line "SanitizeLog/Safe" [673,440,585,444,426,532,520,440,468,493]
+    line "SanitizeLog/Unsafe" [1502,669,794,568,519,657,616,544,677,712]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e07261e,9de7002,32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518]
-    line "AWSChunkedReaderSigned" [114,23,135,107,137,155,135,124,140,122]
-    line "AWSChunkedReaderUnsigned" [105,108,128,104,145,158,136,124,141,123]
+    x-axis [9de7002,32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1]
+    line "AWSChunkedReaderSigned" [23,135,107,137,155,135,124,140,122,112]
+    line "AWSChunkedReaderUnsigned" [108,128,104,145,158,136,124,141,123,123]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e07261e,9de7002,32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518]
-    line "AWSChunkedReaderSigned" [11316,11705,11290,11320,11284,11279,11295,11290,11295,11316]
-    line "AWSChunkedReaderUnsigned" [78590,78616,78594,78612,78570,78565,78569,78578,78577,78586]
+    x-axis [9de7002,32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1]
+    line "AWSChunkedReaderSigned" [11705,11290,11320,11284,11279,11295,11290,11295,11316,11301]
+    line "AWSChunkedReaderUnsigned" [78616,78594,78612,78570,78565,78569,78578,78577,78586,78579]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -32,6 +32,13 @@ var connectToPeer = client.Connect
 // replication forwarding from a store reader instead of a local file path.
 var connectToPeerStream = client.ConnectStream
 
+// replicationForwardTimeout bounds how long the server waits for replication
+// forwarding goroutines to complete before abandoning them. Without this bound,
+// a hung peer or stalled backing store would block the connection-handler
+// goroutine indefinitely (issue #628). It is a variable to allow tests to
+// shorten the window.
+var replicationForwardTimeout = 30 * time.Second
+
 // Daemon is the core of the momo server.
 // It listens for incoming connections and handles file uploads and replication.
 // The server's behavior is determined by the replicationMode, which is received from the client.
@@ -431,6 +438,31 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 
 			var wg sync.WaitGroup
 
+			// forwardTimedOut records whether a replication forwarder was abandoned
+			// due to the hard wait deadline, so the success ACK is suppressed.
+			forwardTimedOut := false
+
+			// waitForForwarders blocks until all replication forwarding goroutines
+			// complete, bounded by a hard deadline. If a forwarder hangs (e.g. an
+			// unresponsive peer or stalled S3 backing store), the forwarding is
+			// abandoned so the connection-handler goroutine is never leaked
+			// forever, and the failure is recorded (Rule 4 / issue #628).
+			waitForForwarders := func() {
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					wg.Wait()
+				}()
+				select {
+				case <-done:
+					// all forwarders completed
+				case <-time.After(replicationForwardTimeout):
+					log.Printf("AUDIT: Replication forwarding timed out after %v for %s", replicationForwardTimeout, fileName)
+					metricsCollector.IncErrors()
+					forwardTimedOut = true
+				}
+			}
+
 			// Handle the file based on the replication mode
 			switch replicationMode {
 			case common.ReplicationNone, common.ReplicationPrimarySplay:
@@ -506,7 +538,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				} else {
 					wg.Done()
 				}
-				wg.Wait()
+				waitForForwarders()
 
 			case common.ReplicationSplay:
 				// In Splay mode, the primary (first node in placement) forwards to all others.
@@ -555,7 +587,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 							metricsCollector.IncReplication()
 						}(targetId)
 					}
-					wg.Wait()
+					waitForForwarders()
 				} else {
 					// We are a secondary in a splay, just receive the file if needed.
 					if canDedup {
@@ -576,6 +608,11 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				}
 			default:
 				log.Printf("AUDIT: *** ERROR: Unknown replication type from %s", remoteAddr)
+				metricsCollector.IncErrors()
+				return
+			}
+			if forwardTimedOut {
+				log.Printf("AUDIT: Upload from %s stored locally but replication forwarding timed out", remoteAddr)
 				metricsCollector.IncErrors()
 				return
 			}

--- a/src/server/server_daemon_test.go
+++ b/src/server/server_daemon_test.go
@@ -216,3 +216,102 @@ func TestDaemonReal(t *testing.T) {
 		}
 	}
 }
+
+// TestDaemonReplicationForwardTimeout verifies that a hung replication
+// forwarder does not block the connection handler forever: after the bounded
+// wait deadline the server abandons forwarding, suppresses the success ACK, and
+// the handler returns. Regression test for issue #628.
+func TestDaemonReplicationForwardTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	tempDir := t.TempDir()
+	primaryAddr := freeAddr(t)
+	daemons := []*common.Daemon{
+		{Host: primaryAddr, Data: tempDir + "/000"},
+		{Host: freeAddr(t), Data: tempDir + "/001"},
+		{Host: freeAddr(t), Data: tempDir + "/002"},
+	}
+	for _, d := range daemons {
+		os.MkdirAll(d.Data, 0755)
+	}
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	cfg := common.Configuration{
+		Daemons: daemons,
+		Global: common.ConfigurationGlobal{
+			AuthToken:         authToken,
+			Protocol:          "momo-tcp",
+			ReplicationFactor: 3,
+		},
+	}
+
+	SetReplicationState(common.ReplicationChain, time.Now().UnixNano())
+
+	// Override the forwarder to block forever, simulating a hung peer/S3 store.
+	blocked := make(chan struct{})
+	originalForward := connectToPeerStream
+	connectToPeerStream = func(cfg common.Configuration, content io.Reader, name, hash string, size int64, remotePath string, s3Headers map[string]string, serverId int, timestamp int64, requestedMode int, replicationFactor int) {
+		<-blocked
+	}
+	defer func() { connectToPeerStream = originalForward }()
+
+	// Shorten the forward wait deadline so the test completes quickly.
+	originalTimeout := replicationForwardTimeout
+	replicationForwardTimeout = 500 * time.Millisecond
+	defer func() { replicationForwardTimeout = originalTimeout }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Daemon(ctx, cfg, 0)
+
+	var conn net.Conn
+	var err error
+	for i := 0; i < 20; i++ {
+		conn, err = net.Dial("tcp", primaryAddr)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("Failed to dial primary Daemon: %v", err)
+	}
+	defer conn.Close()
+
+	comm := transport.NewMomoTCPCommunicator(conn)
+	if _, err := comm.HandshakeClient(authToken, common.DummyEpoch, 0); err != nil {
+		t.Fatalf("Handshake failed: %v", err)
+	}
+
+	meta := &common.FileMetadata{
+		Name: "forward-hang.txt",
+		Hash: common.HashBytes([]byte("forward-hang-data")),
+		Size: 16,
+	}
+	status, err := comm.SendMetadata(meta)
+	if err != nil {
+		t.Fatalf("Failed to send metadata: %v", err)
+	}
+	if status != transport.MetadataStatusSendPayload {
+		t.Fatalf("Expected status %d, got %d", transport.MetadataStatusSendPayload, status)
+	}
+	if _, err := comm.Write([]byte("forward-hang-data")); err != nil {
+		t.Fatalf("Failed to write payload: %v", err)
+	}
+
+	// The blocked forwarder means no success ACK is ever sent. ReceiveACK must
+	// fail (connection closed after abandonment), proving the handler unblocked.
+	done := make(chan error, 1)
+	go func() {
+		comm.SetAbsoluteDeadline(time.Now().Add(5 * time.Second))
+		done <- comm.ReceiveACK()
+	}()
+	select {
+	case ackErr := <-done:
+		if ackErr == nil {
+			t.Fatalf("Expected ReceiveACK to fail when forwarding timed out, but it succeeded")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Handler blocked forever waiting for a hung forwarder")
+	}
+}


### PR DESCRIPTION
Resolves #628

The replication forwarding paths in `server.go` (`ReplicationChain` and `ReplicationSplay`) called `wg.Wait()` unconditionally. If a forwarding goroutine hung (unresponsive peer, stalled S3 backing store, or a blocking `store.Get`/`connectToPeerStream` with no timeout), the connection-handler goroutine was blocked forever — a goroutine and client-connection leak.

## Fix
- Added a `waitForForwarders` helper that blocks on `wg.Wait()` but is bounded by a hard deadline (`replicationForwardTimeout`, default 30s).
- On timeout, the forwarding is abandoned, an error is counted, and the success ACK is suppressed so the client is not falsely told the upload fully replicated.
- `replicationForwardTimeout` is a variable so tests can shorten the window.

## Changelog
- 5006b16: bound forwarding wait with a hard wait deadline

## Testing
- `go build ./...` ✓
- `go vet ./src/server/` ✓
- `go test ./src/server/ -run TestDaemonReplicationForwardTimeout -count=1 -race` ✓ (regression: blocked forwarder no longer hangs the handler)