### PR TITLE
fix: remove closed connections and detach peers on disconnect (#631)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3201,3 +3201,14 @@ fcd41b1,BenchmarkSanitizeLog/Unsafe-8,580.60,704.00,1.00
 9ebbbcc,BenchmarkPadString-8,43.79,64.00,1.00
 9ebbbcc,BenchmarkSanitizeLog/Safe-8,508.10,0.00,0.00
 9ebbbcc,BenchmarkSanitizeLog/Unsafe-8,581.20,704.00,1.00
+b20b2a6,BenchmarkAWSChunkedReaderSigned-8,461874.00,144.11,11278.00
+b20b2a6,BenchmarkAWSChunkedReaderUnsigned-8,469009.00,141.92,78584.00
+b20b2a6,BenchmarkCheckMetricsAndSwap-8,10.86,0.00,0.00
+b20b2a6,BenchmarkCrushOptimized-8,341.30,0.00,0.00
+b20b2a6,BenchmarkCrushOriginal-8,467.10,164.00,3.00
+b20b2a6,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+b20b2a6,BenchmarkIndexSearch-8,3.07,0.00,0.00
+b20b2a6,BenchmarkLoadGlobalConfig-8,8010.00,1576.00,46.00
+b20b2a6,BenchmarkPadString-8,47.05,64.00,1.00
+b20b2a6,BenchmarkSanitizeLog/Safe-8,541.60,0.00,0.00
+b20b2a6,BenchmarkSanitizeLog/Unsafe-8,596.20,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             524.5n ± ∞ ¹    546.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            349.8n ± ∞ ¹    382.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.900µ ± ∞ ¹    8.218µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 49.53n ± ∞ ¹    43.79n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          465.1n ± ∞ ¹    508.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        705.6n ± ∞ ¹    581.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    490.6µ ± ∞ ¹    509.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  491.3µ ± ∞ ¹    492.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       10.83n ± ∞ ¹    10.31n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.012n ± ∞ ¹    2.817n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4578n ± ∞ ¹   0.3833n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     431.1n          414.4n        -3.88%
+CrushOriginal-8                             487.6n ± ∞ ¹    467.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            369.4n ± ∞ ¹    341.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.833µ ± ∞ ¹    8.010µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 45.17n ± ∞ ¹    47.05n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          569.9n ± ∞ ¹    541.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        620.1n ± ∞ ¹    596.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    505.7µ ± ∞ ¹    461.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  464.4µ ± ∞ ¹    469.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.975n ± ∞ ¹   10.860n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.314n ± ∞ ¹    3.066n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3844n ± ∞ ¹   0.3817n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     409.1n          408.9n        -0.06%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.04Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.02%               ⁴
+geomean                                                ⁴                  +0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   129.4Mi ± ∞ ¹   124.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 129.2Mi ± ∞ ¹   129.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    129.3Mi         126.8Mi        -1.91%
+AWSChunkedReaderSigned-8                   125.5Mi ± ∞ ¹   137.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 136.7Mi ± ∞ ¹   135.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    131.0Mi         136.4Mi        +4.13%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 509071.00 ns/op | 130.75 B/op | 11282.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 492103.00 ns/op | 135.26 B/op | 78566.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 382.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 546.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 461874.00 ns/op | 144.11 B/op | 11278.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 469009.00 ns/op | 141.92 B/op | 78584.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.86 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 341.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 467.10 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.82 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8218.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 43.79 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 508.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 581.20 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.07 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8010.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 47.05 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 541.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 596.20 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc]
-    line "AWSChunkedReaderSigned" [493329,623314,485586,428699,494161,536055,474487,547638,501193,509071]
-    line "AWSChunkedReaderUnsigned" [518620,637133,458443,420916,489488,535372,470934,542477,475383,492103]
-    line "CheckMetricsAndSwap" [10,13,9,8,8,11,8,9,8,10]
-    line "CrushOptimized" [353,419,355,342,351,359,357,366,378,382]
-    line "CrushOriginal" [549,628,459,465,587,501,444,519,462,546]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [8352,11680,7877,7811,8699,9154,7311,8381,7902,8218]
-    line "PadString" [53,64,43,49,49,50,41,54,44,44]
+    x-axis [1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6]
+    line "AWSChunkedReaderSigned" [623314,485586,428699,494161,536055,474487,547638,501193,509071,461874]
+    line "AWSChunkedReaderUnsigned" [637133,458443,420916,489488,535372,470934,542477,475383,492103,469009]
+    line "CheckMetricsAndSwap" [13,9,8,8,11,8,9,8,10,11]
+    line "CrushOptimized" [419,355,342,351,359,357,366,378,382,341]
+    line "CrushOriginal" [628,459,465,587,501,444,519,462,546,467]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [11680,7877,7811,8699,9154,7311,8381,7902,8218,8010]
+    line "PadString" [64,43,49,49,50,41,54,44,44,47]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [440,585,444,426,532,520,440,468,490,508]
-    line "SanitizeLog/Unsafe" [669,794,568,519,657,616,544,677,581,581]
+    line "SanitizeLog/Safe" [585,444,426,532,520,440,468,490,508,542]
+    line "SanitizeLog/Unsafe" [794,568,519,657,616,544,677,581,581,596]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc]
-    line "AWSChunkedReaderSigned" [135,107,137,155,135,124,140,122,133,131]
-    line "AWSChunkedReaderUnsigned" [128,104,145,158,136,124,141,123,140,135]
+    x-axis [1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6]
+    line "AWSChunkedReaderSigned" [107,137,155,135,124,140,122,133,131,144]
+    line "AWSChunkedReaderUnsigned" [104,145,158,136,124,141,123,140,135,142]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc]
-    line "AWSChunkedReaderSigned" [11290,11320,11284,11279,11295,11290,11295,11316,11296,11282]
-    line "AWSChunkedReaderUnsigned" [78594,78612,78570,78565,78569,78578,78577,78586,78573,78566]
+    x-axis [1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6]
+    line "AWSChunkedReaderSigned" [11320,11284,11279,11295,11290,11295,11316,11296,11282,11278]
+    line "AWSChunkedReaderUnsigned" [78612,78570,78565,78569,78578,78577,78586,78573,78566,78584]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/tcp_transport.go
+++ b/src/p2p/tcp_transport.go
@@ -102,6 +102,25 @@ func (t *TCPTransport) acceptLoop() {
 	}
 }
 
+// cleanupConn removes a connection from the transport's tracked connection set
+// and detaches it from its peer once the read loop for that connection exits.
+// This prevents closed net.Conn objects from accumulating in t.conns (memory
+// leak) and stops downstream code from writing to a stale, closed connection
+// (issue #631). The peer itself stays in the peer map so gossip can track its
+// liveness state.
+func (t *TCPTransport) cleanupConn(conn net.Conn, peerID int32) {
+	t.mu.Lock()
+	delete(t.conns, conn)
+	t.mu.Unlock()
+
+	if peerID < 0 {
+		return
+	}
+	if peer := t.peerMap.Get(peerID); peer != nil && peer.Conn() == conn {
+		peer.SetConn(nil)
+	}
+}
+
 // handleConn reads RPCs from a single connection and delivers them to rpcCh.
 // The peer ID is extracted from the first RPC received.
 func (t *TCPTransport) handleConn(conn net.Conn) (err error) {
@@ -116,6 +135,8 @@ func (t *TCPTransport) handleConn(conn net.Conn) (err error) {
 
 	var peer *Peer
 	var peerID int32 = -1
+
+	defer func() { t.cleanupConn(conn, peerID) }()
 
 	for {
 		conn.SetReadDeadline(time.Now().Add(p2pReadTimeout))
@@ -251,6 +272,7 @@ func (t *TCPTransport) Connect(peer *Peer) (err error) {
 func (t *TCPTransport) readLoop(peerID int32, conn net.Conn) {
 	defer t.wg.Done()
 	defer conn.Close()
+	defer func() { t.cleanupConn(conn, peerID) }()
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("P2P readLoop panic recovered for peer %d: %v (errno=%d)", peerID, r, syscall.EIO)

--- a/src/p2p/tcp_transport_test.go
+++ b/src/p2p/tcp_transport_test.go
@@ -369,3 +369,64 @@ func TestTCPTransport_AuthFunc(t *testing.T) {
 		t.Fatalf("Dial for authorized peer 2 failed: %v", err)
 	}
 }
+
+// TestTCPTransport_PeerDisconnectCleanup verifies that when a connection ends,
+// the closed net.Conn is removed from the transport's tracked connection set
+// and detached from the peer, preventing a memory leak and writes to stale
+// closed connections (issue #631).
+func TestTCPTransport_PeerDisconnectCleanup(t *testing.T) {
+	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})
+	defer tr2.Close()
+
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := ln.Addr().String()
+	ln.Close()
+
+	if err := tr2.Listen(addr); err != nil {
+		t.Fatalf("tr2 Listen failed: %v", err)
+	}
+
+	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr1.Close()
+
+	peer, err := tr1.Dial(2, addr)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	if peer.Conn() == nil {
+		t.Fatal("expected live connection after dial")
+	}
+
+	// Give the read loop time to register the conn.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		tr1.mu.Lock()
+		n := len(tr1.conns)
+		tr1.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected a tracked connection after dial")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Force disconnect by closing the connection.
+	peer.Conn().Close()
+
+	// After the read loop exits, the conn must be removed and detached.
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		tr1.mu.Lock()
+		n := len(tr1.conns)
+		tr1.mu.Unlock()
+		if n == 0 && peer.Conn() == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("conn not cleaned up after disconnect: tracked=%d, peerConn=nil?%v", n, peer.Conn() == nil)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Resolves #631

When `handleConn` or `readLoop` exited on a peer disconnect, the peer was never removed from the peer map and the closed `net.Conn` was never removed from `t.conns`, accumulating closed connection objects (memory leak). Stale peers with closed connections also caused `Send()`/writes to fail.

## Fix
Added `cleanupConn` which, when a connection's read loop ends, removes the finished `net.Conn` from `t.conns` and detaches it from its peer via `SetConn(nil)`. The peer itself stays in the peer map so gossip can track its liveness state (preserving #632 semantics). Wired into both `handleConn` (inbound) and `readLoop` (outbound).

## Changelog
- b8f92db: cleanup closed connections and detach peers on disconnect

## Testing
- `go build ./...` ✓
- `go test ./src/p2p/` ✓ (incl. new `TestTCPTransport_PeerDisconnectCleanup`)