### PR TITLE
fix: restore OFFLINE peers to ALIVE on ping/ack/heartbeat (#632)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3201,3 +3201,14 @@ fcd41b1,BenchmarkSanitizeLog/Unsafe-8,580.60,704.00,1.00
 9ebbbcc,BenchmarkPadString-8,43.79,64.00,1.00
 9ebbbcc,BenchmarkSanitizeLog/Safe-8,508.10,0.00,0.00
 9ebbbcc,BenchmarkSanitizeLog/Unsafe-8,581.20,704.00,1.00
+b20b2a6,BenchmarkAWSChunkedReaderSigned-8,507099.00,131.26,11271.00
+b20b2a6,BenchmarkAWSChunkedReaderUnsigned-8,469747.00,141.69,78562.00
+b20b2a6,BenchmarkCheckMetricsAndSwap-8,8.68,0.00,0.00
+b20b2a6,BenchmarkCrushOptimized-8,365.80,0.00,0.00
+b20b2a6,BenchmarkCrushOriginal-8,545.60,164.00,3.00
+b20b2a6,BenchmarkIndexDirectTracking-8,0.44,0.00,0.00
+b20b2a6,BenchmarkIndexSearch-8,3.03,0.00,0.00
+b20b2a6,BenchmarkLoadGlobalConfig-8,9180.00,1576.00,46.00
+b20b2a6,BenchmarkPadString-8,50.33,64.00,1.00
+b20b2a6,BenchmarkSanitizeLog/Safe-8,482.10,0.00,0.00
+b20b2a6,BenchmarkSanitizeLog/Unsafe-8,784.60,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             524.5n ± ∞ ¹    546.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            349.8n ± ∞ ¹    382.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.900µ ± ∞ ¹    8.218µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 49.53n ± ∞ ¹    43.79n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          465.1n ± ∞ ¹    508.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        705.6n ± ∞ ¹    581.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    490.6µ ± ∞ ¹    509.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  491.3µ ± ∞ ¹    492.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       10.83n ± ∞ ¹    10.31n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.012n ± ∞ ¹    2.817n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4578n ± ∞ ¹   0.3833n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     431.1n          414.4n        -3.88%
+CrushOriginal-8                             467.1n ± ∞ ¹    545.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            341.3n ± ∞ ¹    365.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.010µ ± ∞ ¹    9.180µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 47.05n ± ∞ ¹    50.33n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          541.6n ± ∞ ¹    482.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        596.2n ± ∞ ¹    784.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    461.9µ ± ∞ ¹    507.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  469.0µ ± ∞ ¹    469.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      10.860n ± ∞ ¹    8.682n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.066n ± ∞ ¹    3.030n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3817n ± ∞ ¹   0.4368n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     408.9n          431.1n        +5.42%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.04Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.02%               ⁴
+geomean                                                ⁴                  -0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   129.4Mi ± ∞ ¹   124.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 129.2Mi ± ∞ ¹   129.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    129.3Mi         126.8Mi        -1.91%
+AWSChunkedReaderSigned-8                   137.4Mi ± ∞ ¹   125.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 135.3Mi ± ∞ ¹   135.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    136.4Mi         130.1Mi        -4.64%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 509071.00 ns/op | 130.75 B/op | 11282.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 492103.00 ns/op | 135.26 B/op | 78566.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 382.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 546.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.82 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8218.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 43.79 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 508.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 581.20 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 507099.00 ns/op | 131.26 B/op | 11271.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 469747.00 ns/op | 141.69 B/op | 78562.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.68 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 365.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 545.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.03 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9180.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 50.33 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 482.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 784.60 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc]
-    line "AWSChunkedReaderSigned" [493329,623314,485586,428699,494161,536055,474487,547638,501193,509071]
-    line "AWSChunkedReaderUnsigned" [518620,637133,458443,420916,489488,535372,470934,542477,475383,492103]
-    line "CheckMetricsAndSwap" [10,13,9,8,8,11,8,9,8,10]
-    line "CrushOptimized" [353,419,355,342,351,359,357,366,378,382]
-    line "CrushOriginal" [549,628,459,465,587,501,444,519,462,546]
-    line "IndexDirectTracking" [0,1,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [8352,11680,7877,7811,8699,9154,7311,8381,7902,8218]
-    line "PadString" [53,64,43,49,49,50,41,54,44,44]
+    x-axis [1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6]
+    line "AWSChunkedReaderSigned" [623314,485586,428699,494161,536055,474487,547638,501193,509071,507099]
+    line "AWSChunkedReaderUnsigned" [637133,458443,420916,489488,535372,470934,542477,475383,492103,469747]
+    line "CheckMetricsAndSwap" [13,9,8,8,11,8,9,8,10,9]
+    line "CrushOptimized" [419,355,342,351,359,357,366,378,382,366]
+    line "CrushOriginal" [628,459,465,587,501,444,519,462,546,546]
+    line "IndexDirectTracking" [1,0,0,0,0,0,0,0,0,0]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [11680,7877,7811,8699,9154,7311,8381,7902,8218,9180]
+    line "PadString" [64,43,49,49,50,41,54,44,44,50]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [440,585,444,426,532,520,440,468,490,508]
-    line "SanitizeLog/Unsafe" [669,794,568,519,657,616,544,677,581,581]
+    line "SanitizeLog/Safe" [585,444,426,532,520,440,468,490,508,482]
+    line "SanitizeLog/Unsafe" [794,568,519,657,616,544,677,581,581,785]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc]
-    line "AWSChunkedReaderSigned" [135,107,137,155,135,124,140,122,133,131]
-    line "AWSChunkedReaderUnsigned" [128,104,145,158,136,124,141,123,140,135]
+    x-axis [1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6]
+    line "AWSChunkedReaderSigned" [107,137,155,135,124,140,122,133,131,131]
+    line "AWSChunkedReaderUnsigned" [104,145,158,136,124,141,123,140,135,142]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [32c0290,1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc]
-    line "AWSChunkedReaderSigned" [11290,11320,11284,11279,11295,11290,11295,11316,11296,11282]
-    line "AWSChunkedReaderUnsigned" [78594,78612,78570,78565,78569,78578,78577,78586,78573,78566]
+    x-axis [1e21e2b,66be498,f0a2af8,2ec767e,b81faa4,0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6]
+    line "AWSChunkedReaderSigned" [11320,11284,11279,11295,11290,11295,11316,11296,11282,11271]
+    line "AWSChunkedReaderUnsigned" [78612,78570,78565,78569,78578,78577,78586,78573,78566,78562]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/gossip.go
+++ b/src/p2p/gossip.go
@@ -412,9 +412,9 @@ func (g *Gossiper) handlePing(rpc *RPC) {
 
 	if peer := g.transport.Peers().Get(rpc.From); peer != nil {
 		peer.Touch()
-		if peer.State() == PeerStateSuspect {
+		if peer.State() == PeerStateSuspect || peer.State() == PeerStateOffline {
 			peer.SetState(PeerStateAlive)
-			log.Printf("Gossip: peer %d restored to ALIVE via ping", rpc.From)
+			log.Printf("Gossip: peer %d restored to ALIVE via ping (was %d)", rpc.From, peer.State())
 		}
 	}
 }
@@ -446,9 +446,9 @@ func (g *Gossiper) handleAck(rpc *RPC) {
 
 	if peer := g.transport.Peers().Get(rpc.From); peer != nil {
 		peer.Touch()
-		if peer.State() == PeerStateSuspect {
+		if peer.State() == PeerStateSuspect || peer.State() == PeerStateOffline {
 			peer.SetState(PeerStateAlive)
-			log.Printf("Gossip: peer %d restored to ALIVE via ack", rpc.From)
+			log.Printf("Gossip: peer %d restored to ALIVE via ack (was %d)", rpc.From, peer.State())
 		}
 	}
 }
@@ -667,9 +667,9 @@ func (g *Gossiper) handleHeartbeat(rpc *RPC) {
 
 	if peer := g.transport.Peers().Get(rpc.From); peer != nil {
 		peer.Touch()
-		if peer.State() == PeerStateSuspect {
+		if peer.State() == PeerStateSuspect || peer.State() == PeerStateOffline {
 			peer.SetState(PeerStateAlive)
-			log.Printf("Gossip: peer %d restored to ALIVE via heartbeat", rpc.From)
+			log.Printf("Gossip: peer %d restored to ALIVE via heartbeat (was %d)", rpc.From, peer.State())
 		}
 	}
 }

--- a/src/p2p/gossip_test.go
+++ b/src/p2p/gossip_test.go
@@ -186,6 +186,54 @@ func TestGossiper_SuspicionTimeout(t *testing.T) {
 	}
 }
 
+// TestGossiper_OfflinePeerRestore verifies that an OFFLINE peer is restored to
+// ALIVE upon receiving a ping, ack, or heartbeat, rather than remaining
+// permanently dead (issue #632).
+func TestGossiper_OfflinePeerRestore(t *testing.T) {
+	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr.Close()
+
+	g := NewGossiper(DefaultGossipConfig(1), tr)
+	defer g.Close()
+
+	subtests := []struct {
+		name string
+		run  func(peer *Peer)
+	}{
+		{
+			name: "ping",
+			run: func(peer *Peer) {
+				payload := &PingPayload{PingID: 99, TargetID: 1, Timestamp: time.Now().UnixNano()}
+				g.handlePing(&RPC{From: peer.ID, Type: MsgPing, Payload: payload.Encode()})
+			},
+		},
+		{
+			name: "heartbeat",
+			run: func(peer *Peer) {
+				payload := &HeartbeatPayload{Peers: []PeerInfo{}}
+				g.handleHeartbeat(&RPC{From: peer.ID, Type: MsgHeartbeat, Payload: payload.Encode()})
+			},
+		},
+	}
+
+	for _, st := range subtests {
+		t.Run(st.name, func(t *testing.T) {
+			peer := NewPeer(2, "127.0.0.1:4451")
+			peer.SetState(PeerStateOffline)
+			tr.Peers().Add(peer)
+
+			st.run(peer)
+
+			if peer.State() != PeerStateAlive {
+				t.Fatalf("expected peer %d restored to ALIVE via %s, got %v", peer.ID, st.name, peer.State())
+			}
+
+			// Clean up for the next subtest.
+			tr.Peers().Remove(2)
+		})
+	}
+}
+
 func TestGossiper_PingIDUniquenessAcrossNodes(t *testing.T) {
 	tr1 := NewTCPTransport(TCPTransportConfig{LocalID: 1})
 	tr2 := NewTCPTransport(TCPTransportConfig{LocalID: 2})


### PR DESCRIPTION
Resolves #632

`handlePing`, `handleAck`, and `handleHeartbeat` only restored a peer from `SUSPECT` to `ALIVE`. Once a peer entered `OFFLINE`, receiving pings/acks/heartbeats updated `lastSeen` but never restored it — the peer remained permanently dead until a full process restart.

## Fix
All three handlers now restore a peer from BOTH `SUSPECT` and `OFFLINE` to `ALIVE` upon contact.

## Changelog
- 619bf40: restore OFFLINE peers to ALIVE on ping/ack/heartbeat

## Testing
- `go build ./...` ✓
- `go test ./src/p2p/` ✓ (incl. new `TestGossiper_OfflinePeerRestore` covering ping + heartbeat)