### PR TITLE
fix: fail lease acquisition on network partition (zero-quorum split-brain) (#630)

### DIFF
--- a/src/p2p/lease.go
+++ b/src/p2p/lease.go
@@ -211,6 +211,16 @@ func (lm *LeaseManager) Acquire(key string, duration time.Duration) (*Lease, err
 		}
 	}
 
+	// Split-brain guard (issue #630): if the cluster is configured with peers
+	// (the peer map is non-empty) but none of them are currently reachable, this
+	// is a network partition, not a single-node cluster. Granting a zero-quorum
+	// lease here would let every partition independently grant the same key.
+	// Distinguish "no peers configured" (single node, lenient self-grant) from
+	// "peers configured but unreachable" (partition, must fail).
+	if lm.transport.Peers().Count() > 0 && peerCount == 0 {
+		return nil, fmt.Errorf("no reachable peers for quorum: cluster partitioned (errno=%d)", syscall.EHOSTUNREACH)
+	}
+
 	quorum := majorityQuorum(peerCount)
 
 	leaseID := lm.nextLeaseID.Add(1)

--- a/src/p2p/lease_test.go
+++ b/src/p2p/lease_test.go
@@ -99,6 +99,30 @@ func TestMajorityQuorum(t *testing.T) {
 	}
 }
 
+// TestLeaseManager_PartitionGuard verifies that a lease is NOT granted when the
+// cluster has configured peers but none are reachable (network partition). This
+// prevents split-brain: each partition would otherwise grant the same key with a
+// zero-quorum lease (issue #630).
+func TestLeaseManager_PartitionGuard(t *testing.T) {
+	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
+	defer tr.Close()
+
+	// Configure a peer in the map that is NOT alive, simulating a peer that was
+	// once connected but is now unreachable (network partition).
+	offlinePeer := NewPeer(2, "127.0.0.1:4451")
+	offlinePeer.SetState(PeerStateOffline)
+	tr.Peers().Add(offlinePeer)
+
+	lm := NewLeaseManager(1, tr)
+	lm.Start()
+	defer lm.Stop()
+
+	_, err := lm.Acquire("test-key", 1*time.Second)
+	if err == nil {
+		t.Fatal("expected lease acquisition to fail when cluster is partitioned (no reachable peers)")
+	}
+}
+
 func TestLeaseManager_NoPeers(t *testing.T) {
 	tr := NewTCPTransport(TCPTransportConfig{LocalID: 1})
 	defer tr.Close()


### PR DESCRIPTION
Resolves #630

When `peerCount == 0` (all peers offline) the lease manager sets `quorum = 0` and the check `sent < quorum` passes (0 < 0 is false) — a lease is returned with `QuorumSize: 0`. In a network partition, every partition can independently grant leases for the same key, causing split-brain.

## Fix
Require at least 1 peer for quorum when known peers exist. The partition guard checks `Peers().Count() > 0 && peerCount == 0` — if peers are configured but none reachable, the grant is refused with `EHOSTUNREACH`. Truly single-node clusters (peer map empty) are still allowed to self-grant (`TestLeaseManager_NoPeers` passes unchanged).

## Changelog
- 7bca909: add partition guard that requires at least 1 peer when known peers exist

## Testing
- `go build ./...` ✓
- `go test ./src/p2p/` ✓ (incl. new `TestLeaseManager_PartitionGuard`)