### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix HTTP Request Smuggling (CRLF Injection) in Momo protocols

### DIFF
--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -620,6 +620,12 @@ func (m *MomoQUICCommunicator) SendMetadata(meta *common.FileMetadata) (status i
 	if len(wireName) > common.FileInfoLength {
 		return 0, fmt.Errorf("metadata name exceeds limit: %w", syscall.ENAMETOOLONG)
 	}
+
+	// 🛡️ Sentinel: Reject carriage returns or line feeds in the path to prevent HTTP Request Smuggling (CRLF Injection).
+	if strings.ContainsAny(wireName, "\r\n") {
+		return 0, fmt.Errorf("invalid characters in wireName: %w", syscall.EBADMSG)
+	}
+
 	for _, part := range strings.Split(wireName, "/") {
 		if common.HasPathTraversalChars(part) {
 			return 0, fmt.Errorf("path traversal in wireName: %w", syscall.EBADMSG)

--- a/src/transport/momo_quic_crlf_test.go
+++ b/src/transport/momo_quic_crlf_test.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"syscall"
 	"testing"
+	"go.uber.org/goleak"
 
 	"github.com/alsotoes/momo/src/common"
 )
 
 func TestMomoQUICCommunicator_SendMetadataCRLF(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	// For SendMetadata validation errors, we just need a non-nil struct so it can do memory validation.
 	comm := &MomoQUICCommunicator{}
 

--- a/src/transport/momo_quic_crlf_test.go
+++ b/src/transport/momo_quic_crlf_test.go
@@ -1,0 +1,28 @@
+package transport
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/alsotoes/momo/src/common"
+)
+
+func TestMomoQUICCommunicator_SendMetadataCRLF(t *testing.T) {
+	// For SendMetadata validation errors, we just need a non-nil struct so it can do memory validation.
+	comm := &MomoQUICCommunicator{}
+
+	// Malicious Name with CRLF
+	badMeta := &common.FileMetadata{
+		Name: "test\r\nName",
+		Hash: "hash123",
+		Size: 100,
+	}
+	_, err := comm.SendMetadata(badMeta)
+	if err == nil {
+		t.Fatal("Expected SendMetadata to fail with CRLF in name")
+	}
+	if !errors.Is(err, syscall.EBADMSG) {
+		t.Errorf("Expected EBADMSG error, got: %v", err)
+	}
+}

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -624,6 +624,12 @@ func (m *MomoTCPCommunicator) SendMetadata(meta *common.FileMetadata) (status in
 	if len(wireName) > common.FileInfoLength {
 		return 0, fmt.Errorf("metadata name exceeds limit: %w", syscall.ENAMETOOLONG)
 	}
+
+	// 🛡️ Sentinel: Reject carriage returns or line feeds in the path to prevent HTTP Request Smuggling (CRLF Injection).
+	if strings.ContainsAny(wireName, "\r\n") {
+		return 0, fmt.Errorf("invalid characters in wireName: %w", syscall.EBADMSG)
+	}
+
 	for _, part := range strings.Split(wireName, "/") {
 		if common.HasPathTraversalChars(part) {
 			return 0, fmt.Errorf("path traversal in wireName: %w", syscall.EBADMSG)

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -528,3 +528,25 @@ func TestMomoTCPCommunicator_SendMetadataPathTraversal(t *testing.T) {
 		t.Errorf("Expected EBADMSG error, got: %v", err)
 	}
 }
+
+func TestMomoTCPCommunicator_SendMetadataCRLF(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	comm := NewMomoTCPCommunicator(clientConn)
+
+	// Malicious Name with CRLF
+	badMeta := &common.FileMetadata{
+		Name: "test\r\nName",
+		Hash: "hash123",
+		Size: 100,
+	}
+	_, err := comm.SendMetadata(badMeta)
+	if err == nil {
+		t.Fatal("Expected SendMetadata to fail with CRLF in name")
+	}
+	if !errors.Is(err, syscall.EBADMSG) {
+		t.Errorf("Expected EBADMSG error, got: %v", err)
+	}
+}

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
+
 	"github.com/alsotoes/momo/src/common"
 )
 
@@ -530,6 +532,7 @@ func TestMomoTCPCommunicator_SendMetadataPathTraversal(t *testing.T) {
 }
 
 func TestMomoTCPCommunicator_SendMetadataCRLF(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()
 	defer serverConn.Close()


### PR DESCRIPTION
Resolves #812

**Severity:** CRITICAL
**Vulnerability:** HTTP Request Smuggling (CRLF Injection) in `MomoTCPCommunicator` and `MomoQUICCommunicator` via unsanitized `wireName` in `SendMetadata`.
**Impact:** Attackers could inject carriage return (`\r`) and line feed (`\n`) characters in metadata to forge requests or corrupt the protocol frame parsing.
**Fix:** Added explicit validation using `strings.ContainsAny` to reject `wireName`s containing `\r` or `\n`, returning `syscall.EBADMSG`. Applied to both `momo_tcp.go` and `momo_quic.go` (Rule 33 parity).
**Verification:** Verified by unit tests `TestMomoTCPCommunicator_SendMetadataCRLF` and `TestMomoQUICCommunicator_SendMetadataCRLF` (both with `goleak`, Rule 5), plus existing suites and full CI (smoke TCP/QUIC/S3, contract, benchstat, encryption, pentest).

---
*PR created automatically by Jules for task [6331151094180163322](https://jules.google.com/task/6331151094180163322) started by @alsotoes*