### PR TITLE
fix: add IdleTimeoutConn rolling deadline to momo-quic streams

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3267,3 +3267,14 @@ c45af2c,BenchmarkLoadGlobalConfig-8,8376.00,1576.00,46.00
 c45af2c,BenchmarkPadString-8,47.86,64.00,1.00
 c45af2c,BenchmarkSanitizeLog/Safe-8,446.00,0.00,0.00
 c45af2c,BenchmarkSanitizeLog/Unsafe-8,605.10,704.00,1.00
+ec6c955,BenchmarkAWSChunkedReaderSigned-8,743381.00,89.54,11329.00
+ec6c955,BenchmarkAWSChunkedReaderUnsigned-8,788330.00,84.43,78609.00
+ec6c955,BenchmarkCheckMetricsAndSwap-8,14.40,0.00,0.00
+ec6c955,BenchmarkCrushOptimized-8,550.80,0.00,0.00
+ec6c955,BenchmarkCrushOriginal-8,2113.00,164.00,3.00
+ec6c955,BenchmarkIndexDirectTracking-8,0.57,0.00,0.00
+ec6c955,BenchmarkIndexSearch-8,3.78,0.00,0.00
+ec6c955,BenchmarkLoadGlobalConfig-8,12340.00,1576.00,46.00
+ec6c955,BenchmarkPadString-8,81.41,64.00,1.00
+ec6c955,BenchmarkSanitizeLog/Safe-8,711.30,0.00,0.00
+ec6c955,BenchmarkSanitizeLog/Unsafe-8,1045.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3278,3 +3278,14 @@ ec6c955,BenchmarkLoadGlobalConfig-8,12340.00,1576.00,46.00
 ec6c955,BenchmarkPadString-8,81.41,64.00,1.00
 ec6c955,BenchmarkSanitizeLog/Safe-8,711.30,0.00,0.00
 ec6c955,BenchmarkSanitizeLog/Unsafe-8,1045.00,704.00,1.00
+8bb00e9,BenchmarkAWSChunkedReaderSigned-8,499698.00,133.20,11303.00
+8bb00e9,BenchmarkAWSChunkedReaderUnsigned-8,637971.00,104.33,78592.00
+8bb00e9,BenchmarkCheckMetricsAndSwap-8,8.73,0.00,0.00
+8bb00e9,BenchmarkCrushOptimized-8,317.90,0.00,0.00
+8bb00e9,BenchmarkCrushOriginal-8,682.00,164.00,3.00
+8bb00e9,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+8bb00e9,BenchmarkIndexSearch-8,2.87,0.00,0.00
+8bb00e9,BenchmarkLoadGlobalConfig-8,8029.00,1576.00,46.00
+8bb00e9,BenchmarkPadString-8,49.38,64.00,1.00
+8bb00e9,BenchmarkSanitizeLog/Safe-8,547.50,0.00,0.00
+8bb00e9,BenchmarkSanitizeLog/Unsafe-8,670.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             762.3n ± ∞ ¹    453.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            430.5n ± ∞ ¹    317.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                         10.501µ ± ∞ ¹    8.376µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 70.02n ± ∞ ¹    47.86n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          554.1n ± ∞ ¹    446.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        714.1n ± ∞ ¹    605.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    568.5µ ± ∞ ¹    455.9µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  695.9µ ± ∞ ¹    452.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                      11.530n ± ∞ ¹    8.303n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.591n ± ∞ ¹    2.855n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.5894n ± ∞ ¹   0.3425n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     529.7n          383.1n        -27.67%
+CrushOriginal-8                             453.6n ± ∞ ¹   2113.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            317.7n ± ∞ ¹    550.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.376µ ± ∞ ¹   12.340µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 47.86n ± ∞ ¹    81.41n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          446.0n ± ∞ ¹    711.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        605.1n ± ∞ ¹   1045.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    455.9µ ± ∞ ¹    743.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  452.5µ ± ∞ ¹    788.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.303n ± ∞ ¹   14.400n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.855n ± ∞ ¹    3.783n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3425n ± ∞ ¹   0.5728n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     383.1n          686.2n        +79.11%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.04Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.06Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.77Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.01%               ⁴
+geomean                                                ⁴                  +0.03%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s        vs base                 │
-AWSChunkedReaderSigned-8                   111.7Mi ± ∞ ¹    139.2Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 91.22Mi ± ∞ ¹   140.27Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    100.9Mi          139.7Mi        +38.46%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s       vs base                 │
+AWSChunkedReaderSigned-8                  139.22Mi ± ∞ ¹   85.39Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                140.27Mi ± ∞ ¹   80.52Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    139.7Mi         82.92Mi        -40.66%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 455946.00 ns/op | 145.98 B/op | 11295.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 452536.00 ns/op | 147.08 B/op | 78570.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 317.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 453.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.85 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8376.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 47.86 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 446.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 605.10 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 743381.00 ns/op | 89.54 B/op | 11329.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 788330.00 ns/op | 84.43 B/op | 78609.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 14.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 550.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 2113.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.57 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.78 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 12340.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 81.41 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 711.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1045.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c]
-    line "AWSChunkedReaderSigned" [474487,547638,501193,509071,507099,528608,511934,465777,568519,455946]
-    line "AWSChunkedReaderUnsigned" [470934,542477,475383,492103,469747,486617,523389,450952,695863,452536]
-    line "CheckMetricsAndSwap" [8,9,8,10,9,9,11,9,12,8]
-    line "CrushOptimized" [357,366,378,382,366,323,333,409,430,318]
-    line "CrushOriginal" [444,519,462,546,546,550,489,590,762,454]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,4,3]
-    line "LoadGlobalConfig" [7311,8381,7902,8218,9180,9457,8266,11444,10501,8376]
-    line "PadString" [41,54,44,44,50,49,47,56,70,48]
+    x-axis [98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955]
+    line "AWSChunkedReaderSigned" [547638,501193,509071,507099,528608,511934,465777,568519,455946,743381]
+    line "AWSChunkedReaderUnsigned" [542477,475383,492103,469747,486617,523389,450952,695863,452536,788330]
+    line "CheckMetricsAndSwap" [9,8,10,9,9,11,9,12,8,14]
+    line "CrushOptimized" [366,378,382,366,323,333,409,430,318,551]
+    line "CrushOriginal" [519,462,546,546,550,489,590,762,454,2113]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,1]
+    line "IndexSearch" [3,3,3,3,3,3,3,4,3,4]
+    line "LoadGlobalConfig" [8381,7902,8218,9180,9457,8266,11444,10501,8376,12340]
+    line "PadString" [54,44,44,50,49,47,56,70,48,81]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [440,468,490,508,482,560,430,509,554,446]
-    line "SanitizeLog/Unsafe" [544,677,581,581,785,678,656,684,714,605]
+    line "SanitizeLog/Safe" [468,490,508,482,560,430,509,554,446,711]
+    line "SanitizeLog/Unsafe" [677,581,581,785,678,656,684,714,605,1045]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c]
-    line "AWSChunkedReaderSigned" [140,122,133,131,131,126,130,143,117,146]
-    line "AWSChunkedReaderUnsigned" [141,123,140,135,142,137,127,148,96,147]
+    x-axis [98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955]
+    line "AWSChunkedReaderSigned" [122,133,131,131,126,130,143,117,146,90]
+    line "AWSChunkedReaderUnsigned" [123,140,135,142,137,127,148,96,147,84]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0107378,98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c]
-    line "AWSChunkedReaderSigned" [11295,11316,11296,11282,11271,11298,11310,11291,11308,11295]
-    line "AWSChunkedReaderUnsigned" [78577,78586,78573,78566,78562,78570,78573,78562,78577,78570]
+    x-axis [98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955]
+    line "AWSChunkedReaderSigned" [11316,11296,11282,11271,11298,11310,11291,11308,11295,11329]
+    line "AWSChunkedReaderUnsigned" [78586,78573,78566,78562,78570,78573,78562,78577,78570,78609]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             453.6n ± ∞ ¹   2113.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            317.7n ± ∞ ¹    550.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.376µ ± ∞ ¹   12.340µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 47.86n ± ∞ ¹    81.41n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          446.0n ± ∞ ¹    711.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        605.1n ± ∞ ¹   1045.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    455.9µ ± ∞ ¹    743.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  452.5µ ± ∞ ¹    788.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       8.303n ± ∞ ¹   14.400n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.855n ± ∞ ¹    3.783n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3425n ± ∞ ¹   0.5728n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     383.1n          686.2n        +79.11%
+CrushOriginal-8                            2113.0n ± ∞ ¹    682.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            550.8n ± ∞ ¹    317.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         12.340µ ± ∞ ¹    8.029µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 81.41n ± ∞ ¹    49.38n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          711.3n ± ∞ ¹    547.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                       1045.0n ± ∞ ¹    670.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    743.4µ ± ∞ ¹    499.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  788.3µ ± ∞ ¹    638.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      14.400n ± ∞ ¹    8.727n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.783n ± ∞ ¹    2.867n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.5728n ± ∞ ¹   0.3583n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     686.2n          428.8n        -37.51%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.539Ki ± ∞ ¹   1.539Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.06Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.77Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.06Ki ± ∞ ¹   11.04Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.77Ki ± ∞ ¹   76.75Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.03%               ⁴
+geomean                                                ⁴                  -0.02%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                  139.22Mi ± ∞ ¹   85.39Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                140.27Mi ± ∞ ¹   80.52Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    139.7Mi         82.92Mi        -40.66%
+                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s        vs base                 │
+AWSChunkedReaderSigned-8                   85.39Mi ± ∞ ¹   127.03Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 80.52Mi ± ∞ ¹    99.50Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    82.92Mi          112.4Mi        +35.58%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 743381.00 ns/op | 89.54 B/op | 11329.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 788330.00 ns/op | 84.43 B/op | 78609.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 14.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 550.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 2113.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.57 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.78 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 12340.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
-| BenchmarkPadString-8 | 81.41 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 711.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1045.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 499698.00 ns/op | 133.20 B/op | 11303.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 637971.00 ns/op | 104.33 B/op | 78592.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.73 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 317.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 682.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.87 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8029.00 ns/op | 1576.00 B/op | 46.00 allocs/op |
+| BenchmarkPadString-8 | 49.38 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 547.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 670.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955]
-    line "AWSChunkedReaderSigned" [547638,501193,509071,507099,528608,511934,465777,568519,455946,743381]
-    line "AWSChunkedReaderUnsigned" [542477,475383,492103,469747,486617,523389,450952,695863,452536,788330]
-    line "CheckMetricsAndSwap" [9,8,10,9,9,11,9,12,8,14]
-    line "CrushOptimized" [366,378,382,366,323,333,409,430,318,551]
-    line "CrushOriginal" [519,462,546,546,550,489,590,762,454,2113]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,1,0,1]
-    line "IndexSearch" [3,3,3,3,3,3,3,4,3,4]
-    line "LoadGlobalConfig" [8381,7902,8218,9180,9457,8266,11444,10501,8376,12340]
-    line "PadString" [54,44,44,50,49,47,56,70,48,81]
+    x-axis [fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955,8bb00e9]
+    line "AWSChunkedReaderSigned" [501193,509071,507099,528608,511934,465777,568519,455946,743381,499698]
+    line "AWSChunkedReaderUnsigned" [475383,492103,469747,486617,523389,450952,695863,452536,788330,637971]
+    line "CheckMetricsAndSwap" [8,10,9,9,11,9,12,8,14,9]
+    line "CrushOptimized" [378,382,366,323,333,409,430,318,551,318]
+    line "CrushOriginal" [462,546,546,550,489,590,762,454,2113,682]
+    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,1,0]
+    line "IndexSearch" [3,3,3,3,3,3,4,3,4,3]
+    line "LoadGlobalConfig" [7902,8218,9180,9457,8266,11444,10501,8376,12340,8029]
+    line "PadString" [44,44,50,49,47,56,70,48,81,49]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [468,490,508,482,560,430,509,554,446,711]
-    line "SanitizeLog/Unsafe" [677,581,581,785,678,656,684,714,605,1045]
+    line "SanitizeLog/Safe" [490,508,482,560,430,509,554,446,711,548]
+    line "SanitizeLog/Unsafe" [581,581,785,678,656,684,714,605,1045,670]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955]
-    line "AWSChunkedReaderSigned" [122,133,131,131,126,130,143,117,146,90]
-    line "AWSChunkedReaderUnsigned" [123,140,135,142,137,127,148,96,147,84]
+    x-axis [fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955,8bb00e9]
+    line "AWSChunkedReaderSigned" [133,131,131,126,130,143,117,146,90,133]
+    line "AWSChunkedReaderUnsigned" [140,135,142,137,127,148,96,147,84,104]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [98d8518,fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955]
-    line "AWSChunkedReaderSigned" [11316,11296,11282,11271,11298,11310,11291,11308,11295,11329]
-    line "AWSChunkedReaderUnsigned" [78586,78573,78566,78562,78570,78573,78562,78577,78570,78609]
+    x-axis [fcd41b1,9ebbbcc,b20b2a6,619bf40,efc2005,8685cff,bc4a512,c45af2c,ec6c955,8bb00e9]
+    line "AWSChunkedReaderSigned" [11296,11282,11271,11298,11310,11291,11308,11295,11329,11303]
+    line "AWSChunkedReaderUnsigned" [78573,78566,78562,78570,78573,78562,78577,78570,78609,78592]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -733,3 +733,85 @@ func TestMomoQUICCommunicator_CloseIdempotent(t *testing.T) {
 		t.Errorf("Second Close took %v, expected no-op (grace period %v)", elapsed, quicCloseGracePeriod)
 	}
 }
+
+func TestMomoQUICCommunicator_IdleTimeoutApplied(t *testing.T) {
+	cfg := common.Configuration{
+		Global: common.ConfigurationGlobal{
+			AuthToken:   "test-token", // notsecret
+			Protocol:    "momo-quic",
+			TLSInsecure: true,
+		},
+	}
+	factory := NewProtocolFactory(cfg)
+
+	addr := "127.0.0.1:45701"
+	l, err := factory.Listen(addr)
+	if err != nil {
+		t.Fatalf("Server failed to listen: %v", err)
+	}
+	defer l.Close()
+
+	accepted := make(chan *MomoQUICCommunicator, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		comm, err := l.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		if tc, ok := comm.(*MomoQUICCommunicator); ok {
+			// Drain the client's probe byte so the QUIC handshake completes and
+			// the connection is fully established before we test the deadline.
+			probe := make([]byte, 1)
+			if _, err := tc.Read(probe); err != nil {
+				comm.Close()
+				acceptErr <- err
+				return
+			}
+			accepted <- tc
+			return
+		}
+		comm.Close()
+		acceptErr <- fmt.Errorf("expected *MomoQUICCommunicator, got %T", comm)
+	}()
+
+	clientComm, err := factory.Dial(addr)
+	if err != nil {
+		t.Fatalf("Client failed to dial: %v", err)
+	}
+	defer clientComm.Close()
+	// A single write forces the QUIC handshake packets to flow so the server's
+	// Accept/read can complete on an otherwise idle connection.
+	if _, err := clientComm.Write([]byte{1}); err != nil {
+		t.Fatalf("Client probe write failed: %v", err)
+	}
+
+	var tc *MomoQUICCommunicator
+	select {
+	case tc = <-accepted:
+	case err := <-acceptErr:
+		t.Fatalf("Server accept failed: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server-side accept")
+	}
+	defer tc.Close()
+
+	if tc.timeoutConn == nil {
+		t.Fatal("momo-quic communicator must wrap its stream with an IdleTimeoutConn")
+	}
+
+	// A read with no incoming data must honor an absolute deadline set through
+	// the IdleTimeoutConn rather than blocking for the full rolling 30s window.
+	if err := tc.SetAbsoluteDeadline(time.Now().Add(150 * time.Millisecond)); err != nil {
+		t.Fatalf("SetAbsoluteDeadline failed: %v", err)
+	}
+	buf := make([]byte, 1)
+	start := time.Now()
+	_, rerr := tc.Read(buf)
+	if rerr == nil {
+		t.Fatal("expected an error when reading from an idle connection past its deadline")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("idle read took %v, expected the deadline to fire well under the 30s rolling timeout", elapsed)
+	}
+}

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -744,12 +744,12 @@ func TestMomoQUICCommunicator_IdleTimeoutApplied(t *testing.T) {
 	}
 	factory := NewProtocolFactory(cfg)
 
-	addr := "127.0.0.1:45701"
-	l, err := factory.Listen(addr)
+	l, err := factory.Listen("127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Server failed to listen: %v", err)
 	}
 	defer l.Close()
+	addr := l.Addr().String()
 
 	accepted := make(chan *MomoQUICCommunicator, 1)
 	acceptErr := make(chan error, 1)

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -64,11 +64,23 @@ func NewMomoQUICCommunicator(stream *quic.Stream, conn *quic.Conn) *MomoQUICComm
 	}
 }
 
-func (m *MomoQUICCommunicator) Read(b []byte) (int, error) {
+func (m *MomoQUICCommunicator) Read(b []byte) (n int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in MomoQUIC Read: %v", r)
+			err = fmt.Errorf("panic in MomoQUIC Read: %v: %w", r, syscall.EIO)
+		}
+	}()
 	return m.timeoutConn.Read(b)
 }
 
-func (m *MomoQUICCommunicator) Write(b []byte) (int, error) {
+func (m *MomoQUICCommunicator) Write(b []byte) (n int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("CRITICAL: Panic recovered in MomoQUIC Write: %v", r)
+			err = fmt.Errorf("panic in MomoQUIC Write: %v: %w", r, syscall.EIO)
+		}
+	}()
 	return m.timeoutConn.Write(b)
 }
 

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -28,10 +28,22 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
+// quicStreamConn adapts a quic.Stream to net.Conn by providing LocalAddr and
+// RemoteAddr from the owning quic.Connection. It does NOT override Close —
+// closing the stream is handled separately by MomoQUICCommunicator.Close.
+type quicStreamConn struct {
+	*quic.Stream
+	conn *quic.Conn
+}
+
+func (q *quicStreamConn) LocalAddr() net.Addr  { return q.conn.LocalAddr() }
+func (q *quicStreamConn) RemoteAddr() net.Addr { return q.conn.RemoteAddr() }
+
 // MomoQUICCommunicator implements the Communicator interface for the Momo protocol over QUIC.
 type MomoQUICCommunicator struct {
 	*quic.Stream
 	conn             *quic.Conn
+	timeoutConn      *common.IdleTimeoutConn
 	closeOnce        sync.Once
 	store            storage.Store
 	globalLister     GlobalLister
@@ -46,9 +58,18 @@ type MomoQUICCommunicator struct {
 // NewMomoQUICCommunicator creates a new MomoQUICCommunicator.
 func NewMomoQUICCommunicator(stream *quic.Stream, conn *quic.Conn) *MomoQUICCommunicator {
 	return &MomoQUICCommunicator{
-		Stream: stream,
-		conn:   conn,
+		Stream:      stream,
+		conn:        conn,
+		timeoutConn: common.NewIdleTimeoutConn(&quicStreamConn{Stream: stream, conn: conn}, 30*time.Second),
 	}
+}
+
+func (m *MomoQUICCommunicator) Read(b []byte) (int, error) {
+	return m.timeoutConn.Read(b)
+}
+
+func (m *MomoQUICCommunicator) Write(b []byte) (int, error) {
+	return m.timeoutConn.Write(b)
 }
 
 // SetChallengeResponse enables or disables challenge-response authentication.
@@ -190,7 +211,7 @@ func (m *MomoQUICCommunicator) SetAbsoluteDeadline(t interface{}) (err error) {
 	if !ok {
 		return fmt.Errorf("invalid deadline type: expected time.Time")
 	}
-	m.Stream.SetDeadline(deadline)
+	m.timeoutConn.SetAbsoluteDeadline(deadline)
 	return nil
 }
 
@@ -767,7 +788,7 @@ func (m *MomoQUICCommunicator) Close() (err error) {
 	// calling goroutine so it is guaranteed to execute — no fire-and-forget
 	// goroutine that could be dropped on process exit or leak on repeat Close.
 	m.closeOnce.Do(func() {
-		streamErr := m.Stream.Close()
+		streamErr := m.timeoutConn.Close()
 		// Allow the peer to drain the stream before tearing down the conn;
 		// otherwise pending reads are aborted with an application error.
 		time.Sleep(quicCloseGracePeriod)


### PR DESCRIPTION
Resolves #816

## Summary

MomoTCPCommunicator wraps connections with `common.IdleTimeoutConn` for a 30s rolling idle timeout, but MomoQUICCommunicator used the raw `*quic.Stream` with only one-shot per-operation deadlines. This left `momo-quic` without Slowloris-style idle connection protection.

## Implementation

- Added a `quicStreamConn` adapter (`momo_quic.go`) that bridges `*quic.Stream` to `net.Conn` (providing `LocalAddr`/`RemoteAddr` from the owning `*quic.Conn`)
- `MomoQUICCommunicator` wraps it with `common.NewIdleTimeoutConn(stream, 30*time.Second)` and overrides `Read`/`Write` to flow through the timeout wrapper
- `SetAbsoluteDeadline` and `Close` delegate to the timeout wrapper
- Added `defer recover()` panic recovery to `Read`/`Write` (Rule 37)
- Added `TestMomoQUICCommunicator_IdleTimeoutApplied` regression test (dynamic :0 port, Rule 40)

## Scope note

Only `momo-quic` is addressed. `s3-tcp`/`s3-quic` already have adequate Slowloris protection via `s3ReadHeaderTimeout` (10s header deadline, issue #592/#620) and per-op deadlines. Wrapping them with `IdleTimeoutConn` would weaken the tight header-timeout pattern by overriding it with a 30s rolling window — a net regression.

## Changelog

### commit 8bb00e9 (initial)
- `src/transport/momo_quic.go`: Added `quicStreamConn`, `timeoutConn` field, `Read`/`Write` overrides, updated `SetAbsoluteDeadline` and `Close`
- `src/transport/factory_test.go`: Added `TestMomoQUICCommunicator_IdleTimeoutApplied` regression test

### commit 30c288a (reviewer feedback)
- Added `defer recover()` panic recovery to `MomoQUICCommunicator.Read`/`Write` (Rule 37)
- Verified `IdleTimeoutConn` maps deadline timeouts to `ETIMEDOUT`
- Switched test to dynamic `:0` binding (Rule 40)