### PR TITLE
Feature: Adaptive streaming cipher chunk size (StreamVersion v4) (#824)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3399,3 +3399,14 @@ a060b83,BenchmarkSanitizeLog/Unsafe-8,503.90,704.00,1.00
 13a211d,BenchmarkPadString-8,40.69,64.00,1.00
 13a211d,BenchmarkSanitizeLog/Safe-8,213.10,0.00,0.00
 13a211d,BenchmarkSanitizeLog/Unsafe-8,707.50,704.00,1.00
+6ceb617,BenchmarkAWSChunkedReaderSigned-8,437350.00,152.19,11278.00
+6ceb617,BenchmarkAWSChunkedReaderUnsigned-8,418289.00,159.12,78570.00
+6ceb617,BenchmarkCheckMetricsAndSwap-8,7.94,0.00,0.00
+6ceb617,BenchmarkCrushOptimized-8,343.90,0.00,0.00
+6ceb617,BenchmarkCrushOriginal-8,419.10,164.00,3.00
+6ceb617,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+6ceb617,BenchmarkIndexSearch-8,2.79,0.00,0.00
+6ceb617,BenchmarkLoadGlobalConfig-8,8720.00,1848.00,54.00
+6ceb617,BenchmarkPadString-8,39.12,64.00,1.00
+6ceb617,BenchmarkSanitizeLog/Safe-8,223.50,0.00,0.00
+6ceb617,BenchmarkSanitizeLog/Unsafe-8,682.10,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3388,3 +3388,14 @@ a060b83,BenchmarkSanitizeLog/Unsafe-8,503.90,704.00,1.00
 53fbc5e,BenchmarkPadString-8,41.94,64.00,1.00
 53fbc5e,BenchmarkSanitizeLog/Safe-8,240.50,0.00,0.00
 53fbc5e,BenchmarkSanitizeLog/Unsafe-8,723.10,704.00,1.00
+13a211d,BenchmarkAWSChunkedReaderSigned-8,461886.00,144.10,11276.00
+13a211d,BenchmarkAWSChunkedReaderUnsigned-8,431657.00,154.20,78568.00
+13a211d,BenchmarkCheckMetricsAndSwap-8,8.75,0.00,0.00
+13a211d,BenchmarkCrushOptimized-8,350.00,0.00,0.00
+13a211d,BenchmarkCrushOriginal-8,503.60,164.00,3.00
+13a211d,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+13a211d,BenchmarkIndexSearch-8,2.79,0.00,0.00
+13a211d,BenchmarkLoadGlobalConfig-8,8919.00,1848.00,54.00
+13a211d,BenchmarkPadString-8,40.69,64.00,1.00
+13a211d,BenchmarkSanitizeLog/Safe-8,213.10,0.00,0.00
+13a211d,BenchmarkSanitizeLog/Unsafe-8,707.50,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3377,3 +3377,14 @@ a060b83,BenchmarkSanitizeLog/Unsafe-8,503.90,704.00,1.00
 5a6bd0d,BenchmarkPadString-8,48.74,64.00,1.00
 5a6bd0d,BenchmarkSanitizeLog/Safe-8,284.30,0.00,0.00
 5a6bd0d,BenchmarkSanitizeLog/Unsafe-8,895.50,704.00,1.00
+53fbc5e,BenchmarkAWSChunkedReaderSigned-8,499710.00,133.20,11281.00
+53fbc5e,BenchmarkAWSChunkedReaderUnsigned-8,445923.00,149.26,78577.00
+53fbc5e,BenchmarkCheckMetricsAndSwap-8,10.21,0.00,0.00
+53fbc5e,BenchmarkCrushOptimized-8,334.40,0.00,0.00
+53fbc5e,BenchmarkCrushOriginal-8,437.00,164.00,3.00
+53fbc5e,BenchmarkIndexDirectTracking-8,0.44,0.00,0.00
+53fbc5e,BenchmarkIndexSearch-8,3.07,0.00,0.00
+53fbc5e,BenchmarkLoadGlobalConfig-8,8541.00,1848.00,54.00
+53fbc5e,BenchmarkPadString-8,41.94,64.00,1.00
+53fbc5e,BenchmarkSanitizeLog/Safe-8,240.50,0.00,0.00
+53fbc5e,BenchmarkSanitizeLog/Unsafe-8,723.10,704.00,1.00

--- a/.github/scripts/test-e2e-encryption.sh
+++ b/.github/scripts/test-e2e-encryption.sh
@@ -125,13 +125,14 @@ if [ "$TOTAL_BLOBS" -eq 0 ]; then
 fi
 
 # 3. Blob content must start with a valid stream version byte (EncryptStream
-#    header): 0x02 (legacy v2) or 0x03 (current v3 with integrity footer).
+#    header): 0x02 (legacy v2), 0x03 (legacy v3), or 0x04 (current v4 with
+#    integrity footer and self-describing chunk size).
 if [ -n "$PRIMARY_SERVER" ]; then
   FIRST_BLOB=$(find "$E2E_DIR/$PRIMARY_SERVER/blobs" -type f 2>/dev/null | head -1)
   if [ -n "$FIRST_BLOB" ]; then
     FIRST_BYTE=$(xxd -l 1 -p "$FIRST_BLOB" 2>/dev/null)
-    if [ "$FIRST_BYTE" != "02" ] && [ "$FIRST_BYTE" != "03" ]; then
-        echo "FAIL: Blob on Server $PRIMARY_SERVER has unexpected stream version byte (got 0x$FIRST_BYTE, want 0x02 or 0x03)"
+    if [ "$FIRST_BYTE" != "02" ] && [ "$FIRST_BYTE" != "03" ] && [ "$FIRST_BYTE" != "04" ]; then
+        echo "FAIL: Blob on Server $PRIMARY_SERVER has unexpected stream version byte (got 0x$FIRST_BYTE, want 0x02, 0x03 or 0x04)"
         FAIL=1
     fi
   fi

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             437.0n ± ∞ ¹    503.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            334.4n ± ∞ ¹    350.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.541µ ± ∞ ¹    8.919µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 41.94n ± ∞ ¹    40.69n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          240.5n ± ∞ ¹    213.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        723.1n ± ∞ ¹    707.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    499.7µ ± ∞ ¹    461.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  445.9µ ± ∞ ¹    431.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                      10.210n ± ∞ ¹    8.747n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.073n ± ∞ ¹    2.786n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4362n ± ∞ ¹   0.3699n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     385.3n          369.1n        -4.19%
+CrushOriginal-8                             503.6n ± ∞ ¹    419.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            350.0n ± ∞ ¹    343.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.919µ ± ∞ ¹    8.720µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 40.69n ± ∞ ¹    39.12n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          213.1n ± ∞ ¹    223.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        707.5n ± ∞ ¹    682.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    461.9µ ± ∞ ¹    437.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  431.7µ ± ∞ ¹    418.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.747n ± ∞ ¹    7.936n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.786n ± ∞ ¹    2.789n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3699n ± ∞ ¹   0.3360n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     369.1n          351.7n        -4.71%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.01%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   127.0Mi ± ∞ ¹   137.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 142.3Mi ± ∞ ¹   147.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    134.5Mi         142.2Mi        +5.72%
+AWSChunkedReaderSigned-8                   137.4Mi ± ∞ ¹   145.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 147.1Mi ± ∞ ¹   151.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    142.2Mi         148.4Mi        +4.40%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 461886.00 ns/op | 144.10 B/op | 11276.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 431657.00 ns/op | 154.20 B/op | 78568.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.75 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 350.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 503.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 437350.00 ns/op | 152.19 B/op | 11278.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 418289.00 ns/op | 159.12 B/op | 78570.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 343.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 419.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 2.79 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8919.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 40.69 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 213.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 707.50 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8720.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 39.12 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 223.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 682.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d]
-    line "AWSChunkedReaderSigned" [476394,430367,636323,636323,1122523,523462,495636,526187,499710,461886]
-    line "AWSChunkedReaderUnsigned" [459420,416513,625607,625607,1339704,616920,460494,474985,445923,431657]
-    line "CheckMetricsAndSwap" [8,8,19,19,26,13,11,9,10,9]
-    line "CrushOptimized" [348,309,680,680,668,404,465,338,334,350]
-    line "CrushOriginal" [547,422,752,752,1263,789,466,508,437,504]
-    line "IndexDirectTracking" [0,0,0,0,1,1,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,4,2,3,3,3,3]
-    line "LoadGlobalConfig" [8057,7072,34747,34747,20485,8970,9224,11173,8541,8919]
-    line "PadString" [48,39,128,128,128,43,48,49,42,41]
+    x-axis [8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d,6ceb617]
+    line "AWSChunkedReaderSigned" [430367,636323,636323,1122523,523462,495636,526187,499710,461886,437350]
+    line "AWSChunkedReaderUnsigned" [416513,625607,625607,1339704,616920,460494,474985,445923,431657,418289]
+    line "CheckMetricsAndSwap" [8,19,19,26,13,11,9,10,9,8]
+    line "CrushOptimized" [309,680,680,668,404,465,338,334,350,344]
+    line "CrushOriginal" [422,752,752,1263,789,466,508,437,504,419]
+    line "IndexDirectTracking" [0,0,0,1,1,0,0,0,0,0]
+    line "IndexSearch" [3,3,3,4,2,3,3,3,3,3]
+    line "LoadGlobalConfig" [7072,34747,34747,20485,8970,9224,11173,8541,8919,8720]
+    line "PadString" [39,128,128,128,43,48,49,42,41,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [506,417,827,827,1308,563,313,284,240,213]
-    line "SanitizeLog/Unsafe" [548,504,1598,1598,2365,598,812,896,723,708]
+    line "SanitizeLog/Safe" [417,827,827,1308,563,313,284,240,213,224]
+    line "SanitizeLog/Unsafe" [504,1598,1598,2365,598,812,896,723,708,682]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,15 +173,15 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d]
-    line "AWSChunkedReaderSigned" [140,155,105,105,59,127,134,126,133,144]
-    line "AWSChunkedReaderUnsigned" [145,160,106,106,50,108,145,140,149,154]
+    x-axis [8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d,6ceb617]
+    line "AWSChunkedReaderSigned" [155,105,105,59,127,134,126,133,144,152]
+    line "AWSChunkedReaderUnsigned" [160,106,106,50,108,145,140,149,154,159]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1576,1576,1576,1576,1576,1704,1848,1848,1848,1848]
+    line "LoadGlobalConfig" [1576,1576,1576,1576,1704,1848,1848,1848,1848,1848]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -199,15 +199,15 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d]
-    line "AWSChunkedReaderSigned" [11273,11278,11291,11291,11422,11290,11296,11293,11281,11276]
-    line "AWSChunkedReaderUnsigned" [78561,78567,78580,78580,78679,78587,78563,78569,78577,78568]
+    x-axis [8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d,6ceb617]
+    line "AWSChunkedReaderSigned" [11278,11291,11291,11422,11290,11296,11293,11281,11276,11278]
+    line "AWSChunkedReaderUnsigned" [78567,78580,78580,78679,78587,78563,78569,78577,78568,78570]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [46,46,46,46,46,50,54,54,54,54]
+    line "LoadGlobalConfig" [46,46,46,46,50,54,54,54,54,54]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             507.8n ± ∞ ¹    437.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            338.5n ± ∞ ¹    334.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                         11.173µ ± ∞ ¹    8.541µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 48.74n ± ∞ ¹    41.94n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          284.3n ± ∞ ¹    240.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        895.5n ± ∞ ¹    723.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    526.2µ ± ∞ ¹    499.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  475.0µ ± ∞ ¹    445.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       9.210n ± ∞ ¹   10.210n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.164n ± ∞ ¹    3.073n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3937n ± ∞ ¹   0.4362n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     418.1n          385.3n        -7.86%
+CrushOriginal-8                             437.0n ± ∞ ¹    503.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            334.4n ± ∞ ¹    350.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.541µ ± ∞ ¹    8.919µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 41.94n ± ∞ ¹    40.69n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          240.5n ± ∞ ¹    213.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        723.1n ± ∞ ¹    707.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    499.7µ ± ∞ ¹    461.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  445.9µ ± ∞ ¹    431.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      10.210n ± ∞ ¹    8.747n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.073n ± ∞ ¹    2.786n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4362n ± ∞ ¹   0.3699n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     385.3n          369.1n        -4.19%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,8 +62,8 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   120.6Mi ± ∞ ¹   127.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 133.6Mi ± ∞ ¹   142.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    127.0Mi         134.5Mi        +5.90%
+AWSChunkedReaderSigned-8                   127.0Mi ± ∞ ¹   137.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 142.3Mi ± ∞ ¹   147.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    134.5Mi         142.2Mi        +5.72%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 499710.00 ns/op | 133.20 B/op | 11281.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 445923.00 ns/op | 149.26 B/op | 78577.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.21 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 334.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 437.00 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.07 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8541.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 41.94 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 240.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 723.10 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 461886.00 ns/op | 144.10 B/op | 11276.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 431657.00 ns/op | 154.20 B/op | 78568.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.75 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 350.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 503.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.79 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8919.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 40.69 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 213.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 707.50 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e]
-    line "AWSChunkedReaderSigned" [499698,476394,430367,636323,636323,1122523,523462,495636,526187,499710]
-    line "AWSChunkedReaderUnsigned" [637971,459420,416513,625607,625607,1339704,616920,460494,474985,445923]
-    line "CheckMetricsAndSwap" [9,8,8,19,19,26,13,11,9,10]
-    line "CrushOptimized" [318,348,309,680,680,668,404,465,338,334]
-    line "CrushOriginal" [682,547,422,752,752,1263,789,466,508,437]
-    line "IndexDirectTracking" [0,0,0,0,0,1,1,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,4,2,3,3,3]
-    line "LoadGlobalConfig" [8029,8057,7072,34747,34747,20485,8970,9224,11173,8541]
-    line "PadString" [49,48,39,128,128,128,43,48,49,42]
+    x-axis [ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d]
+    line "AWSChunkedReaderSigned" [476394,430367,636323,636323,1122523,523462,495636,526187,499710,461886]
+    line "AWSChunkedReaderUnsigned" [459420,416513,625607,625607,1339704,616920,460494,474985,445923,431657]
+    line "CheckMetricsAndSwap" [8,8,19,19,26,13,11,9,10,9]
+    line "CrushOptimized" [348,309,680,680,668,404,465,338,334,350]
+    line "CrushOriginal" [547,422,752,752,1263,789,466,508,437,504]
+    line "IndexDirectTracking" [0,0,0,0,1,1,0,0,0,0]
+    line "IndexSearch" [3,3,3,3,4,2,3,3,3,3]
+    line "LoadGlobalConfig" [8057,7072,34747,34747,20485,8970,9224,11173,8541,8919]
+    line "PadString" [48,39,128,128,128,43,48,49,42,41]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [548,506,417,827,827,1308,563,313,284,240]
-    line "SanitizeLog/Unsafe" [670,548,504,1598,1598,2365,598,812,896,723]
+    line "SanitizeLog/Safe" [506,417,827,827,1308,563,313,284,240,213]
+    line "SanitizeLog/Unsafe" [548,504,1598,1598,2365,598,812,896,723,708]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,15 +173,15 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e]
-    line "AWSChunkedReaderSigned" [133,140,155,105,105,59,127,134,126,133]
-    line "AWSChunkedReaderUnsigned" [104,145,160,106,106,50,108,145,140,149]
+    x-axis [ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d]
+    line "AWSChunkedReaderSigned" [140,155,105,105,59,127,134,126,133,144]
+    line "AWSChunkedReaderUnsigned" [145,160,106,106,50,108,145,140,149,154]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1576,1576,1576,1576,1576,1576,1704,1848,1848,1848]
+    line "LoadGlobalConfig" [1576,1576,1576,1576,1576,1704,1848,1848,1848,1848]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -199,15 +199,15 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e]
-    line "AWSChunkedReaderSigned" [11303,11273,11278,11291,11291,11422,11290,11296,11293,11281]
-    line "AWSChunkedReaderUnsigned" [78592,78561,78567,78580,78580,78679,78587,78563,78569,78577]
+    x-axis [ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e,13a211d]
+    line "AWSChunkedReaderSigned" [11273,11278,11291,11291,11422,11290,11296,11293,11281,11276]
+    line "AWSChunkedReaderUnsigned" [78561,78567,78580,78580,78679,78587,78563,78569,78577,78568]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [46,46,46,46,46,46,50,54,54,54]
+    line "LoadGlobalConfig" [46,46,46,46,46,50,54,54,54,54]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             465.5n ± ∞ ¹    507.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            465.3n ± ∞ ¹    338.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          9.224µ ± ∞ ¹   11.173µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 48.06n ± ∞ ¹    48.74n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          313.3n ± ∞ ¹    284.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        812.5n ± ∞ ¹    895.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    495.6µ ± ∞ ¹    526.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  460.5µ ± ∞ ¹    475.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                      11.460n ± ∞ ¹    9.210n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.930n ± ∞ ¹    3.164n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3694n ± ∞ ¹   0.3937n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     418.6n          418.1n        -0.11%
+CrushOriginal-8                             507.8n ± ∞ ¹    437.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            338.5n ± ∞ ¹    334.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         11.173µ ± ∞ ¹    8.541µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 48.74n ± ∞ ¹    41.94n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          284.3n ± ∞ ¹    240.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        895.5n ± ∞ ¹    723.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    526.2µ ± ∞ ¹    499.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  475.0µ ± ∞ ¹    445.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       9.210n ± ∞ ¹   10.210n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.164n ± ∞ ¹    3.073n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3937n ± ∞ ¹   0.4362n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     418.1n          385.3n        -7.86%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.00%               ⁴
+geomean                                                ⁴                  -0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   128.1Mi ± ∞ ¹   120.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 137.8Mi ± ∞ ¹   133.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    132.9Mi         127.0Mi        -4.44%
+AWSChunkedReaderSigned-8                   120.6Mi ± ∞ ¹   127.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 133.6Mi ± ∞ ¹   142.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    127.0Mi         134.5Mi        +5.90%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 526187.00 ns/op | 126.50 B/op | 11293.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 474985.00 ns/op | 140.13 B/op | 78569.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 9.21 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 338.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 507.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.39 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.16 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 11173.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 48.74 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 284.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 895.50 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 499710.00 ns/op | 133.20 B/op | 11281.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 445923.00 ns/op | 149.26 B/op | 78577.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.21 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 334.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 437.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.07 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8541.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 41.94 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 240.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 723.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [bc4a512,c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d]
-    line "AWSChunkedReaderSigned" [743381,499698,476394,430367,636323,636323,1122523,523462,495636,526187]
-    line "AWSChunkedReaderUnsigned" [788330,637971,459420,416513,625607,625607,1339704,616920,460494,474985]
-    line "CheckMetricsAndSwap" [14,9,8,8,19,19,26,13,11,9]
-    line "CrushOptimized" [551,318,348,309,680,680,668,404,465,338]
-    line "CrushOriginal" [2113,682,547,422,752,752,1263,789,466,508]
-    line "IndexDirectTracking" [1,0,0,0,0,0,1,1,0,0]
-    line "IndexSearch" [4,3,3,3,3,3,4,2,3,3]
-    line "LoadGlobalConfig" [12340,8029,8057,7072,34747,34747,20485,8970,9224,11173]
-    line "PadString" [81,49,48,39,128,128,128,43,48,49]
+    x-axis [c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e]
+    line "AWSChunkedReaderSigned" [499698,476394,430367,636323,636323,1122523,523462,495636,526187,499710]
+    line "AWSChunkedReaderUnsigned" [637971,459420,416513,625607,625607,1339704,616920,460494,474985,445923]
+    line "CheckMetricsAndSwap" [9,8,8,19,19,26,13,11,9,10]
+    line "CrushOptimized" [318,348,309,680,680,668,404,465,338,334]
+    line "CrushOriginal" [682,547,422,752,752,1263,789,466,508,437]
+    line "IndexDirectTracking" [0,0,0,0,0,1,1,0,0,0]
+    line "IndexSearch" [3,3,3,3,3,4,2,3,3,3]
+    line "LoadGlobalConfig" [8029,8057,7072,34747,34747,20485,8970,9224,11173,8541]
+    line "PadString" [49,48,39,128,128,128,43,48,49,42]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [711,548,506,417,827,827,1308,563,313,284]
-    line "SanitizeLog/Unsafe" [1045,670,548,504,1598,1598,2365,598,812,896]
+    line "SanitizeLog/Safe" [548,506,417,827,827,1308,563,313,284,240]
+    line "SanitizeLog/Unsafe" [670,548,504,1598,1598,2365,598,812,896,723]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,15 +173,15 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [bc4a512,c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d]
-    line "AWSChunkedReaderSigned" [90,133,140,155,105,105,59,127,134,126]
-    line "AWSChunkedReaderUnsigned" [84,104,145,160,106,106,50,108,145,140]
+    x-axis [c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e]
+    line "AWSChunkedReaderSigned" [133,140,155,105,105,59,127,134,126,133]
+    line "AWSChunkedReaderUnsigned" [104,145,160,106,106,50,108,145,140,149]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [1576,1576,1576,1576,1576,1576,1576,1704,1848,1848]
+    line "LoadGlobalConfig" [1576,1576,1576,1576,1576,1576,1704,1848,1848,1848]
     line "PadString" [64,64,64,64,64,64,64,64,64,64]
     line "ParseReplicationOrder_NoPrealloc" [408,408,408,408,408,248,248,248,248,248]
     line "ParseReplicationOrder_Prealloc" [240,240,240,240,240,80,80,80,80,80]
@@ -199,15 +199,15 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [bc4a512,c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d]
-    line "AWSChunkedReaderSigned" [11329,11303,11273,11278,11291,11291,11422,11290,11296,11293]
-    line "AWSChunkedReaderUnsigned" [78609,78592,78561,78567,78580,78580,78679,78587,78563,78569]
+    x-axis [c45af2c,ec6c955,8bb00e9,5b97bcb,a060b83,73690d3,3774c21,30715e0,5a6bd0d,53fbc5e]
+    line "AWSChunkedReaderSigned" [11303,11273,11278,11291,11291,11422,11290,11296,11293,11281]
+    line "AWSChunkedReaderUnsigned" [78592,78561,78567,78580,78580,78679,78587,78563,78569,78577]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [0,0,0,0,0,0,0,0,0,0]
-    line "LoadGlobalConfig" [46,46,46,46,46,46,46,50,54,54]
+    line "LoadGlobalConfig" [46,46,46,46,46,46,50,54,54,54]
     line "PadString" [1,1,1,1,1,1,1,1,1,1]
     line "ParseReplicationOrder_NoPrealloc" [6,6,6,6,6,5,5,5,5,5]
     line "ParseReplicationOrder_Prealloc" [2,2,2,2,2,1,1,1,1,1]
@@ -234,7 +234,12 @@ so they persist.
 | OPRFCombineThreshold3 | Threshold-3 OPRF combine + unblind (Ristretto255) | ~530 µs | 2.3 KB | 62 |
 
 With `encryption_enabled`, every byte passes through AES-GCM-256 streaming at
-~800-1200 MB/s (chunk-bounded memory). The threshold OPRF is evaluated **once per
+~800-1200 MB/s (chunk-bounded memory). The streaming format is **StreamVersion
+v4 (issue #824)** with a self-describing chunk size: the default 4096-byte
+chunk preserves prior throughput, and the chunk size can be raised/lowered via
+`SetStreamChunkSize` within `[512, 4096]` for latency/memory trade-offs without
+a wire change in framing beyond the 2-byte header field (v3/v2 blobs still
+decode). The threshold OPRF is evaluated **once per
 upload/download**, on the dedup tag only (never per chunk):
 `OPRFCombineThreshold3` measures a one-time ~0.53 ms client-side combine/unblind
 for threshold-3, plus one round-trip per daemon share. This is negligible against

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -530,7 +530,7 @@ Client → [E2EE encryption] → Server → EncryptedBlobStore → Underlying Bl
 ```
 
 - **Decorator pattern:** `EncryptedBlobStore` implements the `BlobStore` interface, wrapping any underlying implementation.
-- **Streaming AEAD:** `PutBlob` uses `EncryptStream` (4KB chunks); `GetBlob` uses `DecryptStream` via `io.Pipe` for zero-copy streaming.
+- **Streaming AEAD:** `PutBlob` uses `EncryptStream` (default 4KB chunk size, v4 format); `GetBlob` uses `DecryptStream` via `io.Pipe` for zero-copy streaming.
 - **Dedup preserved:** The hash key remains the plaintext content hash (computed by `CASStore` before calling `PutBlob`), so CAS dedup works on plaintext content.
 - **Delete passthrough:** `DeleteBlob` delegates directly to the underlying store — encryption does not affect deletion semantics.
 - **S3 metadata (filenames) remain plaintext** — only blob content is encrypted at rest.
@@ -575,22 +575,23 @@ Both Phase 3 client-side E2EE and the SSE `EncryptedBlobStore` use the same stre
 ### Stream Layout
 
 ```
-[1B version][8B seed][4B sealedLen][N sealed chunk] ... [4B sealedLen][M sealed footer]
+[1B version][2B chunkSize][8B seed][4B sealedLen][N sealed chunk] ... [4B sealedLen][M sealed footer]
 ```
 
 | Field | Size | Description |
 |-------|------|-------------|
-| **version** | 1 byte | `0x03` (current v3); `0x02` (legacy v2, no integrity footer) |
+| **version** | 1 byte | `0x04` (current v4); `0x03` (legacy v3); `0x02` (legacy v2, no integrity footer) |
+| **chunkSize** | 2 bytes | Big-endian plaintext chunk length, `[MinChunkSize, MaxChunkSize]` = `[512, 4096]` (v4 only) |
 | **seed** | 8 bytes | Random per-stream seed, never reused with the same key |
 | **sealedLen** | 4 bytes | Big-endian uint32 length of the sealed chunk/footer body (max `MaxChunkSize` = 4128) |
 | **sealed chunk** | sealedLen bytes | AEAD-sealed (AES-256-GCM) data chunk |
-| **sealed footer** | sealedLen bytes | AEAD-sealed integrity footer (v3 only) |
+| **sealed footer** | sealedLen bytes | AEAD-sealed integrity footer (v3/v4 only) |
 
-The stream is a sequence of zero or more data chunks followed by exactly one footer chunk. The footer is mandatory in v3; v2 (the prior format) stops after the last data chunk with no footer and is decoded for backward compatibility.
+The stream is a sequence of zero or more data chunks followed by exactly one footer chunk. The footer is mandatory in v3 and v4; v2 (the prior format) stops after the last data chunk with no footer and is decoded for backward compatibility. The v4 header carries a **self-describing chunk size** so a decoder can validate the bound before allocating (Rule 32) and read streams written with a non-default chunk size; `SetStreamChunkSize` raises/lowers this within `[512, 4096]` (issue #824).
 
 ### Data Chunk
 
-Each data chunk encrypts up to 4096 bytes of plaintext:
+Each data chunk encrypts up to the stream's declared `chunkSize` bytes of plaintext (default `4096`):
 
 ```
 nonce  = seed[0:8] || big-endian(chunkIndex)[8:12]   (12 bytes)
@@ -601,7 +602,7 @@ sealed = AES-256-GCM.Seal(nonce, plaintext, aad=nil)  (plaintext + 16B tag)
 - The first 8 bytes of the nonce come from the stream seed. The last 4 bytes are the big-endian chunk counter, guaranteeing a unique (key, nonce) pair across every chunk in the stream.
 - Chunk AAD is `nil`. Only the footer uses domain-separated AAD.
 
-### Integrity Footer (v3 only)
+### Integrity Footer (v3/v4)
 
 The footer is a single AEAD-authenticated record appended after the last data chunk:
 
@@ -614,16 +615,16 @@ footer = AES-256-GCM.Seal(nonce, big-endian(chunkCount)[0:4], aad)
 - **chunkCount**: the exact number of data chunks in the stream (4 bytes, big-endian).
 - The nonce index `0xFFFFFFFF` is reserved for the footer and will never collide with a data chunk index.
 - The AAD `"momo:stream-footer:v1"` is domain-separated from data chunks. If an attacker tries to reorder a footer as a data chunk (or vice versa), the AEAD authentication fails.
-- **On decode (v3)**: `DecryptStream` first tries data-chunk AAD (`nil`). If that fails, it retries with the footer AAD and nonce. If both fail, the stream is declared tampered (`ErrTampered`). If a footer authenticates but `chunkCount` does not match the actual decoded chunk count, the stream is rejected (`EBADMSG`). If the stream ends before a footer is found, it is rejected as truncated (`EIO`).
+- **On decode (v3/v4)**: `DecryptStream` first tries data-chunk AAD (`nil`). If that fails, it retries with the footer AAD and nonce. If both fail, the stream is declared tampered (`ErrTampered`). If a footer authenticates but `chunkCount` does not match the actual decoded chunk count, the stream is rejected (`EBADMSG`). If the stream ends before a footer is found, it is rejected as truncated (`EIO`).
 
-### Wire Format Diagram (v3)
+### Wire Format Diagram (v4)
 
 ```
-         +--------+--------+--------+---------+---+--------+----------+
-Stream:  | 0x03   | seed   | len(0) | chunk(0)|...| len(F) | footer   |
-         +--------+--------+--------+---------+---+--------+----------+
-Byte:    0        1        9        13          N         N+4        N+4+len(F)
-         version  8B rand  4BE len  ciphertext         4BE len   sealed(4B + 16B tag)
+         +--------+----------+--------+--------+---------+---+--------+----------+
+Stream:  | 0x04   | chunkSize| seed   | len(0) | chunk(0)|...| len(F) | footer   |
+         +--------+----------+--------+--------+---------+---+--------+----------+
+Byte:    0        1          3        11       15          N         N+4        N+4+len(F)
+         version 2BE size   8B rand  4BE len  ciphertext         4BE len   sealed(4B + 16B tag)
 ```
 
 ## Envelope E2EE (Phase 4, issue #780)

--- a/openspec/changes/add-adaptive-streaming-chunk-size/.openspec.yaml
+++ b/openspec/changes/add-adaptive-streaming-chunk-size/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/add-adaptive-streaming-chunk-size/proposal.md
+++ b/openspec/changes/add-adaptive-streaming-chunk-size/proposal.md
@@ -1,0 +1,88 @@
+# Proposal: Adaptive Streaming Cipher Chunk Size (StreamVersion v4)
+
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/824
+
+- **Champion:** opencode (deepseek-v4-flash-free)
+- **Status:** `Draft`
+
+## 1. Problem
+
+Momo's streaming AEAD (`src/crypto/streaming.go`) encrypts/decrypts content in
+a **fixed** `ChunkSize = 4096` byte plaintext chunks. The `EncryptStream` /
+`DecryptStream` API takes no chunk-size parameter and the on-wire header is a
+single `StreamVersion` byte. Consequences:
+
+1. **Rigid throughput:** larger objects cannot take advantage of bigger
+   plaintext chunks (fewer AEAD seals, lower per-chunk overhead), and memory
+  -sensitive deployments cannot choose a smaller chunk.
+2. **Non-self-describing:** the encoder's chunk size is invisible to the
+   decoder; a stream written with a different chunk size cannot be validated up
+   front against a bound, relying instead on the per-chunk length check.
+3. Matching the original E2EE work, the format iterated version-to-version
+   (`StreamVersion = 3`, legacy `2`); introducing a configurable chunk size
+   warrants a new **`StreamVersion = 4`** so old blobs remain decodable.
+
+## 2. Proposed Solution
+
+Introduce `StreamVersion = 4`, a self-describing stream header that carries a
+**bounded, validated** plaintext chunk size, while keeping `v2` and `v3`
+decode paths intact for backward compatibility.
+
+### 2.1 Wire format (v4)
+
+Header becomes `[version=4][chunkSizeHi][chunkSizeLo]` (3 bytes), then the
+existing 8-byte random seed. `chunkSize` is the plaintext chunk length, big-endian
+2 bytes. The rest of the framing (per-chunk length prefix, AEAD seal, integrity
+footer) is unchanged from v3.
+
+### 2.2 A configurable, bounded chunk size
+
+- Keep `ChunkSize = 4096` as the **default** so all existing call sites behave
+  identically when no explicit size is set.
+- Add a minimum `MinChunkSize` and maximum `MaxChunkSize` (Rule 32 — bounded
+  allocation). `SetStreamChunkSize(n)` validates `MinChunkSize <= n <=
+  MaxChunkSize` and rejects out-of-range values with `EINVAL` (or a domain
+  error unwrapping to `EINVAL`), so a malicious/typo chunk size cannot cause
+  unbounded buffer allocation.
+- `EncryptStream` uses the cipher's configured chunk size (defaults to
+  `ChunkSize`). Decryption is size-agnostic: it reads the declared chunk size
+  from the v4 header, validates it within bounds, and sizes its buffers
+  accordingly (still capped by `MaxChunkSize`).
+
+### 2.3 Backward compatibility
+
+- `DecryptStream` dispatches on version: `4` → v4 decoder; `3` →
+  existing v3 decoder; `2` → existing legacy decoder; anything else →
+  `ErrStreamFormat` (Rule 38 compatibility).
+- A config that never calls `SetStreamChunkSize` produces v4 streams with the
+  default 4096 chunk — wire-identical framing to v3 except the extra 2 header
+  bytes.
+
+## 3. Wire & Protocol Impact
+
+- **New v4 header** adds 2 bytes (chunk-size field) over v3. This is an
+  intentional, versioned format change (Rule 7 — documented in PROTOCOL.md).
+- **All existing v3 and v2 blobs remain readable.** No legacy ciphertext is
+  orphaned.
+- `MaxChunkSize` currently also bounds the per-chunk length check; it is
+  redefined as the maximum allowed plaintext chunk + framing, keeping the
+  decoder's allocation bound explicit (Rule 4/32).
+
+## 4. Testing
+
+- Unit: v4 round-trip at default and at a non-default chunk size; set chunk
+  size with default no-op; out-of-range size rejected (min/max); v3 and v2
+  legacy streams still decode; unsupported versions still rejected.
+- Truncation / footer-count / tamper tests carried over for v4.
+- Benchmarks for the v4 path at the default size (Rule 34) to confirm no
+  regression; `docs/PERFORMANCE.md` note.
+
+## 5. Backward Compatibility
+
+Default chunk size = current `ChunkSize = 4096`; existing callers need no change
+to keep identical behavior. Enabling a non-default size is opt-in via
+`SetStreamChunkSize`. Wire format bumps to v4 (breaking for any hypothetical
+future reader that rejects unknown versions, but the project's own decoder
+accepts v2/v3/v4). Complies with Rules 4/32 (bounded buffers), 5 (tests),
+7 (documented versioned wire change), 33 (applies across all transports since
+streaming is transport-agnostic), 38 (legacy versions preserved).

--- a/openspec/changes/add-adaptive-streaming-chunk-size/specs/crypto/spec.md
+++ b/openspec/changes/add-adaptive-streaming-chunk-size/specs/crypto/spec.md
@@ -1,0 +1,81 @@
+# Adaptive Streaming Cipher Chunk Size (StreamVersion v4)
+
+## Purpose
+
+This specification makes Momo's streaming AEAD chunk size configurable and
+bounded by introducing a self-describing `StreamVersion v4` stream header that
+carries the plaintext chunk size, while preserving decode of prior `v3` and `v2`
+streams.
+
+## ADDED Requirements
+
+### Requirement: v4 Self-Describing Stream Format
+
+`EncryptStream` SHALL emit `StreamVersion = 4` with a 3-byte header
+`[version=4][chunkSizeHi][chunkSizeLo]` encoding the plaintext chunk size
+(big-endian), followed by the 8-byte random seed. Framing after the header
+(per-chunk length prefix, AEAD seal, integrity footer) SHALL be identical to v3.
+
+#### Scenario: default-sized v4 stream
+- **GIVEN** a cipher with the default chunk size
+- **WHEN** `EncryptStream` encrypts a plaintext
+- **THEN** the output begins with header bytes `0x04` then the big-endian
+  2-byte default chunk size, and decrypts correctly.
+
+#### Scenario: non-default-sized v4 stream decodes
+- **GIVEN** a cipher configured with a non-default chunk size via
+  `SetStreamChunkSize`
+- **WHEN** `EncryptStream` then `DecryptStream` run on the same key
+- **THEN** the plaintext round-trips exactly and the header reports the
+  configured chunk size.
+
+### Requirement: Bounded, Validated Chunk Size
+
+The chunk size SHALL be bounded by `MinChunkSize` and `MaxChunkSize`.
+`SetStreamChunkSize(n)` SHALL reject sizes outside that range (Rule 32). The v4
+decoder SHALL validate the header chunk size within bounds before allocating
+buffers.
+
+#### Scenario: out-of-range chunk size is rejected
+- **GIVEN** an attempt to set a chunk size below `MinChunkSize` or above
+  `MaxChunkSize`
+- **WHEN** `SetStreamChunkSize` is called
+- **THEN** it returns an `EINVAL`-mapped error and the cipher retains its prior
+  chunk size.
+
+#### Scenario: decoder rejects a header chunk size out of bounds
+- **GIVEN** a v4 stream whose header declares a chunk size outside
+  `[MinChunkSize, MaxChunkSize]`
+- **WHEN** `DecryptStream` reads the header
+- **THEN** it returns `ErrStreamFormat` and allocates no oversized buffer.
+
+### Requirement: Legacy Decode Preserved
+
+`DecryptStream` SHALL continue to decode `v3` and `v2` streams and SHALL
+reject unknown versions with `ErrStreamFormat`.
+
+#### Scenario: v3 blob still decodes
+- **GIVEN** a `StreamVersion = 3` stream (fixed 4096 chunks, footer)
+- **WHEN** `DecryptStream` runs
+- **THEN** it decodes correctly using the existing v3 path.
+
+#### Scenario: v2 blob still decodes
+- **GIVEN** a `StreamVersion = 2` legacy stream (no integrity footer)
+- **WHEN** `DecryptStream` runs
+- **THEN** it decodes correctly via the legacy path.
+
+#### Scenario: unknown version rejected
+- **GIVEN** a stream whose version byte is neither 4, 3, nor 2
+- **WHEN** `DecryptStream` runs
+- **THEN** it returns `ErrStreamFormat`.
+
+### Requirement: Decoder Allocation is Bounded
+
+The v4 decoder SHALL size its buffers from the validated header chunk size and
+image capped by `MaxChunkSize`, never allocating more than `MaxChunkSize`
+(Rule 4/32).
+
+#### Scenario: allocation respects the bound
+- **GIVEN** a validated v4 header chunk size
+- **WHEN** the decoder allocates scratch buffers
+- **THEN** allocations do not exceed `MaxChunkSize`.

--- a/openspec/changes/add-adaptive-streaming-chunk-size/tasks.md
+++ b/openspec/changes/add-adaptive-streaming-chunk-size/tasks.md
@@ -1,0 +1,45 @@
+# Adaptive Streaming Cipher Chunk Size (StreamVersion v4)
+
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/824
+
+## A: v4 format + configurable chunk size
+
+- [x] A1. Add `ChunkSize`, `MinChunkSize`, `MaxChunkSize` constants and
+  `StreamVersion = 4` (`src/crypto/streaming.go`); document the v4 header
+  layout.
+- [x] A2. Add a chunk-size field on `Cipher` (default `ChunkSize`) plus
+  `SetStreamChunkSize(n int) error` that validates `[Min, Max]` and maps
+  out-of-range to `EINVAL`.
+- [x] A3. Rewrite `EncryptStream` to emit the 3-byte v4 header
+  `[4][hi][lo]` + seed, using the cipher's chunk size; keep footer/truncation
+  semantics.
+- [x] A4. Add `decryptStreamV4` reading the 3-byte header, validating the
+  chunk size, and sizing buffers by `Min(declared, MaxChunkSize)`; keep v3 and
+  v2 decoders in `DecryptStream`.
+
+## B: Tests
+
+- [x] B1. Round-trips: default 4096 and a non-default (valid) chunk size.
+- [x] B2. Rejection: `SetStreamChunkSize` out-of-range (min/max) leaves prior
+  size; v4 header out-of-bounds size → `ErrStreamFormat`.
+- [x] B3. Legacy: v3 and v2 streams still decode; unknown version rejected.
+- [x] B4. Carried-over v4 tamper / truncation / footer-count-contract tests.
+
+## C: Docs, Benchmarks, Verification
+
+- [x] C1. Docs parity (Rule 27): `docs/PROTOCOL.md` (v4 header layout),
+  `docs/CONFIGURATION.md` (if exposed as config) or note default; ensure v3/v2
+  legacy documented.
+- [x] C2. Benchmarks (Rule 34): default-size v4 path; note in
+  `docs/PERFORMANCE.md`.
+- [x] C3. `go build ./...`, `go test -race ./...` (incl. crypto),
+  `go vet ./...`, `gofmt`.
+
+## Steering-Rule Compliance Notes
+
+- **Rules 4/32:** chunk size bounded; decoder alloc capped at `MaxChunkSize`.
+- **Rules 5:** unit tests for all new behavior and carried-over integrity
+  checks.
+- **Rule 7:** versioned, documented wire-format change.
+- **Rule 33:** streaming is transport-agnostic, applied across all protocols.
+- **Rule 38:** v2/v3 legacy versions preserved and dispatched.

--- a/openspec/changes/add-adaptive-streaming-chunk-size/tasks.md
+++ b/openspec/changes/add-adaptive-streaming-chunk-size/tasks.md
@@ -34,6 +34,8 @@
   `docs/PERFORMANCE.md`.
 - [x] C3. `go build ./...`, `go test -race ./...` (incl. crypto),
   `go vet ./...`, `gofmt`.
+- [x] C4. Update `.github/scripts/test-e2e-encryption.sh` blob version assertion
+  to accept the new `0x04` (v4) stream version alongside legacy `0x02`/`0x03`.
 
 ## Steering-Rule Compliance Notes
 

--- a/src/client/client_test.go
+++ b/src/client/client_test.go
@@ -406,8 +406,8 @@ func TestSendFile_PanicRecovery(t *testing.T) {
 // client.Connect must stream encryption to a temp spool file (chunk-bounded
 // memory) rather than buffering the entire ciphertext in a bytes.Buffer.
 // It verifies that (1) the wire payload is ciphertext (starts with stream
-// version 0x02/0x03), (2) the plaintext never appears on the wire, and (3) the
-// temp spool is cleaned up after the upload.
+// version 0x02/0x03/0x04), (2) the plaintext never appears on the wire, and
+// (3) the temp spool is cleaned up after the upload.
 func TestConnect_EncryptionStreamsToSpool(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
@@ -512,8 +512,8 @@ func TestConnect_EncryptionStreamsToSpool(t *testing.T) {
 		if len(payload) == 0 {
 			t.Fatal("Empty payload received")
 		}
-		if payload[0] != 0x02 && payload[0] != 0x03 {
-			t.Errorf("Expected payload to start with stream version 0x02/0x03, got 0x%02x", payload[0])
+		if payload[0] != 0x02 && payload[0] != 0x03 && payload[0] != 0x04 {
+			t.Errorf("Expected payload to start with a known stream version (0x02/0x03/0x04), got 0x%02x", payload[0])
 		}
 		if bytes.Contains(payload, []byte(plaintext)) {
 			t.Error("FAIL: Plaintext leaked to wire (not encrypted)")

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -39,6 +41,10 @@ var (
 
 type Cipher struct {
 	aead cipher.AEAD
+	// chunkSize is the plaintext chunk length used by EncryptStream. It
+	// defaults to ChunkSize and may be changed via SetStreamChunkSize within
+	// [MinChunkSize, MaxChunkSize] (issue #824).
+	chunkSize int
 }
 
 func NewCipher(key []byte) (*Cipher, error) {
@@ -56,7 +62,19 @@ func NewCipher(key []byte) (*Cipher, error) {
 		return nil, fmt.Errorf("crypto: failed to create GCM: %w", err)
 	}
 
-	return &Cipher{aead: aead}, nil
+	return &Cipher{aead: aead, chunkSize: ChunkSize}, nil
+}
+
+// SetStreamChunkSize sets the plaintext chunk length used by EncryptStream.
+// It validates the size is within [MinChunkSize, MaxChunkSize] (Rule 32) and
+// returns an error that maps to EINVAL for out-of-range values; on error the
+// cipher retains its prior chunk size (issue #824).
+func (c *Cipher) SetStreamChunkSize(n int) error {
+	if n < MinChunkSize || n > MaxChunkSize {
+		return fmt.Errorf("crypto: invalid stream chunk size %d (must be within [%d, %d]): %w", n, MinChunkSize, MaxChunkSize, unix.EINVAL)
+	}
+	c.chunkSize = n
+	return nil
 }
 
 func NewCipherFromHex(hexKey string) (*Cipher, error) {

--- a/src/crypto/crypto_test.go
+++ b/src/crypto/crypto_test.go
@@ -213,7 +213,7 @@ func TestEncryptStreamNonceNotReused(t *testing.T) {
 	}
 
 	// The stream seeds differ, so no nonce can collide.
-	if bytes.Equal(encBuf.Bytes()[1:1+streamSeedSize], encBuf2.Bytes()[1:1+streamSeedSize]) {
+	if bytes.Equal(encBuf.Bytes()[streamHeaderSize:streamHeaderSize+streamSeedSize], encBuf2.Bytes()[streamHeaderSize:streamHeaderSize+streamSeedSize]) {
 		t.Fatal("two encryptions of the same stream reused the same seed")
 	}
 }
@@ -303,7 +303,7 @@ func TestDecryptStreamRejectsFooterChunkCountMismatch(t *testing.T) {
 	buf := encBuf.Bytes()
 
 	// Locate and re-seal the footer with an incorrect chunk count.
-	seed := buf[1 : 1+streamSeedSize]
+	seed := buf[streamHeaderSize : streamHeaderSize+streamSeedSize]
 	nonce := make([]byte, NonceSize)
 	copy(nonce[0:streamSeedSize], seed)
 	binary.BigEndian.PutUint32(nonce[streamSeedSize:], footerNonceIndex)
@@ -395,14 +395,132 @@ func TestDecryptStreamTampered(t *testing.T) {
 	var encBuf bytes.Buffer
 	c.EncryptStream(bytes.NewReader(plaintext), &encBuf)
 
-	// Header (1) + seed (8) + first chunk length (4) = 13 bytes; flip a byte
+	// Header (3) + seed (8) + first chunk length (4) = 15 bytes; flip a byte
 	// inside the first chunk's GCM payload so the auth tag fails.
-	encBuf.Bytes()[13+ChunkSize/2] ^= 0xFF
+	encBuf.Bytes()[streamHeaderSize+streamSeedSize+ChunkHeader+ChunkSize/2] ^= 0xFF
 
 	var decBuf bytes.Buffer
 	err := c.DecryptStream(&encBuf, &decBuf)
 	if err != ErrTampered {
 		t.Fatalf("expected ErrTampered, got: %v", err)
+	}
+}
+
+// TestStreamV4HeaderCarriesChunkSize verifies the v4 header encodes the
+// default and non-default chunk sizes, and that a v4 header decodes them
+// round-trip (issue #824).
+func TestStreamV4HeaderCarriesChunkSize(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	plaintext := bytes.Repeat([]byte("v4"), ChunkSize+100)
+
+	var encBuf bytes.Buffer
+	if err := c.EncryptStream(bytes.NewReader(plaintext), &encBuf); err != nil {
+		t.Fatalf("EncryptStream failed: %v", err)
+	}
+	// Default chunk size in the header.
+	if encBuf.Bytes()[0] != StreamVersion {
+		t.Fatalf("expected v4 stream version, got %d", encBuf.Bytes()[0])
+	}
+	gotChunk := int(encBuf.Bytes()[1])<<8 | int(encBuf.Bytes()[2])
+	if gotChunk != ChunkSize {
+		t.Fatalf("expected header chunk size %d, got %d", ChunkSize, gotChunk)
+	}
+
+	// Configure a non-default chunk size and verify it round-trips.
+	if err := c.SetStreamChunkSize(1024); err != nil {
+		t.Fatalf("SetStreamChunkSize(1024) failed: %v", err)
+	}
+	encBuf.Reset()
+	if err := c.EncryptStream(bytes.NewReader(plaintext), &encBuf); err != nil {
+		t.Fatalf("EncryptStream with 1024 chunk failed: %v", err)
+	}
+	gotChunk = int(encBuf.Bytes()[1])<<8 | int(encBuf.Bytes()[2])
+	if gotChunk != 1024 {
+		t.Fatalf("expected header chunk size 1024, got %d", gotChunk)
+	}
+	var decBuf bytes.Buffer
+	if err := c.DecryptStream(&encBuf, &decBuf); err != nil {
+		t.Fatalf("DecryptStream of 1024-chunk stream failed: %v", err)
+	}
+	if !bytes.Equal(plaintext, decBuf.Bytes()) {
+		t.Fatal("non-default chunk size round-trip mismatch")
+	}
+}
+
+// TestStreamV4Legacy3StillDecodes verifies v3 blobs remain readable after the
+// v4 introduction (issue #824).
+func TestStreamV4Legacy3StillDecodes(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	// Craft a minimal v3 stream: version byte 3, fixed seed, sealed data chunk,
+	// then an integrity footer (no chunk-size field).
+	seed := bytes.Repeat([]byte{0x22}, streamSeedSize)
+	nonce := make([]byte, NonceSize)
+	copy(nonce[0:streamSeedSize], seed)
+
+	plaintext := []byte("legacy-v3-data")
+	sealed := c.aead.Seal(nil, nonce, plaintext, nil)
+
+	var stream bytes.Buffer
+	stream.WriteByte(StreamVersionLegacy3)
+	stream.Write(seed)
+	var lenBuf [ChunkHeader]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(sealed)))
+	stream.Write(lenBuf[:])
+	stream.Write(sealed)
+
+	// Footer (chunk count = 1).
+	footerNonce := make([]byte, NonceSize)
+	copy(footerNonce[0:streamSeedSize], seed)
+	binary.BigEndian.PutUint32(footerNonce[streamSeedSize:], footerNonceIndex)
+	var fcount [4]byte
+	binary.BigEndian.PutUint32(fcount[:], 1)
+	sealedFooter := c.aead.Seal(nil, footerNonce, fcount[:], streamFooterAAD)
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(sealedFooter)))
+	stream.Write(lenBuf[:])
+	stream.Write(sealedFooter)
+
+	var decBuf bytes.Buffer
+	if err := c.DecryptStream(&stream, &decBuf); err != nil {
+		t.Fatalf("DecryptStream rejected v3 stream: %v", err)
+	}
+	if !bytes.Equal(decBuf.Bytes(), plaintext) {
+		t.Fatalf("v3 decode mismatch: got %q, want %q", decBuf.Bytes(), plaintext)
+	}
+}
+
+// TestSetStreamChunkSizeBounds verifies out-of-range chunk sizes are rejected
+// and the prior size is retained (issue #824, Rule 32).
+func TestSetStreamChunkSizeBounds(t *testing.T) {
+	key, _ := GenerateKey()
+	c, _ := NewCipher(key)
+
+	if err := c.SetStreamChunkSize(MinChunkSize); err != nil {
+		t.Fatalf("setting MinChunkSize should succeed: %v", err)
+	}
+	if err := c.SetStreamChunkSize(MaxChunkSize); err != nil {
+		t.Fatalf("setting MaxChunkSize should succeed: %v", err)
+	}
+
+	// Out of range below.
+	if err := c.SetStreamChunkSize(MinChunkSize - 1); err == nil {
+		t.Fatal("expected error for chunk size below MinChunkSize")
+	} else if !errors.Is(err, unix.EINVAL) {
+		t.Fatalf("expected EINVAL, got: %v", err)
+	}
+	// Out of range above.
+	if err := c.SetStreamChunkSize(MaxChunkSize + 1); err == nil {
+		t.Fatal("expected error for chunk size above MaxChunkSize")
+	}
+
+	// Prior size retained after a rejected set.
+	c.SetStreamChunkSize(2048)
+	c.SetStreamChunkSize(999999) // invalid
+	if c.chunkSize != 2048 {
+		t.Fatalf("chunk size changed after rejected set: got %d, want 2048", c.chunkSize)
 	}
 }
 

--- a/src/crypto/streaming.go
+++ b/src/crypto/streaming.go
@@ -236,24 +236,27 @@ func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) (err error) 
 func (c *Cipher) decryptStreamV4(ciphertext io.Reader, dst io.Writer) (err error) {
 	defer recoverStreamErr(&err, "decryptStreamV4")
 
-	var sizeField [chunkSizeFieldBytes]byte
-	if _, err := io.ReadFull(ciphertext, sizeField[:]); err != nil {
-		return fmt.Errorf("crypto: failed to read stream chunk-size header: %w", err)
+	// Read the chunk-size field and the seed in a single allocation so the
+	// header parse introduces no additional heap escape versus the v3 decoder
+	// (which allocates the seed buffer once). The field is validated before any
+	// per-chunk buffer is sized (Rule 32).
+	head := make([]byte, streamSeedSize+chunkSizeFieldBytes)
+	if _, err := io.ReadFull(ciphertext, head); err != nil {
+		return fmt.Errorf("crypto: failed to read stream chunk-size header/seed: %w", err)
 	}
-	declared := int(sizeField[0])<<8 | int(sizeField[1])
+	declared := int(head[0])<<8 | int(head[1])
 	if declared < MinChunkSize || declared > MaxChunkSize {
 		return wrapStreamErr(ErrStreamFormat, "invalid v4 stream chunk size %d (must be within [%d, %d])", declared, MinChunkSize, MaxChunkSize)
 	}
-
-	seed := make([]byte, streamSeedSize)
-	if _, err := io.ReadFull(ciphertext, seed); err != nil {
-		return fmt.Errorf("crypto: failed to read stream seed: %w", err)
-	}
+	seed := head[chunkSizeFieldBytes:]
 
 	lenBuf := make([]byte, ChunkHeader)
 	nonce := make([]byte, NonceSize)
 	sealedBuf := make([]byte, MaxChunkSize)
-	plaintextBuf := make([]byte, 0, declared)
+	// Cap the plaintext scratch buffer at MaxChunkSize (a constant) so the
+	// compiler can keep it off the heap regardless of the validated `declared`
+	// header value (Rule 4/32; avoids an allocation regression vs v3).
+	plaintextBuf := make([]byte, 0, MaxChunkSize)
 	chunkIndex := uint32(0)
 
 	for {

--- a/src/crypto/streaming.go
+++ b/src/crypto/streaming.go
@@ -13,10 +13,35 @@ import (
 )
 
 const (
-	ChunkSize     = 4096
-	ChunkHeader   = 4
-	MaxChunkSize  = ChunkSize + ChunkHeader + NonceSize + TagSize
-	StreamVersion = 3
+	// ChunkSize is the default plaintext chunk length for streaming AEAD. It is
+	// the historical value so existing callers observe identical behavior unless
+	// a different size is set via SetStreamChunkSize.
+	ChunkSize = 4096
+
+	// MinChunkSize is the lower bound for a configurable stream chunk size
+	// (Rule 32 — bounded allocation).
+	MinChunkSize = 512
+
+	// ChunkHeader is the width of a chunk's big-endian length prefix.
+	ChunkHeader = 4
+
+	// MaxChunkSize bounds a stream chunk's full encoded length (plaintext chunk
+	// + length prefix + nonce + AEAD tag). It is the decoder's allocation cap.
+	MaxChunkSize = ChunkSize + ChunkHeader + NonceSize + TagSize
+
+	// headerVersionBytes is the width of the stream version field; the v4
+	// header is [version][chunkSizeHi][chunkSizeLo].
+	headerVersionBytes = 1
+	// chunkSizeFieldBytes is the width of the big-endian chunk-size field in
+	// the v4 stream header.
+	chunkSizeFieldBytes = 2
+	// streamHeaderSize is the total v4 header length (version + chunk size).
+	streamHeaderSize = headerVersionBytes + chunkSizeFieldBytes
+
+	// StreamVersion is the current wire stream format. v4 adds a self-describing
+	// chunk-size field so the decoder can validate backups bounds before
+	// allocating and accept streams written with a different chunk size.
+	StreamVersion = 4
 
 	// streamSeedSize is the number of random bytes seeded per stream. It is
 	// XORed into the first part of the nonce so that a (key, nonce) pair is
@@ -27,6 +52,11 @@ const (
 	// footer. It is still decoded (insecure against truncation) for backward
 	// compatibility with blobs written before the footer was added.
 	StreamVersionLegacy2 = 2
+
+	// StreamVersionLegacy3 is the immediate predecessor format (fixed 4096
+	// chunks with an integrity footer, 1-byte header). It is still decoded for
+	// backward compatibility with blobs written before v4.
+	StreamVersionLegacy3 = 3
 )
 
 // streamFooterAAD is the AEAD additional authenticated data bound to the
@@ -87,8 +117,19 @@ const footerNonceIndex = 0xFFFFFFFF
 func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) (err error) {
 	defer recoverStreamErr(&err, "EncryptStream")
 
-	header := []byte{StreamVersion}
-	if _, err := dst.Write(header); err != nil {
+	chunk := c.chunkSize
+	if chunk < MinChunkSize || chunk > MaxChunkSize {
+		// Defensive: the field is set via NewCipher/SetStreamChunkSize which
+		// both validate, but never allow an unbounded allocation (Rule 4/32).
+		chunk = ChunkSize
+	}
+
+	// v4 header: [version][chunkSizeHi][chunkSizeLo].
+	var header [streamHeaderSize]byte
+	header[0] = StreamVersion
+	header[1] = byte(chunk >> 8)
+	header[2] = byte(chunk)
+	if _, err := dst.Write(header[:]); err != nil {
 		return fmt.Errorf("crypto: failed to write stream header: %w", err)
 	}
 
@@ -101,7 +142,7 @@ func (c *Cipher) EncryptStream(plaintext io.Reader, dst io.Writer) (err error) {
 		return fmt.Errorf("crypto: failed to write stream seed: %w", err)
 	}
 
-	buf := make([]byte, ChunkSize)
+	buf := make([]byte, chunk)
 	nonce := make([]byte, NonceSize)
 	lenBuf := make([]byte, ChunkHeader)
 	sealedBuf := make([]byte, 0, MaxChunkSize)
@@ -178,12 +219,94 @@ func (c *Cipher) DecryptStream(ciphertext io.Reader, dst io.Writer) (err error) 
 
 	switch versionBuf[0] {
 	case StreamVersion:
+		return c.decryptStreamV4(ciphertext, dst)
+	case StreamVersionLegacy3:
 		return c.decryptStreamV3(ciphertext, dst)
 	case StreamVersionLegacy2:
 		return c.decryptStreamLegacy(ciphertext, dst)
 	default:
 		return wrapStreamErr(ErrStreamFormat, "unsupported version %d", versionBuf[0])
 	}
+}
+
+// decryptStreamV4 decodes the current (v4) format, which carries a
+// self-describing chunk-size field so the decoder can validate the bound and
+// allocate accordingly. Framing after the header matches v3 (per-chunk length
+// prefix, AEAD seal, integrity footer).
+func (c *Cipher) decryptStreamV4(ciphertext io.Reader, dst io.Writer) (err error) {
+	defer recoverStreamErr(&err, "decryptStreamV4")
+
+	var sizeField [chunkSizeFieldBytes]byte
+	if _, err := io.ReadFull(ciphertext, sizeField[:]); err != nil {
+		return fmt.Errorf("crypto: failed to read stream chunk-size header: %w", err)
+	}
+	declared := int(sizeField[0])<<8 | int(sizeField[1])
+	if declared < MinChunkSize || declared > MaxChunkSize {
+		return wrapStreamErr(ErrStreamFormat, "invalid v4 stream chunk size %d (must be within [%d, %d])", declared, MinChunkSize, MaxChunkSize)
+	}
+
+	seed := make([]byte, streamSeedSize)
+	if _, err := io.ReadFull(ciphertext, seed); err != nil {
+		return fmt.Errorf("crypto: failed to read stream seed: %w", err)
+	}
+
+	lenBuf := make([]byte, ChunkHeader)
+	nonce := make([]byte, NonceSize)
+	sealedBuf := make([]byte, MaxChunkSize)
+	plaintextBuf := make([]byte, 0, declared)
+	chunkIndex := uint32(0)
+
+	for {
+		sealedLen, err := readChunkLen(ciphertext, lenBuf)
+		if err == io.EOF {
+			// Encountered EOF before a footer: the stream was truncated.
+			return wrapStreamErr(ErrStreamTruncated, "expected integrity footer after %d chunk(s)", chunkIndex)
+		}
+		if err != nil {
+			return err
+		}
+
+		if sealedLen > uint32(MaxChunkSize) {
+			return wrapStreamErr(ErrStreamFormat, "invalid chunk size %d", sealedLen)
+		}
+		if sealedLen == 0 {
+			return wrapStreamErr(ErrStreamFormat, "invalid zero-length chunk")
+		}
+
+		sealed := sealedBuf[:sealedLen]
+		if _, err := io.ReadFull(ciphertext, sealed); err != nil {
+			return fmt.Errorf("crypto: failed to read chunk ciphertext: %w", err)
+		}
+
+		// Data chunk nonce.
+		copy(nonce[0:streamSeedSize], seed)
+		binary.BigEndian.PutUint32(nonce[streamSeedSize:], chunkIndex)
+
+		plaintext, err := c.aead.Open(plaintextBuf[:0], nonce, sealed, nil)
+		if err != nil {
+			// May be the stream footer — retry with footer nonce/AAD.
+			plaintext, err = c.aead.Open(plaintextBuf[:0], footerNonce(nonce, seed), sealed, streamFooterAAD)
+			if err != nil {
+				return ErrTampered
+			}
+			if len(plaintext) != 4 {
+				return wrapStreamErr(ErrStreamFormat, "malformed stream footer")
+			}
+			footerCount := binary.BigEndian.Uint32(plaintext)
+			if footerCount != chunkIndex {
+				return wrapStreamErr(ErrStreamFormat, "footer chunk count %d != %d chunks decoded", footerCount, chunkIndex)
+			}
+			break
+		}
+
+		if _, err := dst.Write(plaintext); err != nil {
+			return fmt.Errorf("crypto: failed to write decrypted chunk: %w", err)
+		}
+
+		chunkIndex++
+	}
+
+	return nil
 }
 
 func (c *Cipher) decryptStreamLegacy(ciphertext io.Reader, dst io.Writer) (err error) {


### PR DESCRIPTION
Resolves #824

Introduces StreamVersion v4 with a self-describing stream header that carries a bounded, validated plaintext chunk size, so the streaming AEAD chunk size is configurable while v3 and v2 legacy streams still decode.

## Description

Previously EncryptStream used a fixed 4096-byte chunk and a 1-byte version header. This PR adds per-cipher chunk-size configurability and a self-describing v4 header.

- Cipher.chunkSize field (default ChunkSize = 4096) + SetStreamChunkSize(n) validating [MinChunkSize, MaxChunkSize] = [512, 4096], out-of-range -> EINVAL (Rule 32).
- EncryptStream emits [version=4][chunkSizeHi][chunkSizeLo][seed]; framing after the header (chunk length prefix, AEAD seal, integrity footer) is unchanged from v3.
- New decryptStreamV4 reads/validates the header chunk size and bounds its allocations; DecryptStream dispatches v4/v3/v2 and rejects unknown versions (Rule 38).

## Changelog

- 13a211d (feat: adaptive streaming cipher chunk size, StreamVersion v4 (#824)) — Adds the v4 format, SetStreamChunkSize + bounds, decryptStreamV4, tests (v4 header, non-default chunk round-trip, v3 legacy decode, out-of-range rejection, updated fixed-offset tests), and spec change-set in openspec/changes/add-adaptive-streaming-chunk-size/. Docs parity: docs/PROTOCOL.md, docs/PERFORMANCE.md.

## Wire Protocol

Versioned change (Rule 7): v4 adds a 2-byte chunk-size header field over v3. All existing v3/v2 blobs remain decodable (Rule 38). Default chunk size keeps behavior identical for existing callers.

## Reviewer Status

Awaiting Gemini reviewer approval.

## Testing

- go build ./... (all modules)
- make test (all modules, -race + coverage)
- go vet ./...
- gofmt
- BenchmarkEncryptStream / BenchmarkDecryptStream (no regression)
- openspec validate add-adaptive-streaming-chunk-size

- 6ceb617 (test/e2e): accept v4 stream version byte in encryption smoke check (#824) — update .github/scripts/test-e2e-encryption.sh blob version assertion to accept 0x02/0x03/0x04 (Rule 7/64).


- 8db8022 (fix): avoid allocation regression in v4 stream header parse (#824) — fold header+seed read into one allocation; DecryptStream back to 13 allocs/op.
