### PR TITLE
fix: preserve payloadPool fixed buffer across reallocation (#667)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3509,3 +3509,14 @@ ea64898,BenchmarkLoadGlobalConfig-8,12014.00,1848.00,54.00
 ea64898,BenchmarkPadString-8,55.89,64.00,1.00
 ea64898,BenchmarkSanitizeLog/Safe-8,613.90,0.00,0.00
 ea64898,BenchmarkSanitizeLog/Unsafe-8,804.40,704.00,1.00
+c0e11e5,BenchmarkAWSChunkedReaderSigned-8,535526.00,124.29,11288.00
+c0e11e5,BenchmarkAWSChunkedReaderUnsigned-8,451534.00,147.41,78570.00
+c0e11e5,BenchmarkCheckMetricsAndSwap-8,9.02,0.00,0.00
+c0e11e5,BenchmarkCrushOptimized-8,334.60,0.00,0.00
+c0e11e5,BenchmarkCrushOriginal-8,455.60,164.00,3.00
+c0e11e5,BenchmarkIndexDirectTracking-8,0.56,0.00,0.00
+c0e11e5,BenchmarkIndexSearch-8,3.18,0.00,0.00
+c0e11e5,BenchmarkLoadGlobalConfig-8,9184.00,1848.00,54.00
+c0e11e5,BenchmarkPadString-8,45.99,64.00,1.00
+c0e11e5,BenchmarkSanitizeLog/Safe-8,504.10,0.00,0.00
+c0e11e5,BenchmarkSanitizeLog/Unsafe-8,635.60,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                           │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             664.1n ± ∞ ¹    873.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            415.2n ± ∞ ¹    420.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          13.04µ ± ∞ ¹    12.01µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 62.73n ± ∞ ¹    55.89n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          569.3n ± ∞ ¹    613.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        816.1n ± ∞ ¹    804.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    576.5µ ± ∞ ¹    620.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  605.7µ ± ∞ ¹    652.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       11.15n ± ∞ ¹    10.00n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.542n ± ∞ ¹    3.184n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4515n ± ∞ ¹   0.3828n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     513.4n          509.5n        -0.75%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                           │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                             873.5n ± ∞ ¹    455.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            420.2n ± ∞ ¹    334.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         12.014µ ± ∞ ¹    9.184µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 55.89n ± ∞ ¹    45.99n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          613.9n ± ∞ ¹    504.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        804.4n ± ∞ ¹    635.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    620.6µ ± ∞ ¹    535.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  652.6µ ± ∞ ¹    451.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      10.000n ± ∞ ¹    9.023n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.184n ± ∞ ¹    3.183n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3828n ± ∞ ¹   0.5592n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     509.5n          424.2n        -16.74%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.05Ki ± ∞ ¹   11.04Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.76Ki ± ∞ ¹   76.76Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.04Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.76Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.00%               ⁴
+geomean                                                ⁴                  -0.02%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                           │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   110.1Mi ± ∞ ¹   102.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                104.79Mi ± ∞ ¹   97.27Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    107.4Mi         99.74Mi        -7.15%
+                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s        vs base                 │
+AWSChunkedReaderSigned-8                   102.3Mi ± ∞ ¹    118.5Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 97.27Mi ± ∞ ¹   140.58Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    99.74Mi          129.1Mi        +29.42%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 620631.00 ns/op | 107.25 B/op | 11309.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 652637.00 ns/op | 101.99 B/op | 78604.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 420.20 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 873.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 535526.00 ns/op | 124.29 B/op | 11288.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 451534.00 ns/op | 147.41 B/op | 78570.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.02 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 334.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 455.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.56 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 3.18 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 12014.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 55.89 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 613.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 804.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9184.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 45.99 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 504.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 635.60 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [13a211d,6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898]
-    line "AWSChunkedReaderSigned" [437350,447444,456452,448270,622202,380899,410944,580705,576464,620631]
-    line "AWSChunkedReaderUnsigned" [418289,476966,484613,436099,484134,403705,410907,557512,605728,652637]
-    line "CheckMetricsAndSwap" [8,10,9,10,8,9,7,10,11,10]
-    line "CrushOptimized" [344,353,360,384,403,296,264,368,415,420]
-    line "CrushOriginal" [419,488,539,442,474,375,370,598,664,874]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,4,3]
-    line "LoadGlobalConfig" [8720,9023,9246,9136,9150,7234,7096,10842,13042,12014]
-    line "PadString" [39,53,48,50,48,35,34,55,63,56]
+    x-axis [6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5]
+    line "AWSChunkedReaderSigned" [447444,456452,448270,622202,380899,410944,580705,576464,620631,535526]
+    line "AWSChunkedReaderUnsigned" [476966,484613,436099,484134,403705,410907,557512,605728,652637,451534]
+    line "CheckMetricsAndSwap" [10,9,10,8,9,7,10,11,10,9]
+    line "CrushOptimized" [353,360,384,403,296,264,368,415,420,335]
+    line "CrushOriginal" [488,539,442,474,375,370,598,664,874,456]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
+    line "IndexSearch" [3,3,3,3,3,3,3,4,3,3]
+    line "LoadGlobalConfig" [9023,9246,9136,9150,7234,7096,10842,13042,12014,9184]
+    line "PadString" [53,48,50,48,35,34,55,63,56,46]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [224,479,510,430,543,398,379,530,569,614]
-    line "SanitizeLog/Unsafe" [682,607,625,542,680,482,537,734,816,804]
+    line "SanitizeLog/Safe" [479,510,430,543,398,379,530,569,614,504]
+    line "SanitizeLog/Unsafe" [607,625,542,680,482,537,734,816,804,636]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [13a211d,6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898]
-    line "AWSChunkedReaderSigned" [152,149,146,148,107,175,162,115,115,107]
-    line "AWSChunkedReaderUnsigned" [159,140,137,153,137,165,162,119,110,102]
+    x-axis [6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5]
+    line "AWSChunkedReaderSigned" [149,146,148,107,175,162,115,115,107,124]
+    line "AWSChunkedReaderUnsigned" [140,137,153,137,165,162,119,110,102,147]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [13a211d,6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898]
-    line "AWSChunkedReaderSigned" [11278,11291,11281,11297,11281,11264,11269,11322,11314,11309]
-    line "AWSChunkedReaderUnsigned" [78570,78564,78574,78571,78567,78568,78569,78587,78599,78604]
+    x-axis [6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5]
+    line "AWSChunkedReaderSigned" [11291,11281,11297,11281,11264,11269,11322,11314,11309,11288]
+    line "AWSChunkedReaderUnsigned" [78564,78574,78571,78567,78568,78569,78587,78599,78604,78570]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -15,10 +15,23 @@ import (
 	"github.com/alsotoes/momo/src/transport"
 )
 
+// payloadPoolCapacity is the fixed capacity of the reusable byte slices
+// handed out by payloadPool. Only buffers with this exact capacity are ever
+// returned to the pool; growth beyond it is discarded (fix #667).
+const payloadPoolCapacity = 1024
+
+// payloadPoolc is the minimal contract payloadPool needs: fetch a buffer and
+// hand one back. sync.Pool satisfies it; tests substitute an instrumented
+// implementation to assert returned capacities.
+type payloadPoolc interface {
+	Get() interface{}
+	Put(interface{})
+}
+
 // payloadPool provides reusable byte slices for replication broadcasts to reduce allocations.
-var payloadPool = sync.Pool{
+var payloadPool payloadPoolc = &sync.Pool{
 	New: func() interface{} {
-		return make([]byte, 1024)
+		return make([]byte, payloadPoolCapacity)
 	},
 }
 
@@ -276,7 +289,12 @@ func ChangeReplicationModeClient(factory *transport.ProtocolFactory, replication
 	payload = payload[:0]
 	payload = append(payload, replicationJson...)
 	payload = append(payload, '\n')
-	defer payloadPool.Put(payload[:cap(payload)])
+	// 🛡️ Sentinel: Only return the buffer to the pool if append did not
+	// reallocate it. When the payload exceeds payloadPoolCapacity, a new,
+	// larger slice is allocated and the fixed-capacity pool buffer is lost.
+	// Returning the grown slice thrashes the pool and defeats its purpose,
+	// so it is released instead (fix #667).
+	defer releasePayload(payload)
 
 	if _, err := comm.Write(payload); err != nil {
 		log.Printf("Failed to send ReplicationData to %d: %v", serverId, common.SanitizeLog(err.Error()))
@@ -293,4 +311,15 @@ func ChangeReplicationModeClient(factory *transport.ProtocolFactory, replication
 	}
 
 	log.Printf("ReplicationData sent to serverId: %d", serverId)
+}
+
+// releasePayload returns a replication payload buffer to the pool, but only if
+// it still has the fixed pool capacity. A payload that outgrew its original
+// buffer (append reallocated) never came from the pool as the grown slice, so
+// the pooled fixed-capacity buffer has already been lost; returning the grown
+// slice would poison the pool with oversized buffers (fix #667).
+func releasePayload(payload []byte) {
+	if cap(payload) == payloadPoolCapacity {
+		payloadPool.Put(payload[:payloadPoolCapacity])
+	}
 }

--- a/src/server/replication_test.go
+++ b/src/server/replication_test.go
@@ -196,3 +196,98 @@ func TestGetCurrentReplicationMode(t *testing.T) {
 		t.Errorf("Expected replication mode %d, got %d", expectedMode, currentMode)
 	}
 }
+
+// recordingPool satisfies payloadPoolc and records the capacity of every
+// buffer handed back to the pool, so tests can assert only fixed-capacity
+// buffers are ever returned.
+type recordingPool struct {
+	putCaps []int
+}
+
+func (p *recordingPool) Get() interface{} { return make([]byte, payloadPoolCapacity) }
+
+func (p *recordingPool) Put(b interface{}) { p.putCaps = append(p.putCaps, cap(b.([]byte))) }
+
+// TestReleasePayloadOnlyReturnsFixedCapacity verifies that buffers are only
+// returned to payloadPool when their capacity is still the pool's fixed size
+// (fix #667). A payload that grew past 1024 bytes must not put an oversized
+// slice back into the pool.
+func TestReleasePayloadOnlyReturnsFixedCapacity(t *testing.T) {
+	orig := payloadPool
+	rp := &recordingPool{}
+	payloadPool = rp
+	defer func() { payloadPool = orig }()
+
+	// A grown buffer (append reallocated past the fixed capacity) must not be
+	// returned to the pool.
+	buf := payloadPool.Get().([]byte)
+	grown := append(buf, []byte(strings.Repeat("x", payloadPoolCapacity*2))...)
+	if cap(grown) <= payloadPoolCapacity {
+		t.Fatalf("test setup: expected grown buffer to exceed capacity, got cap=%d", cap(grown))
+	}
+	releasePayload(grown)
+
+	// A fixed-capacity buffer must be returned normally.
+	releasePayload(buf[:0])
+
+	if len(rp.putCaps) != 1 {
+		t.Fatalf("expected exactly 1 Put of a fixed-capacity buffer, got %d puts (caps=%v)", len(rp.putCaps), rp.putCaps)
+	}
+	if rp.putCaps[0] != payloadPoolCapacity {
+		t.Errorf("expected Put cap=%d (fixed), got cap=%d", payloadPoolCapacity, rp.putCaps[0])
+	}
+
+	// ChangeReplicationModeClient must use the guarded release path: exercising
+	// it with both a small and an oversized payload must never put an oversized
+	// buffer (the fixed allocation can still be returned).
+	rp.putCaps = nil
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+	defer listener.Close()
+	serverAddr := listener.Addr().String()
+
+	acceptOnce := func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
+		io.ReadFull(conn, handshakeBuf[:])
+		conn.Write([]byte("0"))
+		// Read the payload, then ACK so the client returns promptly.
+		var payloadBuf [payloadPoolCapacity * 3]byte
+		conn.Read(payloadBuf[:])
+		conn.Write([]byte("OK"))
+	}
+
+	cfg := common.Configuration{
+		Global: common.ConfigurationGlobal{
+			AuthToken: authToken,
+			Protocol:  "momo-tcp",
+		},
+		Daemons: []*common.Daemon{
+			{ChangeReplication: serverAddr},
+		},
+	}
+	factory := transport.NewProtocolFactory(cfg)
+
+	// Small payload: fits in the fixed buffer, must be returned to the pool.
+	go acceptOnce()
+	ChangeReplicationModeClient(factory, []byte(`{"New":1,"TimeStamp":1}`), 0)
+
+	// Oversized payload: exceeds the fixed buffer, must NOT be pooled.
+	bigJSON := `{"New":2,"TimeStamp":1,"payload":"` + strings.Repeat("x", payloadPoolCapacity*2) + `"}`
+	go acceptOnce()
+	ChangeReplicationModeClient(factory, []byte(bigJSON), 0)
+
+	for i, c := range rp.putCaps {
+		if c != payloadPoolCapacity {
+			t.Errorf("client put cap=%d (idx %d), want fixed %d", c, i, payloadPoolCapacity)
+		}
+	}
+}


### PR DESCRIPTION
Resolves #667

## Summary

`payloadPool` hands out 1024-byte slices for replication broadcasts. When a payload outgrew that buffer, `append` allocated a new, larger slice — but the code returned `payload[:cap(payload)]` (the **grown** slice) to the pool, permanently losing the original fixed buffer while poisoning the pool with oversized slices. This PR only returns a buffer when it still has the pool's fixed capacity; grown slices are discarded.

## Implementation

- `src/server/replication.go`:
  - New `payloadPoolCapacity = 1024` constant (single source of truth for the pool's fixed size).
  - `releasePayload(payload)` helper: hands a buffer back to the pool **only if** `cap(payload) == payloadPoolCapacity`. A reallocated slice never enters the pool.
  - `ChangeReplicationModeClient` now `defer releasePayload(payload)` instead of the unconditional `payloadPool.Put(payload[:cap(payload)])`.
  - `payloadPool` typed as an interface (`payloadPoolc`) so tests can substitute an instrumented pool; `&sync.Pool` satisfies it unchanged.
- `src/server/replication_test.go`: `TestReleasePayloadOnlyReturnsFixedCapacity` swaps in a recording pool and asserts:
  - `releasePayload` on a grown slice performs **no** Put.
  - `releasePayload` on a fixed-capacity slice performs exactly one Put with cap 1024.
  - Exercising `ChangeReplicationModeClient` with small + oversized payloads never pools an oversized buffer.

## Verification

- New test fails on pre-fix code (grown slice got pooled) and passes with the fix.
- `go build ./...`, `go vet ./src/server/...`, `gofmt` clean.
- Full `go test ./...` passes; `go work vendor` produces no diff (Rule 25).

## Changelog

- **2026-08-17**: `releasePayload` now guards pool returns by fixed capacity so reallocated buffers are discarded, not pooled (fix #667).

## Reviewer Status

- **Status**: Awaiting review.
- **CI**: Pending.
