### PR TITLE
fix: honor caller-provided timeout in LeaseAcquirerAdapter (#666)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3520,3 +3520,14 @@ c0e11e5,BenchmarkLoadGlobalConfig-8,9184.00,1848.00,54.00
 c0e11e5,BenchmarkPadString-8,45.99,64.00,1.00
 c0e11e5,BenchmarkSanitizeLog/Safe-8,504.10,0.00,0.00
 c0e11e5,BenchmarkSanitizeLog/Unsafe-8,635.60,704.00,1.00
+50203a3,BenchmarkAWSChunkedReaderSigned-8,482680.00,137.90,11293.00
+50203a3,BenchmarkAWSChunkedReaderUnsigned-8,511362.00,130.16,78569.00
+50203a3,BenchmarkCheckMetricsAndSwap-8,10.28,0.00,0.00
+50203a3,BenchmarkCrushOptimized-8,311.00,0.00,0.00
+50203a3,BenchmarkCrushOriginal-8,584.30,164.00,3.00
+50203a3,BenchmarkIndexDirectTracking-8,0.38,0.00,0.00
+50203a3,BenchmarkIndexSearch-8,2.97,0.00,0.00
+50203a3,BenchmarkLoadGlobalConfig-8,10419.00,1848.00,54.00
+50203a3,BenchmarkPadString-8,48.12,64.00,1.00
+50203a3,BenchmarkSanitizeLog/Safe-8,553.90,0.00,0.00
+50203a3,BenchmarkSanitizeLog/Unsafe-8,638.30,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             873.5n ± ∞ ¹    455.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            420.2n ± ∞ ¹    334.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                         12.014µ ± ∞ ¹    9.184µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 55.89n ± ∞ ¹    45.99n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          613.9n ± ∞ ¹    504.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        804.4n ± ∞ ¹    635.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    620.6µ ± ∞ ¹    535.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  652.6µ ± ∞ ¹    451.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                      10.000n ± ∞ ¹    9.023n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.184n ± ∞ ¹    3.183n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3828n ± ∞ ¹   0.5592n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     509.5n          424.2n        -16.74%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                             455.6n ± ∞ ¹    584.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            334.6n ± ∞ ¹    311.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          9.184µ ± ∞ ¹   10.419µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 45.99n ± ∞ ¹    48.12n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          504.1n ± ∞ ¹    553.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        635.6n ± ∞ ¹    638.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    535.5µ ± ∞ ¹    482.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  451.5µ ± ∞ ¹    511.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       9.023n ± ∞ ¹   10.280n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.183n ± ∞ ¹    2.970n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.5592n ± ∞ ¹   0.3833n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     424.2n          430.0n        +1.37%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.04Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.76Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.02%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s        vs base                 │
-AWSChunkedReaderSigned-8                   102.3Mi ± ∞ ¹    118.5Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 97.27Mi ± ∞ ¹   140.58Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    99.74Mi          129.1Mi        +29.42%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │             B/s             │      B/s       vs base                │
+AWSChunkedReaderSigned-8                   118.5Mi ± ∞ ¹   131.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 140.6Mi ± ∞ ¹   124.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    129.1Mi         127.8Mi        -1.02%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 535526.00 ns/op | 124.29 B/op | 11288.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 451534.00 ns/op | 147.41 B/op | 78570.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 9.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 334.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 455.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.56 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.18 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9184.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 45.99 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 504.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 635.60 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 482680.00 ns/op | 137.90 B/op | 11293.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 511362.00 ns/op | 130.16 B/op | 78569.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.28 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 311.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 584.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 10419.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 48.12 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 553.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 638.30 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5]
-    line "AWSChunkedReaderSigned" [447444,456452,448270,622202,380899,410944,580705,576464,620631,535526]
-    line "AWSChunkedReaderUnsigned" [476966,484613,436099,484134,403705,410907,557512,605728,652637,451534]
-    line "CheckMetricsAndSwap" [10,9,10,8,9,7,10,11,10,9]
-    line "CrushOptimized" [353,360,384,403,296,264,368,415,420,335]
-    line "CrushOriginal" [488,539,442,474,375,370,598,664,874,456]
-    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,1]
-    line "IndexSearch" [3,3,3,3,3,3,3,4,3,3]
-    line "LoadGlobalConfig" [9023,9246,9136,9150,7234,7096,10842,13042,12014,9184]
-    line "PadString" [53,48,50,48,35,34,55,63,56,46]
+    x-axis [c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3]
+    line "AWSChunkedReaderSigned" [456452,448270,622202,380899,410944,580705,576464,620631,535526,482680]
+    line "AWSChunkedReaderUnsigned" [484613,436099,484134,403705,410907,557512,605728,652637,451534,511362]
+    line "CheckMetricsAndSwap" [9,10,8,9,7,10,11,10,9,10]
+    line "CrushOptimized" [360,384,403,296,264,368,415,420,335,311]
+    line "CrushOriginal" [539,442,474,375,370,598,664,874,456,584]
+    line "IndexDirectTracking" [0,0,0,0,0,0,0,0,1,0]
+    line "IndexSearch" [3,3,3,3,3,3,4,3,3,3]
+    line "LoadGlobalConfig" [9246,9136,9150,7234,7096,10842,13042,12014,9184,10419]
+    line "PadString" [48,50,48,35,34,55,63,56,46,48]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [479,510,430,543,398,379,530,569,614,504]
-    line "SanitizeLog/Unsafe" [607,625,542,680,482,537,734,816,804,636]
+    line "SanitizeLog/Safe" [510,430,543,398,379,530,569,614,504,554]
+    line "SanitizeLog/Unsafe" [625,542,680,482,537,734,816,804,636,638]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5]
-    line "AWSChunkedReaderSigned" [149,146,148,107,175,162,115,115,107,124]
-    line "AWSChunkedReaderUnsigned" [140,137,153,137,165,162,119,110,102,147]
+    x-axis [c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3]
+    line "AWSChunkedReaderSigned" [146,148,107,175,162,115,115,107,124,138]
+    line "AWSChunkedReaderUnsigned" [137,153,137,165,162,119,110,102,147,130]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [6ceb617,c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5]
-    line "AWSChunkedReaderSigned" [11291,11281,11297,11281,11264,11269,11322,11314,11309,11288]
-    line "AWSChunkedReaderUnsigned" [78564,78574,78571,78567,78568,78569,78587,78599,78604,78570]
+    x-axis [c62f0a5,0d846a4,49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3]
+    line "AWSChunkedReaderSigned" [11281,11297,11281,11264,11269,11322,11314,11309,11288,11293]
+    line "AWSChunkedReaderUnsigned" [78574,78571,78567,78568,78569,78587,78599,78604,78570,78569]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/p2p_adapters.go
+++ b/src/server/p2p_adapters.go
@@ -61,23 +61,31 @@ func (s *ScatterGatherLister) GlobalList(timeout time.Duration) ([]common.FileMe
 	return MergeFileMetadataLists(allLists...), nil
 }
 
+// leaseManager is the minimal contract LeaseAcquirerAdapter needs. It is
+// satisfied by *p2p.LeaseManager and lets tests inject a recording fake.
+type leaseManager interface {
+	Acquire(key string, duration time.Duration) (*p2p.Lease, error)
+	ReleaseByKey(key string) error
+}
+
 // LeaseAcquirerAdapter adapts p2p.LeaseManager to the transport.LeaseAcquirer interface.
 type LeaseAcquirerAdapter struct {
-	lm       *p2p.LeaseManager
-	duration time.Duration
+	lm leaseManager
 }
 
 // NewLeaseAcquirerAdapter creates a new LeaseAcquirerAdapter.
-func NewLeaseAcquirerAdapter(lm *p2p.LeaseManager, duration time.Duration) *LeaseAcquirerAdapter {
-	return &LeaseAcquirerAdapter{lm: lm, duration: duration}
+func NewLeaseAcquirerAdapter(lm *p2p.LeaseManager) *LeaseAcquirerAdapter {
+	return &LeaseAcquirerAdapter{lm: lm}
 }
 
-// AcquireLease acquires a lease for the given key.
+// AcquireLease acquires a lease for the given key for the caller-provided
+// timeout duration (fix #666). The caller's timeout must be respected rather
+// than a value captured at construction.
 func (l *LeaseAcquirerAdapter) AcquireLease(key string, timeout time.Duration) error {
 	if l.lm == nil {
 		return fmt.Errorf("lease manager not initialized")
 	}
-	_, err := l.lm.Acquire(key, l.duration)
+	_, err := l.lm.Acquire(key, timeout)
 	return err
 }
 

--- a/src/server/p2p_adapters_test.go
+++ b/src/server/p2p_adapters_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alsotoes/momo/src/p2p"
+)
+
+// recordingLeaseManager satisfies leaseManager and records the durations
+// passed to Acquire so tests can assert the caller's timeout is honored.
+type recordingLeaseManager struct {
+	mu        sync.Mutex
+	acquired  []string
+	durations []time.Duration
+}
+
+func (r *recordingLeaseManager) Acquire(key string, duration time.Duration) (*p2p.Lease, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.acquired = append(r.acquired, key)
+	r.durations = append(r.durations, duration)
+	return &p2p.Lease{Key: key, Expiry: time.Now().Add(duration)}, nil
+}
+
+func (r *recordingLeaseManager) ReleaseByKey(key string) error {
+	return nil
+}
+
+// TestAcquireLeaseHonorsCallerTimeout verifies the caller-provided timeout is
+// passed through to the lease manager rather than being replaced by a value
+// captured at construction (fix #666).
+func TestAcquireLeaseHonorsCallerTimeout(t *testing.T) {
+	rl := &recordingLeaseManager{}
+	adapter := &LeaseAcquirerAdapter{lm: rl}
+
+	if err := adapter.AcquireLease("key-a", 37*time.Millisecond); err != nil {
+		t.Fatalf("AcquireLease failed: %v", err)
+	}
+	if err := adapter.AcquireLease("key-b", 5*time.Second); err != nil {
+		t.Fatalf("AcquireLease failed: %v", err)
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if len(rl.durations) != 2 {
+		t.Fatalf("expected 2 Acquire calls, got %d", len(rl.durations))
+	}
+	if rl.durations[0] != 37*time.Millisecond {
+		t.Errorf("first Acquire duration = %v, want 37ms (caller timeout)", rl.durations[0])
+	}
+	if rl.durations[1] != 5*time.Second {
+		t.Errorf("second Acquire duration = %v, want 5s (caller timeout)", rl.durations[1])
+	}
+}
+
+// TestAcquireLeaseNilManager verifies the nil-guard is intact.
+func TestAcquireLeaseNilManager(t *testing.T) {
+	adapter := &LeaseAcquirerAdapter{lm: nil}
+	if err := adapter.AcquireLease("key", time.Second); err == nil {
+		t.Fatal("expected error when lease manager is nil")
+	}
+}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -269,8 +269,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 			}
 			if leaseManager != nil {
 				if laComm, ok := comm.(interface{ SetLeaseAcquirer(transport.LeaseAcquirer) }); ok {
-					laComm.SetLeaseAcquirer(NewLeaseAcquirerAdapter(leaseManager,
-						time.Duration(cfg.P2P.LeaseTimeout)*time.Second))
+					laComm.SetLeaseAcquirer(NewLeaseAcquirerAdapter(leaseManager))
 				}
 			}
 			if oprfService != nil {


### PR DESCRIPTION
Resolves #666

## Summary

`LeaseAcquirerAdapter.AcquireLease(key, timeout)` accepted a caller-provided `timeout` but silently ignored it — it always passed the construction-time `duration` (`cfg.P2P.LeaseTimeout`) to `lm.Acquire`. The `transport.LeaseAcquirer` interface is explicit that the caller controls the lease duration (`AcquireLease(key, timeout)`), and every caller (QUIC/TCP/S3 communicators) passes `10*time.Second`. This PR passes the caller's timeout through and removes the dead construction-time duration.

## Implementation

- `src/server/p2p_adapters.go`:
  - `AcquireLease` now calls `l.lm.Acquire(key, timeout)` — caller's value honored.
  - Removed the `duration` field + constructor parameter (now dead). `NewLeaseAcquirerAdapter(lm)` takes only the lease manager.
  - Typed the `lm` field as a small `leaseManager` interface (Acquire + ReleaseByKey) so tests can inject a recording fake — same pattern as #667.
- `src/server/server.go`: updated wiring — `NewLeaseAcquirerAdapter(leaseManager)` no longer passes `cfg.P2P.LeaseTimeout`.
- `src/server/p2p_adapters_test.go` (new): `TestAcquireLeaseHonorsCallerTimeout` uses a recording fake and asserts the exact durations passed through for multiple calls; `TestAcquireLeaseNilManager` keeps the nil-guard covered.

## Verification

- New test fails on pre-fix code (30s construction-time duration passed, not caller's) and passes with the fix.
- `go build ./...`, `go vet ./src/server/...`, `gofmt` clean.
- Full `go test ./...` passes; `go work vendor` produces no diff (Rule 25).

## Changelog

- **2026-08-17**: `AcquireLease` now honors the caller-provided timeout; removed dead construction-time duration (fix #666).

## Reviewer Status

- **Status**: Awaiting review.
- **CI**: Pending.
