### PR TITLE
perf(storage): combine Get metadata reads into single bbolt View (#636)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3553,3 +3553,14 @@ f766ad6,BenchmarkLoadGlobalConfig-8,11718.00,1848.00,54.00
 f766ad6,BenchmarkPadString-8,44.73,64.00,1.00
 f766ad6,BenchmarkSanitizeLog/Safe-8,619.50,0.00,0.00
 f766ad6,BenchmarkSanitizeLog/Unsafe-8,535.30,704.00,1.00
+f05f787,BenchmarkAWSChunkedReaderSigned-8,433269.00,153.62,11276.00
+f05f787,BenchmarkAWSChunkedReaderUnsigned-8,423356.00,157.22,78564.00
+f05f787,BenchmarkCheckMetricsAndSwap-8,7.50,0.00,0.00
+f05f787,BenchmarkCrushOptimized-8,323.10,0.00,0.00
+f05f787,BenchmarkCrushOriginal-8,538.90,164.00,3.00
+f05f787,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+f05f787,BenchmarkIndexSearch-8,2.80,0.00,0.00
+f05f787,BenchmarkLoadGlobalConfig-8,9120.00,1848.00,54.00
+f05f787,BenchmarkPadString-8,43.85,64.00,1.00
+f05f787,BenchmarkSanitizeLog/Safe-8,444.00,0.00,0.00
+f05f787,BenchmarkSanitizeLog/Unsafe-8,519.70,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             545.6n ± ∞ ¹    566.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            403.2n ± ∞ ¹    379.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          9.722µ ± ∞ ¹   11.718µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 52.77n ± ∞ ¹    44.73n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          456.7n ± ∞ ¹    619.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        832.2n ± ∞ ¹    535.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    775.2µ ± ∞ ¹    442.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  709.9µ ± ∞ ¹    431.2µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       9.059n ± ∞ ¹    7.947n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.235n ± ∞ ¹    3.234n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4407n ± ∞ ¹   0.3399n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     479.0n          414.7n        -13.44%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                             566.2n ± ∞ ¹    538.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            379.5n ± ∞ ¹    323.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         11.718µ ± ∞ ¹    9.120µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 44.73n ± ∞ ¹    43.85n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          619.5n ± ∞ ¹    444.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        535.3n ± ∞ ¹    519.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    442.8µ ± ∞ ¹    433.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  431.2µ ± ∞ ¹    423.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.947n ± ∞ ¹    7.505n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.234n ± ∞ ¹    2.802n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3399n ± ∞ ¹   0.3369n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     414.7n          375.4n        -9.46%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.06Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.77Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.04%               ⁴
+geomean                                                ⁴                  -0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s        vs base                 │
-AWSChunkedReaderSigned-8                   81.88Mi ± ∞ ¹   143.34Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 89.42Mi ± ∞ ¹   147.20Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    85.57Mi          145.3Mi        +69.76%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │             B/s             │      B/s       vs base                │
+AWSChunkedReaderSigned-8                   143.3Mi ± ∞ ¹   146.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 147.2Mi ± ∞ ¹   149.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    145.3Mi         148.2Mi        +2.03%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 442836.00 ns/op | 150.30 B/op | 11281.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 431233.00 ns/op | 154.35 B/op | 78565.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.95 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 379.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 566.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 433269.00 ns/op | 153.62 B/op | 11276.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 423356.00 ns/op | 157.22 B/op | 78564.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 323.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 538.90 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.23 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 11718.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 44.73 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 619.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 535.30 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9120.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 43.85 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 444.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 519.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6]
-    line "AWSChunkedReaderSigned" [622202,380899,410944,580705,576464,620631,535526,482680,775197,442836]
-    line "AWSChunkedReaderUnsigned" [484134,403705,410907,557512,605728,652637,451534,511362,709921,431233]
-    line "CheckMetricsAndSwap" [8,9,7,10,11,10,9,10,9,8]
-    line "CrushOptimized" [403,296,264,368,415,420,335,311,403,380]
-    line "CrushOriginal" [474,375,370,598,664,874,456,584,546,566]
-    line "IndexDirectTracking" [0,0,0,0,0,0,1,0,0,0]
-    line "IndexSearch" [3,3,3,3,4,3,3,3,3,3]
-    line "LoadGlobalConfig" [9150,7234,7096,10842,13042,12014,9184,10419,9722,11718]
-    line "PadString" [48,35,34,55,63,56,46,48,53,45]
+    x-axis [5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787]
+    line "AWSChunkedReaderSigned" [380899,410944,580705,576464,620631,535526,482680,775197,442836,433269]
+    line "AWSChunkedReaderUnsigned" [403705,410907,557512,605728,652637,451534,511362,709921,431233,423356]
+    line "CheckMetricsAndSwap" [9,7,10,11,10,9,10,9,8,8]
+    line "CrushOptimized" [296,264,368,415,420,335,311,403,380,323]
+    line "CrushOriginal" [375,370,598,664,874,456,584,546,566,539]
+    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
+    line "IndexSearch" [3,3,3,4,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [7234,7096,10842,13042,12014,9184,10419,9722,11718,9120]
+    line "PadString" [35,34,55,63,56,46,48,53,45,44]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [543,398,379,530,569,614,504,554,457,620]
-    line "SanitizeLog/Unsafe" [680,482,537,734,816,804,636,638,832,535]
+    line "SanitizeLog/Safe" [398,379,530,569,614,504,554,457,620,444]
+    line "SanitizeLog/Unsafe" [482,537,734,816,804,636,638,832,535,520]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6]
-    line "AWSChunkedReaderSigned" [107,175,162,115,115,107,124,138,86,150]
-    line "AWSChunkedReaderUnsigned" [137,165,162,119,110,102,147,130,94,154]
+    x-axis [5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787]
+    line "AWSChunkedReaderSigned" [175,162,115,115,107,124,138,86,150,154]
+    line "AWSChunkedReaderUnsigned" [165,162,119,110,102,147,130,94,154,157]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [49387ee,5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6]
-    line "AWSChunkedReaderSigned" [11281,11264,11269,11322,11314,11309,11288,11293,11324,11281]
-    line "AWSChunkedReaderUnsigned" [78567,78568,78569,78587,78599,78604,78570,78569,78612,78565]
+    x-axis [5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787]
+    line "AWSChunkedReaderSigned" [11264,11269,11322,11314,11309,11288,11293,11324,11281,11276]
+    line "AWSChunkedReaderUnsigned" [78568,78569,78587,78599,78604,78570,78569,78612,78565,78564]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -288,8 +288,13 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 		}
 	}()
 
-	// Read metadata from DB
+	// Read metadata from DB in a single View (size, remotePath, modTime) to
+	// minimize bbolt read-lock acquisition (perf: was 3 separate Views).
+	// The blob open above intentionally stays outside any transaction so a
+	// slow S3 download does not hold the bbolt read lock and block writers.
 	var size int64
+	var remotePath string
+	var modTime int64
 	err = s.db.View(func(tx *bbolt.Tx) error {
 		val := tx.Bucket(bucketObjects).Get([]byte(hash))
 		if val == nil {
@@ -302,34 +307,18 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 		if size < 0 {
 			return fmt.Errorf("invalid size %d for hash %s: %w", size, hash, syscall.EBADMSG)
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, common.FileMetadata{}, err
-	}
 
-	var remotePath string
-	err = s.db.View(func(tx *bbolt.Tx) error {
-		p := tx.Bucket(bucketPaths).Get([]byte(name))
-		if p != nil {
+		if p := tx.Bucket(bucketPaths).Get([]byte(name)); p != nil {
 			remotePath = string(p)
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, common.FileMetadata{}, fmt.Errorf("failed to read remotePath: %w", err)
-	}
 
-	var modTime int64
-	err = s.db.View(func(tx *bbolt.Tx) error {
-		mt := tx.Bucket(bucketModTimes).Get([]byte(name))
-		if len(mt) >= 8 {
+		if mt := tx.Bucket(bucketModTimes).Get([]byte(name)); len(mt) >= 8 {
 			modTime = int64(binary.BigEndian.Uint64(mt[:8]))
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, common.FileMetadata{}, fmt.Errorf("failed to read modtime: %w", err)
+		return nil, common.FileMetadata{}, err
 	}
 
 	return f, common.FileMetadata{Name: name, Hash: hash, Size: size, RemotePath: remotePath, ModTime: modTime}, nil

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -373,6 +373,57 @@ func TestCASStore_GetHashForName(t *testing.T) {
 	}
 }
 
+func TestCASStoreGetReturnsFullMetadata(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tmpDir, err := os.MkdirTemp("", "momo-get-meta-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := NewCASStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create CASStore: %v", err)
+	}
+	defer store.Close()
+
+	content := []byte("hello metadata")
+	hash := common.HashBytes(content)
+	size := int64(len(content))
+	name := "dirA/meta.txt"
+	remotePath := "virtual/dir"
+
+	if err := store.Put(name, hash, size, remotePath, bytes.NewReader(content)); err != nil {
+		t.Fatalf("Failed to Put: %v", err)
+	}
+
+	rc, meta, err := store.Get(name)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Content mismatch: got %q", got)
+	}
+	if meta.Hash != hash {
+		t.Errorf("Hash: got %s, want %s", meta.Hash, hash)
+	}
+	if meta.Size != size {
+		t.Errorf("Size: got %d, want %d", meta.Size, size)
+	}
+	if meta.RemotePath != remotePath {
+		t.Errorf("RemotePath: got %q, want %q", meta.RemotePath, remotePath)
+	}
+	if meta.ModTime == 0 {
+		t.Error("ModTime: expected non-zero after Put")
+	}
+}
+
 func TestCASStoreDeleteRemovesBlobImmediately(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	tmpDir, err := os.MkdirTemp("", "momo-cve006-test-*")


### PR DESCRIPTION
Resolves #636

**Problem** — `CASStore.Get` issued 4 separate `db.View` transactions (tombstone/hash lookup, size, remotePath, modTime), each acquiring a bbolt read lock.

**Fix** — collapsed the three post-open metadata lookups (size, remotePath, modTime) into a single `View` transaction. The blob open (`s.blobs.GetBlob`) intentionally stays outside any transaction, so a slow S3 download never holds the bbolt read lock and blocks writers (bbolt read tx would otherwise pin writers for the download duration — a worse contention regression than the 3 quick Views this replaces).

**Tests**
- `TestCASStoreGetReturnsFullMetadata` — asserts content, hash, size, remotePath, and non-zero modTime round-trip through the merged path.
- Behavior-preservation verified: test passes on both old (4-View) and new (2-View) implementations.
- gofmt/vet clean; full `./src/storage` suite passes.