### PR TITLE
fix(gc): log ts.Delete failures in tombstone sweep (#637)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3564,3 +3564,14 @@ f05f787,BenchmarkLoadGlobalConfig-8,9120.00,1848.00,54.00
 f05f787,BenchmarkPadString-8,43.85,64.00,1.00
 f05f787,BenchmarkSanitizeLog/Safe-8,444.00,0.00,0.00
 f05f787,BenchmarkSanitizeLog/Unsafe-8,519.70,704.00,1.00
+1af8ba3,BenchmarkAWSChunkedReaderSigned-8,471486.00,141.17,11279.00
+1af8ba3,BenchmarkAWSChunkedReaderUnsigned-8,474357.00,140.32,78575.00
+1af8ba3,BenchmarkCheckMetricsAndSwap-8,8.13,0.00,0.00
+1af8ba3,BenchmarkCrushOptimized-8,349.60,0.00,0.00
+1af8ba3,BenchmarkCrushOriginal-8,457.80,164.00,3.00
+1af8ba3,BenchmarkIndexDirectTracking-8,0.40,0.00,0.00
+1af8ba3,BenchmarkIndexSearch-8,3.04,0.00,0.00
+1af8ba3,BenchmarkLoadGlobalConfig-8,9517.00,1848.00,54.00
+1af8ba3,BenchmarkPadString-8,44.37,64.00,1.00
+1af8ba3,BenchmarkSanitizeLog/Safe-8,473.70,0.00,0.00
+1af8ba3,BenchmarkSanitizeLog/Unsafe-8,580.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             566.2n ± ∞ ¹    538.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            379.5n ± ∞ ¹    323.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                         11.718µ ± ∞ ¹    9.120µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 44.73n ± ∞ ¹    43.85n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          619.5n ± ∞ ¹    444.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        535.3n ± ∞ ¹    519.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    442.8µ ± ∞ ¹    433.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  431.2µ ± ∞ ¹    423.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.947n ± ∞ ¹    7.505n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.234n ± ∞ ¹    2.802n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3399n ± ∞ ¹   0.3369n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     414.7n          375.4n        -9.46%
+CrushOriginal-8                             538.9n ± ∞ ¹    457.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            323.1n ± ∞ ¹    349.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          9.120µ ± ∞ ¹    9.517µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 43.85n ± ∞ ¹    44.37n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          444.0n ± ∞ ¹    473.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        519.7n ± ∞ ¹    580.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    433.3µ ± ∞ ¹    471.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  423.4µ ± ∞ ¹    474.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.505n ± ∞ ¹    8.133n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.802n ± ∞ ¹    3.037n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3369n ± ∞ ¹   0.3994n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     375.4n          399.2n        +6.33%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.00%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   143.3Mi ± ∞ ¹   146.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 147.2Mi ± ∞ ¹   149.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    145.3Mi         148.2Mi        +2.03%
+AWSChunkedReaderSigned-8                   146.5Mi ± ∞ ¹   134.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 149.9Mi ± ∞ ¹   133.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    148.2Mi         134.2Mi        -9.44%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 433269.00 ns/op | 153.62 B/op | 11276.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 423356.00 ns/op | 157.22 B/op | 78564.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 323.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 538.90 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9120.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 43.85 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 444.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 519.70 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 471486.00 ns/op | 141.17 B/op | 11279.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 474357.00 ns/op | 140.32 B/op | 78575.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.13 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 349.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 457.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.04 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9517.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 44.37 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 473.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 580.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787]
-    line "AWSChunkedReaderSigned" [380899,410944,580705,576464,620631,535526,482680,775197,442836,433269]
-    line "AWSChunkedReaderUnsigned" [403705,410907,557512,605728,652637,451534,511362,709921,431233,423356]
-    line "CheckMetricsAndSwap" [9,7,10,11,10,9,10,9,8,8]
-    line "CrushOptimized" [296,264,368,415,420,335,311,403,380,323]
-    line "CrushOriginal" [375,370,598,664,874,456,584,546,566,539]
-    line "IndexDirectTracking" [0,0,0,0,0,1,0,0,0,0]
-    line "IndexSearch" [3,3,3,4,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [7234,7096,10842,13042,12014,9184,10419,9722,11718,9120]
-    line "PadString" [35,34,55,63,56,46,48,53,45,44]
+    x-axis [baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787,1af8ba3]
+    line "AWSChunkedReaderSigned" [410944,580705,576464,620631,535526,482680,775197,442836,433269,471486]
+    line "AWSChunkedReaderUnsigned" [410907,557512,605728,652637,451534,511362,709921,431233,423356,474357]
+    line "CheckMetricsAndSwap" [7,10,11,10,9,10,9,8,8,8]
+    line "CrushOptimized" [264,368,415,420,335,311,403,380,323,350]
+    line "CrushOriginal" [370,598,664,874,456,584,546,566,539,458]
+    line "IndexDirectTracking" [0,0,0,0,1,0,0,0,0,0]
+    line "IndexSearch" [3,3,4,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [7096,10842,13042,12014,9184,10419,9722,11718,9120,9517]
+    line "PadString" [34,55,63,56,46,48,53,45,44,44]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [398,379,530,569,614,504,554,457,620,444]
-    line "SanitizeLog/Unsafe" [482,537,734,816,804,636,638,832,535,520]
+    line "SanitizeLog/Safe" [379,530,569,614,504,554,457,620,444,474]
+    line "SanitizeLog/Unsafe" [537,734,816,804,636,638,832,535,520,580]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787]
-    line "AWSChunkedReaderSigned" [175,162,115,115,107,124,138,86,150,154]
-    line "AWSChunkedReaderUnsigned" [165,162,119,110,102,147,130,94,154,157]
+    x-axis [baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787,1af8ba3]
+    line "AWSChunkedReaderSigned" [162,115,115,107,124,138,86,150,154,141]
+    line "AWSChunkedReaderUnsigned" [162,119,110,102,147,130,94,154,157,140]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [5322b2c,baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787]
-    line "AWSChunkedReaderSigned" [11264,11269,11322,11314,11309,11288,11293,11324,11281,11276]
-    line "AWSChunkedReaderUnsigned" [78568,78569,78587,78599,78604,78570,78569,78612,78565,78564]
+    x-axis [baf52a7,2684aa7,2766ce2,ea64898,c0e11e5,50203a3,24e30d3,f766ad6,f05f787,1af8ba3]
+    line "AWSChunkedReaderSigned" [11269,11322,11314,11309,11288,11293,11324,11281,11276,11279]
+    line "AWSChunkedReaderUnsigned" [78569,78587,78599,78604,78570,78569,78612,78565,78564,78575]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/storage/gc.go
+++ b/src/storage/gc.go
@@ -136,7 +136,11 @@ func (s *CASStore) sweepExpiredTombstones(retention time.Duration) error {
 		}
 
 		for _, name := range expiredNames {
-			ts.Delete(name)
+			// 🔊 Log Delete failures instead of swallowing them; sweep
+			// continues so one bad entry can't block the rest.
+			if err := ts.Delete(name); err != nil {
+				log.Printf("CAS GC: failed to delete expired tombstone for %q: %v", name, err)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
Resolves #637

**Problem** — `sweepExpiredTombstones` called `ts.Delete(name)` inside the bbolt tx and ignored its error. A failed delete silently left an expired tombstone in place.

**Fix** — failures now log with the tombstone name and the sweep continues, so one bad entry cannot block the rest.

**Tests** — sweep behavior verified via existing tombstone tests (`TestTombstoneExpiry`, `TestTombstoneHidesFromListAndGet`, `TestGCBackgroundSweeper`). Delete failure is not injectable in bbolt without corrupting the bucket; the log path is a single `if err := ...` guard.

gofmt/vet clean.