### PR TITLE
fix: deterministic error messages for missing daemon fields (#644)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3674,3 +3674,14 @@ d25a8f0f,BenchmarkSanitizeLog/Unsafe-8,564.40,704.00,1.00
 7fdac824,BenchmarkPadString-8,45.69,64.00,1.00
 7fdac824,BenchmarkSanitizeLog/Safe-8,420.90,0.00,0.00
 7fdac824,BenchmarkSanitizeLog/Unsafe-8,628.20,704.00,1.00
+da1029be,BenchmarkAWSChunkedReaderSigned-8,409335.00,162.61,11270.00
+da1029be,BenchmarkAWSChunkedReaderUnsigned-8,400921.00,166.02,78555.00
+da1029be,BenchmarkCheckMetricsAndSwap-8,7.27,0.00,0.00
+da1029be,BenchmarkCrushOptimized-8,296.90,0.00,0.00
+da1029be,BenchmarkCrushOriginal-8,396.40,164.00,3.00
+da1029be,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+da1029be,BenchmarkIndexSearch-8,1.58,0.00,0.00
+da1029be,BenchmarkLoadGlobalConfig-8,7743.00,1848.00,54.00
+da1029be,BenchmarkPadString-8,37.63,64.00,1.00
+da1029be,BenchmarkSanitizeLog/Safe-8,213.10,0.00,0.00
+da1029be,BenchmarkSanitizeLog/Unsafe-8,658.10,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,20 +39,20 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             439.3n ± ∞ ¹    459.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            354.2n ± ∞ ¹    427.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.791µ ± ∞ ¹    9.473µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 46.84n ± ∞ ¹    45.69n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          446.5n ± ∞ ¹    420.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        564.4n ± ∞ ¹    628.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    490.7µ ± ∞ ¹    484.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  440.7µ ± ∞ ¹    466.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       8.153n ± ∞ ¹   10.030n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.630n ± ∞ ¹    2.236n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4381n ± ∞ ¹   0.3601n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     374.5n          399.2n        +6.58%
+CrushOriginal-8                             396.4n ± ∞ ¹    396.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            296.9n ± ∞ ¹    296.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.743µ ± ∞ ¹    7.743µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 37.63n ± ∞ ¹    37.63n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          213.1n ± ∞ ¹    213.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        658.1n ± ∞ ¹    658.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    409.3µ ± ∞ ¹    409.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  400.9µ ± ∞ ¹    400.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.266n ± ∞ ¹    7.266n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.584n ± ∞ ¹    1.584n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3312n ± ∞ ¹   0.3312n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     314.8n          314.8n        +0.00%
 ¹ need >= 6 samples for confidence interval at level 0.95
-² need >= 4 samples to detect a difference at alpha level 0.05
+² all samples are equal
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │            B/op             │     B/op       vs base                │
@@ -62,16 +62,15 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 76.71Ki ± ∞ ¹   76.71Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.01%               ⁴
+geomean                                                ³                  +0.00%               ³
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
-³ need >= 4 samples to detect a difference at alpha level 0.05
-⁴ summaries must be >0 to compute geomean
+³ summaries must be >0 to compute geomean
 
                            │ /tmp/old_bench_filtered.txt │     /tmp/new_bench_filtered.txt     │
                            │          allocs/op          │  allocs/op   vs base                │
@@ -93,11 +92,11 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   129.4Mi ± ∞ ¹   130.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 144.0Mi ± ∞ ¹   136.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    136.5Mi         133.5Mi        -2.17%
+AWSChunkedReaderSigned-8                   155.1Mi ± ∞ ¹   155.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 158.3Mi ± ∞ ¹   158.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    156.7Mi         156.7Mi        +0.00%
 ¹ need >= 6 samples for confidence interval at level 0.95
-² need >= 4 samples to detect a difference at alpha level 0.05
+² all samples are equal
 ```
 
 ### Latest Benchmark Results
@@ -108,17 +107,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 484836.00 ns/op | 137.28 B/op | 11292.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 465971.00 ns/op | 142.84 B/op | 78560.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.03 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 427.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 459.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.24 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9473.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 45.69 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 420.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 628.20 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 409335.00 ns/op | 162.61 B/op | 11270.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 400921.00 ns/op | 166.02 B/op | 78555.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.27 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 296.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 396.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.58 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7743.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 37.63 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 213.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 658.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +146,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [1af8ba3,70cf4d8,467a907,208af30,0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82]
-    line "AWSChunkedReaderSigned" [471486,516881,507945,510634,443312,465495,449386,448000,490719,484836]
-    line "AWSChunkedReaderUnsigned" [474357,455846,516953,473850,430915,492166,423737,435828,440689,465971]
-    line "CheckMetricsAndSwap" [8,10,11,10,9,8,8,9,8,10]
-    line "CrushOptimized" [350,364,346,377,292,388,386,330,354,427]
-    line "CrushOriginal" [458,474,505,535,424,557,423,425,439,459]
+    x-axis [70cf4d8,467a907,208af30,0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b]
+    line "AWSChunkedReaderSigned" [516881,507945,510634,443312,465495,449386,448000,490719,484836,409335]
+    line "AWSChunkedReaderUnsigned" [455846,516953,473850,430915,492166,423737,435828,440689,465971,400921]
+    line "CheckMetricsAndSwap" [10,11,10,9,8,8,9,8,10,7]
+    line "CrushOptimized" [364,346,377,292,388,386,330,354,427,297]
+    line "CrushOriginal" [474,505,535,424,557,423,425,439,459,396]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,2,2,2,2]
-    line "LoadGlobalConfig" [9517,9076,10103,9520,8358,8807,8472,8919,8791,9473]
-    line "PadString" [44,45,50,50,38,50,47,41,47,46]
+    line "IndexSearch" [3,3,3,3,3,2,2,2,2,2]
+    line "LoadGlobalConfig" [9076,10103,9520,8358,8807,8472,8919,8791,9473,7743]
+    line "PadString" [45,50,50,38,50,47,41,47,46,38]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [474,429,578,516,490,475,259,236,446,421]
-    line "SanitizeLog/Unsafe" [580,718,732,656,551,638,691,701,564,628]
+    line "SanitizeLog/Safe" [429,578,516,490,475,259,236,446,421,213]
+    line "SanitizeLog/Unsafe" [718,732,656,551,638,691,701,564,628,658]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +172,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [1af8ba3,70cf4d8,467a907,208af30,0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82]
-    line "AWSChunkedReaderSigned" [141,129,131,130,150,143,148,149,136,137]
-    line "AWSChunkedReaderUnsigned" [140,146,129,140,154,135,157,153,151,143]
+    x-axis [70cf4d8,467a907,208af30,0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b]
+    line "AWSChunkedReaderSigned" [129,131,130,150,143,148,149,136,137,163]
+    line "AWSChunkedReaderUnsigned" [146,129,140,154,135,157,153,151,143,166]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +198,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [1af8ba3,70cf4d8,467a907,208af30,0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82]
-    line "AWSChunkedReaderSigned" [11279,11278,11297,11285,11285,11290,11275,11278,11276,11292]
-    line "AWSChunkedReaderUnsigned" [78575,78573,78574,78586,78562,78583,78570,78570,78570,78560]
+    x-axis [70cf4d8,467a907,208af30,0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b]
+    line "AWSChunkedReaderSigned" [11278,11297,11285,11285,11290,11275,11278,11276,11292,11270]
+    line "AWSChunkedReaderUnsigned" [78573,78574,78586,78562,78583,78570,78570,78570,78560,78555]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -569,7 +570,14 @@ func loadDaemons(cfg *ini.File) ([]*Daemon, error) {
 			"drive":              &d.Drive,
 		}
 
-		for key, ptr := range requiredFields {
+		keys := make([]string, 0, len(requiredFields))
+		for key := range requiredFields {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			ptr := requiredFields[key]
 			*ptr = section.Key(key).String()
 			if *ptr == "" {
 				return nil, fmt.Errorf("missing '%s' in section [%s]", key, sectionName)

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -152,6 +152,43 @@ func TestGetConfig_Failures(t *testing.T) {
 	}
 }
 
+// TestLoadDaemons_MissingFieldsDeterministic ensures that when multiple required
+// daemon fields are missing, the reported error is deterministic across runs
+// (map iteration order must not influence the chosen field, issue #644).
+func TestLoadDaemons_MissingFieldsDeterministic(t *testing.T) {
+	// Drop both host and drive from the daemon section.
+	content := strings.Replace(validConfig, "host = localhost:8080", "", 1)
+	content = strings.Replace(content, "drive = /dev/sda1", "", 1)
+
+	tmpDir := t.TempDir()
+	tmpfile := filepath.Join(tmpDir, "momo.conf")
+	if err := os.WriteFile(tmpfile, []byte(content), 0666); err != nil {
+		t.Fatalf("Failed to write to temporary config file: %v", err)
+	}
+
+	var firstErr error
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		_, err := GetConfig(tmpfile)
+		if err == nil {
+			t.Fatalf("Expected an error for missing fields, got none")
+		}
+		if i == 0 {
+			firstErr = err
+			continue
+		}
+		if err.Error() != firstErr.Error() {
+			t.Fatalf("Non-deterministic error: iteration %d got %q, wanted %q", i, err.Error(), firstErr.Error())
+		}
+	}
+
+	// Sorted field order is: change_replication, data, drive, host.
+	// "drive" is the alphabetically-first missing field, so it must be reported.
+	if !strings.Contains(firstErr.Error(), "missing 'drive' in section [daemon.0]") {
+		t.Errorf("Expected deterministic error for alphabetically-first missing field, got %q", firstErr.Error())
+	}
+}
+
 func TestGetConfig_FileErrors(t *testing.T) {
 	// 1. Non-existent file
 	_, err := GetConfig("nonexistent-config.conf")


### PR DESCRIPTION
Resolves #644

## Problem
`loadDaemons` in `src/common/config.go` iterated over the `requiredFields` map, whose iteration order is non-deterministic in Go. When multiple required daemon fields (`host`, `change_replication`, `data`, `drive`) were missing, the reported error picked a random one.

## Fix
Sort the field keys (`sort.Strings`) before iterating. The error now deterministically reports the alphabetically-first missing field (e.g. `drive`).

## Changelog
- `src/common/config.go`: sort `requiredFields` keys before validation loop; adds `sort` import.
- `src/common/config_test.go`: new `TestLoadDaemons_MissingFieldsDeterministic` — runs `GetConfig` 100× on a config missing `host` + `drive`, asserts identical error every run and that the sorted-first missing field (`drive`) is reported. Existing singular-missing-field error strings are unchanged (backward compatible).
- `docs/PERFORMANCE.md`, `.github/data/benchmark_history.csv`: regenerated by pre-commit hook.

## Verification
- `go build ./...` ✅
- `go test ./...` ✅
- `go vet ./src/common/` ✅
- `gofmt -l` clean ✅
- `go work vendor` produces no diff (Rule 25) ✅