### PR TITLE
fix: log warning when capping replication factor (#645)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3718,3 +3718,14 @@ e00e9d0f,BenchmarkSanitizeLog/Unsafe-8,673.00,704.00,1.00
 9e617f5c,BenchmarkPadString-8,39.10,64.00,1.00
 9e617f5c,BenchmarkSanitizeLog/Safe-8,222.30,0.00,0.00
 9e617f5c,BenchmarkSanitizeLog/Unsafe-8,658.40,704.00,1.00
+db4c2dfe,BenchmarkAWSChunkedReaderSigned-8,504383.00,131.96,11292.00
+db4c2dfe,BenchmarkAWSChunkedReaderUnsigned-8,490906.00,135.59,78578.00
+db4c2dfe,BenchmarkCheckMetricsAndSwap-8,7.95,0.00,0.00
+db4c2dfe,BenchmarkCrushOptimized-8,375.30,0.00,0.00
+db4c2dfe,BenchmarkCrushOriginal-8,471.40,164.00,3.00
+db4c2dfe,BenchmarkIndexDirectTracking-8,0.45,0.00,0.00
+db4c2dfe,BenchmarkIndexSearch-8,1.50,0.00,0.00
+db4c2dfe,BenchmarkLoadGlobalConfig-8,9117.00,1848.00,54.00
+db4c2dfe,BenchmarkPadString-8,48.91,64.00,1.00
+db4c2dfe,BenchmarkSanitizeLog/Safe-8,429.70,0.00,0.00
+db4c2dfe,BenchmarkSanitizeLog/Unsafe-8,600.70,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                           │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             410.8n ± ∞ ¹    409.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            318.4n ± ∞ ¹    318.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.049µ ± ∞ ¹    8.138µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 38.80n ± ∞ ¹    39.10n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          213.4n ± ∞ ¹    222.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        673.0n ± ∞ ¹    658.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    429.5µ ± ∞ ¹    443.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  416.0µ ± ∞ ¹    416.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       8.243n ± ∞ ¹    7.313n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.574n ± ∞ ¹    1.645n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3570n ± ∞ ¹   0.3369n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     328.8n          326.8n        -0.61%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                           │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                             409.2n ± ∞ ¹    471.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            318.1n ± ∞ ¹    375.3n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.138µ ± ∞ ¹    9.117µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 39.10n ± ∞ ¹    48.91n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          222.3n ± ∞ ¹    429.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        658.4n ± ∞ ¹    600.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    443.5µ ± ∞ ¹    504.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  416.6µ ± ∞ ¹    490.9µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.313n ± ∞ ¹    7.953n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.645n ± ∞ ¹    1.503n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3369n ± ∞ ¹   0.4507n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     326.8n          384.5n        +17.66%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.00%               ⁴
+geomean                                                ⁴                  +0.02%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                           │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   147.8Mi ± ∞ ¹   143.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 152.6Mi ± ∞ ¹   152.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    150.2Mi         147.7Mi        -1.65%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s       vs base                 │
+AWSChunkedReaderSigned-8                   143.1Mi ± ∞ ¹   125.8Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 152.4Mi ± ∞ ¹   129.3Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    147.7Mi         127.6Mi        -13.62%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 443463.00 ns/op | 150.09 B/op | 11275.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 416589.00 ns/op | 159.77 B/op | 78558.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.31 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 318.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 409.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.65 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8138.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 39.10 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 222.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 658.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 504383.00 ns/op | 131.96 B/op | 11292.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 490906.00 ns/op | 135.59 B/op | 78578.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.95 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 375.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 471.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.45 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9117.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 48.91 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 429.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 600.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5]
-    line "AWSChunkedReaderSigned" [443312,465495,449386,448000,490719,484836,409335,415353,429495,443463]
-    line "AWSChunkedReaderUnsigned" [430915,492166,423737,435828,440689,465971,400921,427097,416046,416589]
-    line "CheckMetricsAndSwap" [9,8,8,9,8,10,7,8,8,7]
-    line "CrushOptimized" [292,388,386,330,354,427,297,293,318,318]
-    line "CrushOriginal" [424,557,423,425,439,459,396,411,411,409]
+    x-axis [651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df]
+    line "AWSChunkedReaderSigned" [465495,449386,448000,490719,484836,409335,415353,429495,443463,504383]
+    line "AWSChunkedReaderUnsigned" [492166,423737,435828,440689,465971,400921,427097,416046,416589,490906]
+    line "CheckMetricsAndSwap" [8,8,9,8,10,7,8,8,7,8]
+    line "CrushOptimized" [388,386,330,354,427,297,293,318,318,375]
+    line "CrushOriginal" [557,423,425,439,459,396,411,411,409,471]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [8358,8807,8472,8919,8791,9473,7743,7862,8049,8138]
-    line "PadString" [38,50,47,41,47,46,38,38,39,39]
+    line "IndexSearch" [3,2,2,2,2,2,2,2,2,2]
+    line "LoadGlobalConfig" [8807,8472,8919,8791,9473,7743,7862,8049,8138,9117]
+    line "PadString" [50,47,41,47,46,38,38,39,39,49]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [490,475,259,236,446,421,213,231,213,222]
-    line "SanitizeLog/Unsafe" [551,638,691,701,564,628,658,674,673,658]
+    line "SanitizeLog/Safe" [475,259,236,446,421,213,231,213,222,430]
+    line "SanitizeLog/Unsafe" [638,691,701,564,628,658,674,673,658,601]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5]
-    line "AWSChunkedReaderSigned" [150,143,148,149,136,137,163,160,155,150]
-    line "AWSChunkedReaderUnsigned" [154,135,157,153,151,143,166,156,160,160]
+    x-axis [651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df]
+    line "AWSChunkedReaderSigned" [143,148,149,136,137,163,160,155,150,132]
+    line "AWSChunkedReaderUnsigned" [135,157,153,151,143,166,156,160,160,136]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0682f60,651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5]
-    line "AWSChunkedReaderSigned" [11285,11290,11275,11278,11276,11292,11270,11274,11274,11275]
-    line "AWSChunkedReaderUnsigned" [78562,78583,78570,78570,78570,78560,78555,78563,78570,78558]
+    x-axis [651dd80,41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df]
+    line "AWSChunkedReaderSigned" [11290,11275,11278,11276,11292,11270,11274,11274,11275,11292]
+    line "AWSChunkedReaderUnsigned" [78583,78570,78570,78570,78560,78555,78563,78570,78558,78578]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -63,6 +63,8 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 	}
 
 	if replicationFactor > len(eligible) {
+		log.Printf("WARNING: replication factor %d exceeds %d eligible nodes in cluster map, capping to %d",
+			replicationFactor, len(eligible), len(eligible))
 		replicationFactor = len(eligible)
 	}
 

--- a/src/common/crush_test.go
+++ b/src/common/crush_test.go
@@ -1,8 +1,11 @@
 package common
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -158,7 +161,7 @@ func TestClusterMap_Placement_SkipsZeroWeightNodes(t *testing.T) {
 	nodes := []*Node{
 		{ID: 0, Weight: 1, Addr: "127.0.0.1:4440"},
 		{ID: 1, Weight: 1, Addr: "127.0.0.1:4441"},
-		{ID: 2, Weight: 0, Addr: "127.0.0.1:4442"},   // disabled
+		{ID: 2, Weight: 0, Addr: "127.0.0.1:4442"},  // disabled
 		{ID: 3, Weight: -5, Addr: "127.0.0.1:4443"}, // decommissioned
 	}
 	m := &ClusterMap{Nodes: nodes}
@@ -194,4 +197,44 @@ func TestClusterMap_Placement_AllZeroWeight(t *testing.T) {
 	if !errors.Is(err, syscall.EINVAL) {
 		t.Errorf("Expected error to wrap syscall.EINVAL, got %v", err)
 	}
+}
+
+// TestClusterMap_Placement_CapWarning verifies that requesting a replication
+// factor larger than the eligible node count logs a warning instead of silently
+// capping (fix #645), and that no warning is logged when RF fits.
+func TestClusterMap_Placement_CapWarning(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	nodes := []*Node{
+		{ID: 0, Weight: 1, Addr: "127.0.0.1:4440"},
+		{ID: 1, Weight: 1, Addr: "127.0.0.1:4441"},
+	}
+	m := &ClusterMap{Nodes: nodes}
+
+	wantWarning := func(label, wantSub, forbiddenSub string, rf int, wantLen int) {
+		t.Helper()
+		var buf bytes.Buffer
+		prev := log.Writer()
+		log.SetOutput(&buf)
+		defer log.SetOutput(prev)
+
+		out, err := m.Placement("some-hash", rf)
+		if err != nil {
+			t.Fatalf("%s: Placement failed: %v", label, err)
+		}
+		if len(out) != wantLen {
+			t.Fatalf("%s: Expected %d nodes, got %d", label, wantLen, len(out))
+		}
+		if wantSub != "" && !strings.Contains(buf.String(), wantSub) {
+			t.Errorf("%s: Expected log to contain %q, got %q", label, wantSub, buf.String())
+		}
+		if forbiddenSub != "" && strings.Contains(buf.String(), forbiddenSub) {
+			t.Errorf("%s: Expected log to NOT contain %q, got %q", label, forbiddenSub, buf.String())
+		}
+	}
+
+	// RF=5 with 2 eligible nodes: capped to 2, warning logged.
+	wantWarning("oversized RF", "replication factor 5 exceeds 2 eligible nodes", "", 5, 2)
+	// RF=2 with 2 nodes: no capping, no warning.
+	wantWarning("fitting RF", "", "exceeds", 2, 2)
 }


### PR DESCRIPTION
Resolves #645

## Problem
`ClusterMap.Placement` in `src/common/crush.go` silently capped `replicationFactor` to the eligible node count. A caller requesting RF=5 could silently receive only 3 nodes, reducing redundancy without warning.

## Fix
Log a `WARNING` line when capping occurs: `log.Printf("WARNING: replication factor %d exceeds %d eligible nodes in cluster map, capping to %d", ...)`. Behavior otherwise unchanged — capped placement still returned, formatting matches existing `WARNING:` log convention.

## Changelog
- `src/common/crush.go`: emit `WARNING` log before capping `replicationFactor` to `len(eligible)`.
- `src/common/crush_test.go`: new `TestClusterMap_Placement_CapWarning` — captures log output, asserts warning string on RF=5/2-nodes and absence of warning on RF=2/2-nodes; placeholder checks placement length in both cases.
- `docs/PERFORMANCE.md`, `.github/data/benchmark_history.csv`: regenerated by pre-commit hook.

## Verification
- `go build ./...` ✅
- `go test ./...` ✅
- `go vet ./src/common/` ✅
- `gofmt -l` clean ✅
- `go work vendor` produces no diff (Rule 25) ✅
- Master CI validated green before branching (Rule 71, dispatch run 32293188321) ✅