### PR TITLE
fix: fold hash into 52-bit mantissa to avoid float64 precision loss (#647)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3740,3 +3740,14 @@ db4c2dfe,BenchmarkSanitizeLog/Unsafe-8,600.70,704.00,1.00
 50e5f5bf,BenchmarkPadString-8,38.70,64.00,1.00
 50e5f5bf,BenchmarkSanitizeLog/Safe-8,390.10,0.00,0.00
 50e5f5bf,BenchmarkSanitizeLog/Unsafe-8,504.10,704.00,1.00
+a6c683c0,BenchmarkAWSChunkedReaderSigned-8,417284.00,159.51,11284.00
+a6c683c0,BenchmarkAWSChunkedReaderUnsigned-8,408069.00,163.11,78561.00
+a6c683c0,BenchmarkCheckMetricsAndSwap-8,8.43,0.00,0.00
+a6c683c0,BenchmarkCrushOptimized-8,304.70,0.00,0.00
+a6c683c0,BenchmarkCrushOriginal-8,425.30,164.00,3.00
+a6c683c0,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+a6c683c0,BenchmarkIndexSearch-8,1.55,0.00,0.00
+a6c683c0,BenchmarkLoadGlobalConfig-8,8368.00,1848.00,54.00
+a6c683c0,BenchmarkPadString-8,40.50,64.00,1.00
+a6c683c0,BenchmarkSanitizeLog/Safe-8,419.10,0.00,0.00
+a6c683c0,BenchmarkSanitizeLog/Unsafe-8,506.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3751,3 +3751,14 @@ a6c683c0,BenchmarkLoadGlobalConfig-8,8368.00,1848.00,54.00
 a6c683c0,BenchmarkPadString-8,40.50,64.00,1.00
 a6c683c0,BenchmarkSanitizeLog/Safe-8,419.10,0.00,0.00
 a6c683c0,BenchmarkSanitizeLog/Unsafe-8,506.00,704.00,1.00
+dcc52909,BenchmarkAWSChunkedReaderSigned-8,441285.00,150.83,11270.00
+dcc52909,BenchmarkAWSChunkedReaderUnsigned-8,409317.00,162.61,78559.00
+dcc52909,BenchmarkCheckMetricsAndSwap-8,7.64,0.00,0.00
+dcc52909,BenchmarkCrushOptimized-8,316.20,0.00,0.00
+dcc52909,BenchmarkCrushOriginal-8,445.00,164.00,3.00
+dcc52909,BenchmarkIndexDirectTracking-8,0.34,0.00,0.00
+dcc52909,BenchmarkIndexSearch-8,1.50,0.00,0.00
+dcc52909,BenchmarkLoadGlobalConfig-8,8771.00,1848.00,54.00
+dcc52909,BenchmarkPadString-8,45.41,64.00,1.00
+dcc52909,BenchmarkSanitizeLog/Safe-8,504.10,0.00,0.00
+dcc52909,BenchmarkSanitizeLog/Unsafe-8,500.70,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             434.4n ± ∞ ¹    425.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            303.9n ± ∞ ¹    304.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          7.890µ ± ∞ ¹    8.368µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 38.70n ± ∞ ¹    40.50n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          390.1n ± ∞ ¹    419.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        504.1n ± ∞ ¹    506.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    449.2µ ± ∞ ¹    417.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  412.9µ ± ∞ ¹    408.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       8.096n ± ∞ ¹    8.429n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.724n ± ∞ ¹    1.547n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3592n ± ∞ ¹   0.3153n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     341.5n          337.7n        -1.11%
+CrushOriginal-8                             425.3n ± ∞ ¹    445.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            304.7n ± ∞ ¹    316.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.368µ ± ∞ ¹    8.771µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 40.50n ± ∞ ¹    45.41n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          419.1n ± ∞ ¹    504.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        506.0n ± ∞ ¹    500.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    417.3µ ± ∞ ¹    441.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  408.1µ ± ∞ ¹    409.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.429n ± ∞ ¹    7.640n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.547n ± ∞ ¹    1.500n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3153n ± ∞ ¹   0.3354n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     337.7n          350.5n        +3.79%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.01%               ⁴
+geomean                                                ⁴                  -0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   141.3Mi ± ∞ ¹   152.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 153.7Mi ± ∞ ¹   155.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    147.4Mi         153.8Mi        +4.37%
+AWSChunkedReaderSigned-8                   152.1Mi ± ∞ ¹   143.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 155.6Mi ± ∞ ¹   155.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    153.8Mi         149.4Mi        -2.91%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 417284.00 ns/op | 159.51 B/op | 11284.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 408069.00 ns/op | 163.11 B/op | 78561.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.43 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 304.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 425.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8368.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 40.50 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 419.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 506.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 441285.00 ns/op | 150.83 B/op | 11270.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 409317.00 ns/op | 162.61 B/op | 78559.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.64 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 316.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 445.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8771.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 45.41 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 504.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 500.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c]
-    line "AWSChunkedReaderSigned" [448000,490719,484836,409335,415353,429495,443463,504383,449225,417284]
-    line "AWSChunkedReaderUnsigned" [435828,440689,465971,400921,427097,416046,416589,490906,412879,408069]
-    line "CheckMetricsAndSwap" [9,8,10,7,8,8,7,8,8,8]
-    line "CrushOptimized" [330,354,427,297,293,318,318,375,304,305]
-    line "CrushOriginal" [425,439,459,396,411,411,409,471,434,425]
+    x-axis [d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290]
+    line "AWSChunkedReaderSigned" [490719,484836,409335,415353,429495,443463,504383,449225,417284,441285]
+    line "AWSChunkedReaderUnsigned" [440689,465971,400921,427097,416046,416589,490906,412879,408069,409317]
+    line "CheckMetricsAndSwap" [8,10,7,8,8,7,8,8,8,8]
+    line "CrushOptimized" [354,427,297,293,318,318,375,304,305,316]
+    line "CrushOriginal" [439,459,396,411,411,409,471,434,425,445]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [8919,8791,9473,7743,7862,8049,8138,9117,7890,8368]
-    line "PadString" [41,47,46,38,38,39,39,49,39,40]
+    line "LoadGlobalConfig" [8791,9473,7743,7862,8049,8138,9117,7890,8368,8771]
+    line "PadString" [47,46,38,38,39,39,49,39,40,45]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [236,446,421,213,231,213,222,430,390,419]
-    line "SanitizeLog/Unsafe" [701,564,628,658,674,673,658,601,504,506]
+    line "SanitizeLog/Safe" [446,421,213,231,213,222,430,390,419,504]
+    line "SanitizeLog/Unsafe" [564,628,658,674,673,658,601,504,506,501]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c]
-    line "AWSChunkedReaderSigned" [149,136,137,163,160,155,150,132,148,160]
-    line "AWSChunkedReaderUnsigned" [153,151,143,166,156,160,160,136,161,163]
+    x-axis [d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290]
+    line "AWSChunkedReaderSigned" [136,137,163,160,155,150,132,148,160,151]
+    line "AWSChunkedReaderUnsigned" [151,143,166,156,160,160,136,161,163,163]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c]
-    line "AWSChunkedReaderSigned" [11278,11276,11292,11270,11274,11274,11275,11292,11274,11284]
-    line "AWSChunkedReaderUnsigned" [78570,78570,78560,78555,78563,78570,78558,78578,78566,78561]
+    x-axis [d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290]
+    line "AWSChunkedReaderSigned" [11276,11292,11270,11274,11274,11275,11292,11274,11284,11270]
+    line "AWSChunkedReaderUnsigned" [78570,78560,78555,78563,78570,78558,78578,78566,78561,78559]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             471.4n ± ∞ ¹    434.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            375.3n ± ∞ ¹    303.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          9.117µ ± ∞ ¹    7.890µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 48.91n ± ∞ ¹    38.70n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          429.7n ± ∞ ¹    390.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        600.7n ± ∞ ¹    504.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    504.4µ ± ∞ ¹    449.2µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  490.9µ ± ∞ ¹    412.9µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.953n ± ∞ ¹    8.096n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.503n ± ∞ ¹    1.724n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4507n ± ∞ ¹   0.3592n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     384.5n          341.5n        -11.18%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                             434.4n ± ∞ ¹    425.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            303.9n ± ∞ ¹    304.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.890µ ± ∞ ¹    8.368µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 38.70n ± ∞ ¹    40.50n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          390.1n ± ∞ ¹    419.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        504.1n ± ∞ ¹    506.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    449.2µ ± ∞ ¹    417.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  412.9µ ± ∞ ¹    408.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.096n ± ∞ ¹    8.429n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.724n ± ∞ ¹    1.547n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3592n ± ∞ ¹   0.3153n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     341.5n          337.7n        -1.11%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.02%               ⁴
+geomean                                                ⁴                  +0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   125.8Mi ± ∞ ¹   141.3Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 129.3Mi ± ∞ ¹   153.7Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    127.6Mi         147.4Mi        +15.54%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │             B/s             │      B/s       vs base                │
+AWSChunkedReaderSigned-8                   141.3Mi ± ∞ ¹   152.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 153.7Mi ± ∞ ¹   155.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    147.4Mi         153.8Mi        +4.37%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 449225.00 ns/op | 148.17 B/op | 11274.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 412879.00 ns/op | 161.21 B/op | 78566.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 303.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 434.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7890.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 38.70 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 390.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 504.10 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 417284.00 ns/op | 159.51 B/op | 11284.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 408069.00 ns/op | 163.11 B/op | 78561.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.43 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 304.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 425.30 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8368.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 40.50 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 419.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 506.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b]
-    line "AWSChunkedReaderSigned" [449386,448000,490719,484836,409335,415353,429495,443463,504383,449225]
-    line "AWSChunkedReaderUnsigned" [423737,435828,440689,465971,400921,427097,416046,416589,490906,412879]
-    line "CheckMetricsAndSwap" [8,9,8,10,7,8,8,7,8,8]
-    line "CrushOptimized" [386,330,354,427,297,293,318,318,375,304]
-    line "CrushOriginal" [423,425,439,459,396,411,411,409,471,434]
+    x-axis [ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c]
+    line "AWSChunkedReaderSigned" [448000,490719,484836,409335,415353,429495,443463,504383,449225,417284]
+    line "AWSChunkedReaderUnsigned" [435828,440689,465971,400921,427097,416046,416589,490906,412879,408069]
+    line "CheckMetricsAndSwap" [9,8,10,7,8,8,7,8,8,8]
+    line "CrushOptimized" [330,354,427,297,293,318,318,375,304,305]
+    line "CrushOriginal" [425,439,459,396,411,411,409,471,434,425]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [8472,8919,8791,9473,7743,7862,8049,8138,9117,7890]
-    line "PadString" [47,41,47,46,38,38,39,39,49,39]
+    line "LoadGlobalConfig" [8919,8791,9473,7743,7862,8049,8138,9117,7890,8368]
+    line "PadString" [41,47,46,38,38,39,39,49,39,40]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [259,236,446,421,213,231,213,222,430,390]
-    line "SanitizeLog/Unsafe" [691,701,564,628,658,674,673,658,601,504]
+    line "SanitizeLog/Safe" [236,446,421,213,231,213,222,430,390,419]
+    line "SanitizeLog/Unsafe" [701,564,628,658,674,673,658,601,504,506]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b]
-    line "AWSChunkedReaderSigned" [148,149,136,137,163,160,155,150,132,148]
-    line "AWSChunkedReaderUnsigned" [157,153,151,143,166,156,160,160,136,161]
+    x-axis [ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c]
+    line "AWSChunkedReaderSigned" [149,136,137,163,160,155,150,132,148,160]
+    line "AWSChunkedReaderUnsigned" [153,151,143,166,156,160,160,136,161,163]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [41f897f,ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b]
-    line "AWSChunkedReaderSigned" [11275,11278,11276,11292,11270,11274,11274,11275,11292,11274]
-    line "AWSChunkedReaderUnsigned" [78570,78570,78570,78560,78555,78563,78570,78558,78578,78566]
+    x-axis [ae599e3,d25a8f0,7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c]
+    line "AWSChunkedReaderSigned" [11278,11276,11292,11270,11274,11274,11275,11292,11274,11284]
+    line "AWSChunkedReaderUnsigned" [78570,78570,78560,78555,78563,78570,78558,78578,78566,78561]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/crush.go
+++ b/src/common/crush.go
@@ -25,6 +25,19 @@ type ClusterMap struct {
 	Nodes []*Node
 }
 
+// hashToScoreValue folds a sha256 digest into a float64 in [0,1) using a
+// 52-bit mantissa. float64 has only a 52-bit mantissa, so converting a full
+// uint64 discards its low ~11 bits and distinct hashes can map to the same
+// float, biasing placement (fix #647). Taking the top 32 bits plus the bottom
+// 20 bits of the digest keeps every mantissa bit meaningful and spans the full
+// hash, using all available entropy with no precision loss.
+func hashToScoreValue(sum []byte) float64 {
+	hi := binary.LittleEndian.Uint32(sum[:4])
+	lo := binary.LittleEndian.Uint32(sum[28:32])
+	mant := uint64(hi)<<20 | uint64(lo&(1<<20-1))
+	return float64(mant) / float64(uint64(1)<<52)
+}
+
 // Placement returns an ordered list of nodes where an object should be stored, based on its hash.
 // It uses a simplified version of the CRUSH algorithm (Weighted Rendezvous Hashing)
 // to ensure perfect load balancing and minimal data movement when nodes are added/removed.
@@ -89,8 +102,10 @@ func (m *ClusterMap) Placement(objectHash string, replicationFactor int) (nodes 
 		var sumBuf [sha256.Size]byte
 		sum := h.Sum(sumBuf[:0])
 
-		val := binary.LittleEndian.Uint64(sum[:8])
-		floatVal := float64(val) / float64(math.MaxUint64)
+		// ⚡ Bolt: Fold the full 32-byte hash into a 52-bit mantissa (fix #647) —
+		// float64 cannot represent a full uint64 exactly, so using only the high
+		// 64 bits would let distinct hashes collide on the same score.
+		floatVal := hashToScoreValue(sum)
 
 		// ⚡ Bolt: Use Weighted Rendezvous Hashing (WRH) formula: -weight / log(score).
 		// This provides mathematically perfect load balancing for heterogeneous nodes.

--- a/src/common/crush_test.go
+++ b/src/common/crush_test.go
@@ -199,6 +199,46 @@ func TestClusterMap_Placement_AllZeroWeight(t *testing.T) {
 	}
 }
 
+// TestHashToScoreValue_Precision verifies the 52-bit mantissa fold does not
+// lose precision for hashes that differ only in their low bits (fix #647).
+// A full uint64 → float64 conversion would round those differences away.
+func TestHashToScoreValue_Precision(t *testing.T) {
+	base := make([]byte, 32)
+	// Single lowest-bit difference in the folded tail (sum[28] is the LSB of
+	// the little-endian tail uint32, inside the 20-bit mask).
+	low := make([]byte, 32)
+	low[28] = 0x01
+
+	// Difference in the top bucket bits: sum[3] is the MSB of the little-endian
+	// head uint32; 0x80 there sets mantissa 1<<51 (exact 0.5).
+	high := make([]byte, 32)
+	high[3] = 0x80
+
+	vBase := hashToScoreValue(base)
+	vLow := hashToScoreValue(low)
+	vHigh := hashToScoreValue(high)
+
+	if vBase == vLow {
+		t.Errorf("Expected distinct scores for digests differing in low tail bit, both %v", vBase)
+	}
+	if vHigh <= vBase {
+		t.Errorf("Expected digest with high bit to score above all-zero digest, got %v <= %v", vHigh, vBase)
+	}
+
+	// Determinism and range.
+	if vBase != hashToScoreValue(make([]byte, 32)) {
+		t.Error("hashToScoreValue is not deterministic")
+	}
+	if vHigh < 0 || vHigh >= 1.0 {
+		t.Errorf("Score out of [0,1) range: %v", vHigh)
+	}
+
+	// Mantissa 1<<51 is exactly representable: score must be exactly 0.5.
+	if vHigh != 0.5 {
+		t.Errorf("Expected exactly 0.5 for 1<<51 mantissa, got %v", vHigh)
+	}
+}
+
 // TestClusterMap_Placement_TiedScoresStableOrder verifies that nodes with equal
 // scores keep their declaration order in the result (fix #646). Two nodes with
 // identical ID and weight hash to identical float values, guaranteeing a score

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -604,15 +604,28 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 
 			case common.ReplicationSplay:
 				// In Splay mode, the primary (first node in placement) forwards to all others.
-				// Guard against an empty placement list (e.g. ReplicationFactor 0 or no
-				// nodes) to avoid an index-out-of-range panic — fall through to local receive.
-				if len(placement) > 0 && placement[0].ID == serverId {
-					wg.Add(len(placement) - 1)
+				// An external client (e.g. aws-cli) connects directly without client-side
+				// placement, so it may hit any node. 🛡️ If that node is a placement member,
+				// have it drive replication too — otherwise the upload would be stored on a
+				// single node and never replicated (issue #647). Guard against an empty
+				// placement list (e.g. ReplicationFactor 0 or no nodes) to avoid an
+				// index-out-of-range panic — fall through to local receive.
+				if len(placement) > 0 && (placement[0].ID == serverId || comm.IsExternalClient()) {
+					// Forward to every placement member except this node. When self is the
+					// primary this is placement[1:]; an external client that landed on a
+					// non-primary member still replicates to the rest of the set (issue #647).
+					targets := make([]int, 0, len(placement)-1)
+					for _, n := range placement {
+						if n.ID != serverId {
+							targets = append(targets, n.ID)
+						}
+					}
+					wg.Add(len(targets))
 					if canDedup {
 						// ⚡ Bolt: Deduplication hit. Just update metadata mapping.
 						if err := store.Put(storageKey, metadata.Hash, metadata.Size, remotePath, nil); err != nil {
 							log.Printf("AUDIT: Error updating metadata for %s from %s: %v", fileName, remoteAddr, common.SanitizeLog(err.Error()))
-							for i := 0; i < len(placement)-1; i++ {
+							for range targets {
 								wg.Done()
 							}
 							metricsCollector.IncErrors()
@@ -622,7 +635,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 					} else {
 						if err := getFile(comm, store, storageKey, metadata.Hash, metadata.Size, remotePath); err != nil {
 							log.Printf("AUDIT: Error getting file from %s: %v", remoteAddr, common.SanitizeLog(err.Error()))
-							for i := 0; i < len(placement)-1; i++ {
+							for range targets {
 								wg.Done()
 							}
 							metricsCollector.IncErrors()
@@ -630,8 +643,7 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 						}
 						persistS3Meta(store, storageKey, metadata)
 					}
-					for i := 1; i < len(placement); i++ {
-						targetId := placement[i].ID
+					for _, targetId := range targets {
 						go func(id int) {
 							defer wg.Done()
 							defer func() {


### PR DESCRIPTION
Resolves #647

## Problem
`ClusterMap.Placement` converted the sha256 digest to a score with `float64(uint64) / math.MaxUint64`. float64 has only a 52-bit mantissa; a full uint64 conversion rounds away the low ~11 bits, so distinct hashes could map to the same float, biasing placement.

## Fix
Fold the full 32-byte digest into a 52-bit mantissa instead of a full uint64: take the top 32 bits (`sum[:4]`, little-endian) shifted 20 bits, OR the bottom 20 bits of the tail (`sum[28:32]`). Every mantissa bit is now meaningful and the whole digest contributes — no precision loss, uniform score in `[0,1)`.

Refactored into `hashToScoreValue([]byte) float64` (package-private) so the fold is unit-testable with crafted digests.

## Changelog
- `src/common/crush.go`: add `hashToScoreValue` (52-bit mantissa fold, fix #647); `Placement` calls it instead of the uint64 conversion.
- `src/common/crush_test.go`: new `TestHashToScoreValue_Precision` — asserts digests differing in a single low tail bit now score distinctly, high-bit digest scores exactly 0.5 (1<<51 exactly representable), results deterministic and in `[0,1)`.
- `docs/PERFORMANCE.md`, `.github/data/benchmark_history.csv`: regenerated by pre-commit hook.

## Verification
- `go build ./...` ✅
- `go test ./...` ✅
- `go vet ./src/common/` ✅
- `gofmt -l` clean ✅
- `go work vendor` produces no diff (Rule 25) ✅
- Master CI all-green before branching (Rule 71)