### PR TITLE
fix: validate storage backend at config load time (#649)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3773,3 +3773,14 @@ c169bb54,BenchmarkLoadGlobalConfig-8,8344.00,1848.00,54.00
 c169bb54,BenchmarkPadString-8,40.99,64.00,1.00
 c169bb54,BenchmarkSanitizeLog/Safe-8,229.30,0.00,0.00
 c169bb54,BenchmarkSanitizeLog/Unsafe-8,678.40,704.00,1.00
+ecfc1d30,BenchmarkAWSChunkedReaderSigned-8,408990.00,162.74,11273.00
+ecfc1d30,BenchmarkAWSChunkedReaderUnsigned-8,401783.00,165.66,78563.00
+ecfc1d30,BenchmarkCheckMetricsAndSwap-8,8.00,0.00,0.00
+ecfc1d30,BenchmarkCrushOptimized-8,303.80,0.00,0.00
+ecfc1d30,BenchmarkCrushOriginal-8,406.60,164.00,3.00
+ecfc1d30,BenchmarkIndexDirectTracking-8,0.33,0.00,0.00
+ecfc1d30,BenchmarkIndexSearch-8,1.52,0.00,0.00
+ecfc1d30,BenchmarkLoadGlobalConfig-8,7742.00,1848.00,54.00
+ecfc1d30,BenchmarkPadString-8,39.51,64.00,1.00
+ecfc1d30,BenchmarkSanitizeLog/Safe-8,396.20,0.00,0.00
+ecfc1d30,BenchmarkSanitizeLog/Unsafe-8,513.70,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             445.0n ± ∞ ¹    416.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            316.2n ± ∞ ¹    337.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.771µ ± ∞ ¹    8.344µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 45.41n ± ∞ ¹    40.99n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          504.1n ± ∞ ¹    229.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        500.7n ± ∞ ¹    678.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    441.3µ ± ∞ ¹    421.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  409.3µ ± ∞ ¹    434.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.640n ± ∞ ¹    8.347n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.500n ± ∞ ¹    1.517n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3354n ± ∞ ¹   0.3337n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     350.5n          334.2n        -4.67%
+CrushOriginal-8                             416.7n ± ∞ ¹    406.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            337.9n ± ∞ ¹    303.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.344µ ± ∞ ¹    7.742µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 40.99n ± ∞ ¹    39.51n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          229.3n ± ∞ ¹    396.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        678.4n ± ∞ ¹    513.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    421.8µ ± ∞ ¹    409.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  434.5µ ± ∞ ¹    401.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.347n ± ∞ ¹    8.002n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.517n ± ∞ ¹    1.520n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3337n ± ∞ ¹   0.3326n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     334.2n          330.3n        -1.14%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -67,7 +67,7 @@ AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.01%               ⁴
+geomean                                                ⁴                  -0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   143.8Mi ± ∞ ¹   150.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 155.1Mi ± ∞ ¹   146.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    149.4Mi         148.3Mi        -0.73%
+AWSChunkedReaderSigned-8                   150.5Mi ± ∞ ¹   155.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 146.1Mi ± ∞ ¹   158.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    148.3Mi         156.6Mi        +5.61%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 421825.00 ns/op | 157.79 B/op | 11276.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 434524.00 ns/op | 153.18 B/op | 78564.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.35 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 337.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 416.70 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 408990.00 ns/op | 162.74 B/op | 11273.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 401783.00 ns/op | 165.66 B/op | 78563.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 303.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 406.60 ns/op | 164.00 B/op | 3.00 allocs/op |
 | BenchmarkIndexDirectTracking-8 | 0.33 ns/op | 0.00 B/op | 0.00 allocs/op |
 | BenchmarkIndexSearch-8 | 1.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8344.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 40.99 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 229.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 678.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7742.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 39.51 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 396.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 513.70 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5]
-    line "AWSChunkedReaderSigned" [484836,409335,415353,429495,443463,504383,449225,417284,441285,421825]
-    line "AWSChunkedReaderUnsigned" [465971,400921,427097,416046,416589,490906,412879,408069,409317,434524]
-    line "CheckMetricsAndSwap" [10,7,8,8,7,8,8,8,8,8]
-    line "CrushOptimized" [427,297,293,318,318,375,304,305,316,338]
-    line "CrushOriginal" [459,396,411,411,409,471,434,425,445,417]
+    x-axis [da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3]
+    line "AWSChunkedReaderSigned" [409335,415353,429495,443463,504383,449225,417284,441285,421825,408990]
+    line "AWSChunkedReaderUnsigned" [400921,427097,416046,416589,490906,412879,408069,409317,434524,401783]
+    line "CheckMetricsAndSwap" [7,8,8,7,8,8,8,8,8,8]
+    line "CrushOptimized" [297,293,318,318,375,304,305,316,338,304]
+    line "CrushOriginal" [396,411,411,409,471,434,425,445,417,407]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [9473,7743,7862,8049,8138,9117,7890,8368,8771,8344]
-    line "PadString" [46,38,38,39,39,49,39,40,45,41]
+    line "LoadGlobalConfig" [7743,7862,8049,8138,9117,7890,8368,8771,8344,7742]
+    line "PadString" [38,38,39,39,49,39,40,45,41,40]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [421,213,231,213,222,430,390,419,504,229]
-    line "SanitizeLog/Unsafe" [628,658,674,673,658,601,504,506,501,678]
+    line "SanitizeLog/Safe" [213,231,213,222,430,390,419,504,229,396]
+    line "SanitizeLog/Unsafe" [658,674,673,658,601,504,506,501,678,514]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5]
-    line "AWSChunkedReaderSigned" [137,163,160,155,150,132,148,160,151,158]
-    line "AWSChunkedReaderUnsigned" [143,166,156,160,160,136,161,163,163,153]
+    x-axis [da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3]
+    line "AWSChunkedReaderSigned" [163,160,155,150,132,148,160,151,158,163]
+    line "AWSChunkedReaderUnsigned" [166,156,160,160,136,161,163,163,153,166]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7fdac82,da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5]
-    line "AWSChunkedReaderSigned" [11292,11270,11274,11274,11275,11292,11274,11284,11270,11276]
-    line "AWSChunkedReaderUnsigned" [78560,78555,78563,78570,78558,78578,78566,78561,78559,78564]
+    x-axis [da1029b,8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3]
+    line "AWSChunkedReaderSigned" [11270,11274,11274,11275,11292,11274,11284,11270,11276,11273]
+    line "AWSChunkedReaderUnsigned" [78555,78563,78570,78558,78578,78566,78561,78559,78564,78563]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -27,6 +27,16 @@ const (
 	prefixDaemon = "daemon."
 )
 
+// Storage backend identifiers accepted by the [storage] section.
+// These are shared with the blob-store factory (storage/factory.go) so the
+// config-time validation and the runtime switch can never drift (issue #649).
+const (
+	BackendLocal = "local"
+	BackendNFS   = "nfs"
+	BackendS3    = "s3"
+	BackendRaw   = "raw"
+)
+
 // defaultClientSideReplicationModes is the default when client_side_replication_modes
 // is not specified in config. Defined at package level to avoid per-call allocation.
 var defaultClientSideReplicationModes = []int{ReplicationPrimarySplay}
@@ -500,7 +510,7 @@ func loadP2PConfig(section *ini.Section) (ConfigurationP2P, error) {
 // defaultStorageConfig returns the default storage configuration.
 func defaultStorageConfig() ConfigurationStorage {
 	return ConfigurationStorage{
-		Backend:            "local",
+		Backend:            BackendLocal,
 		GCInterval:         300,
 		TombstoneRetention: 86400,
 	}
@@ -513,7 +523,14 @@ func loadStorageConfig(section *ini.Section) (ConfigurationStorage, error) {
 
 	cfg.Backend = section.Key("backend").String()
 	if cfg.Backend == "" {
-		cfg.Backend = "local"
+		cfg.Backend = BackendLocal
+	}
+	// 🛡️ Validate the backend eagerly so an invalid value (e.g. "foobar") fails
+	// at config load time instead of surfacing as a runtime error later (issue #649).
+	switch cfg.Backend {
+	case BackendLocal, BackendNFS, BackendS3, BackendRaw:
+	default:
+		return ConfigurationStorage{}, fmt.Errorf("unsupported storage backend %q (valid: %s, %s, %s, %s): %w", cfg.Backend, BackendLocal, BackendNFS, BackendS3, BackendRaw, syscall.EINVAL)
 	}
 
 	cfg.GCInterval, err = section.Key("gc_interval").Int()

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -130,6 +130,11 @@ func TestGetConfig_Failures(t *testing.T) {
 			content:       strings.Replace(validConfig, "fallback_interval = 30", "fallback_interval = -5", 1),
 			expectedError: "failed to load [metrics] section: 'fallback_interval' must be positive",
 		},
+		{
+			name:          "Unsupported storage backend",
+			content:       validConfig + "\n[storage]\nbackend = foobar\n",
+			expectedError: "failed to load [storage] section: unsupported storage backend",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -150,6 +155,44 @@ func TestGetConfig_Failures(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetConfig_StorageBackends_Valid ensures every supported storage backend is
+// accepted at config load time and that the default (missing [storage] section)
+// falls back to "local" (issue #649).
+func TestGetConfig_StorageBackends_Valid(t *testing.T) {
+	for _, backend := range []string{BackendLocal, BackendNFS, BackendS3, BackendRaw} {
+		t.Run(backend, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpfile := filepath.Join(tmpDir, "momo.conf")
+			content := validConfig + "\n[storage]\nbackend = " + backend + "\n"
+			if err := os.WriteFile(tmpfile, []byte(content), 0666); err != nil {
+				t.Fatalf("Failed to write to temporary config file: %v", err)
+			}
+			config, err := GetConfig(tmpfile)
+			if err != nil {
+				t.Fatalf("GetConfig failed for backend %q: %v", backend, err)
+			}
+			if config.Storage.Backend != backend {
+				t.Errorf("Expected Storage.Backend to be %q, got %q", backend, config.Storage.Backend)
+			}
+		})
+	}
+
+	t.Run("default local", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpfile := filepath.Join(tmpDir, "momo.conf")
+		if err := os.WriteFile(tmpfile, []byte(validConfig), 0666); err != nil {
+			t.Fatalf("Failed to write to temporary config file: %v", err)
+		}
+		config, err := GetConfig(tmpfile)
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+		if config.Storage.Backend != BackendLocal {
+			t.Errorf("Expected default Storage.Backend to be %q, got %q", BackendLocal, config.Storage.Backend)
+		}
+	})
 }
 
 // TestLoadDaemons_MissingFieldsDeterministic ensures that when multiple required

--- a/src/storage/factory.go
+++ b/src/storage/factory.go
@@ -24,11 +24,11 @@ func NewStore(cfg common.ConfigurationStorage, daemon *common.Daemon, encKeyHex 
 	var err error
 
 	switch cfg.Backend {
-	case "", "local", "nfs":
+	case "", common.BackendLocal, common.BackendNFS:
 		blobs, err = NewLocalBlobStore(daemon.Data)
-	case "s3":
+	case common.BackendS3:
 		blobs, err = NewS3BlobStore(cfg)
-	case "raw":
+	case common.BackendRaw:
 		blobs, err = NewRawBlobStore(cfg, daemon)
 	default:
 		return nil, fmt.Errorf("unsupported storage backend %q: %w", cfg.Backend, syscall.EINVAL)


### PR DESCRIPTION
## Summary

Validate the `[storage]` `backend` value at config load time instead of surfacing
an invalid value (e.g. `foobar`) as a runtime error later.

### Problem
`loadStorageConfig` (`src/common/config.go:510`) accepted any string for `backend`;
the doc claims valid values are `local`, `nfs`, `s3`, `raw`, but an unknown value
only failed much later inside `storage.NewStore`.

### Fix
- Added `common.BackendLocal/NFS/S3/Raw` constants (shared source of truth).
- `loadStorageConfig` now rejects unknown backends eagerly:
  `unsupported storage backend "foobar" (valid: local, nfs, s3, raw): EINVAL`.
- `storage/factory.go` switch now uses the same constants so the config-time
  allowlist and the runtime switch can never drift.

### Caller impact
Empty/missing `backend` still defaults to `local`. All four valid backends load
unchanged. Runtime `NewStore` behavior untouched (same strings, same switch).

### Testing
- `TestGetConfig_Failures` + case: `backend = foobar` → error contains
  `failed to load [storage] section: unsupported storage backend`.
- New `TestGetConfig_StorageBackends_Valid`: `local`/`nfs`/`s3`/`raw` all accepted;
  missing `[storage]` defaults to `local`.
- `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work vendor` (Rule 25) clean.

Resolves #649