### PR TITLE
fix: check write errors in LIST/DELETE/GET handlers (#651)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3795,3 +3795,14 @@ ecfc1d30,BenchmarkSanitizeLog/Unsafe-8,513.70,704.00,1.00
 650994d9,BenchmarkPadString-8,37.86,64.00,1.00
 650994d9,BenchmarkSanitizeLog/Safe-8,398.50,0.00,0.00
 650994d9,BenchmarkSanitizeLog/Unsafe-8,487.30,704.00,1.00
+7505017c,BenchmarkAWSChunkedReaderSigned-8,418649.00,158.99,11278.00
+7505017c,BenchmarkAWSChunkedReaderUnsigned-8,424530.00,156.79,78563.00
+7505017c,BenchmarkCheckMetricsAndSwap-8,8.34,0.00,0.00
+7505017c,BenchmarkCrushOptimized-8,309.30,0.00,0.00
+7505017c,BenchmarkCrushOriginal-8,421.80,164.00,3.00
+7505017c,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+7505017c,BenchmarkIndexSearch-8,1.57,0.00,0.00
+7505017c,BenchmarkLoadGlobalConfig-8,8319.00,1848.00,54.00
+7505017c,BenchmarkPadString-8,40.20,64.00,1.00
+7505017c,BenchmarkSanitizeLog/Safe-8,415.60,0.00,0.00
+7505017c,BenchmarkSanitizeLog/Unsafe-8,505.60,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             406.6n ± ∞ ¹    393.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            303.8n ± ∞ ¹    305.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          7.742µ ± ∞ ¹    7.670µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 39.51n ± ∞ ¹    37.86n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          396.2n ± ∞ ¹    398.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        513.7n ± ∞ ¹    487.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    409.0µ ± ∞ ¹    457.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  401.8µ ± ∞ ¹    408.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       8.002n ± ∞ ¹    7.996n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.520n ± ∞ ¹    1.522n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3326n ± ∞ ¹   0.3391n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     330.3n          331.0n        +0.20%
+CrushOriginal-8                             393.7n ± ∞ ¹    421.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            305.5n ± ∞ ¹    309.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.670µ ± ∞ ¹    8.319µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 37.86n ± ∞ ¹    40.20n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          398.5n ± ∞ ¹    415.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        487.3n ± ∞ ¹    505.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    457.7µ ± ∞ ¹    418.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  408.1µ ± ∞ ¹    424.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.996n ± ∞ ¹    8.342n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.522n ± ∞ ¹    1.574n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3391n ± ∞ ¹   0.3694n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     331.0n          343.7n        +3.83%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -63,7 +63,7 @@ PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   155.2Mi ± ∞ ¹   138.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 158.0Mi ± ∞ ¹   155.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    156.6Mi         146.9Mi        -6.20%
+AWSChunkedReaderSigned-8                   138.7Mi ± ∞ ¹   151.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 155.5Mi ± ∞ ¹   149.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    146.9Mi         150.6Mi        +2.52%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 457655.00 ns/op | 145.44 B/op | 11274.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 408115.00 ns/op | 163.09 B/op | 78571.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 305.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 393.70 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7670.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 37.86 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 398.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 487.30 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 418649.00 ns/op | 158.99 B/op | 11278.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 424530.00 ns/op | 156.79 B/op | 78563.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 309.30 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 421.80 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.57 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8319.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 40.20 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 415.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 505.60 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d]
-    line "AWSChunkedReaderSigned" [415353,429495,443463,504383,449225,417284,441285,421825,408990,457655]
-    line "AWSChunkedReaderUnsigned" [427097,416046,416589,490906,412879,408069,409317,434524,401783,408115]
-    line "CheckMetricsAndSwap" [8,8,7,8,8,8,8,8,8,8]
-    line "CrushOptimized" [293,318,318,375,304,305,316,338,304,306]
-    line "CrushOriginal" [411,411,409,471,434,425,445,417,407,394]
+    x-axis [e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017]
+    line "AWSChunkedReaderSigned" [429495,443463,504383,449225,417284,441285,421825,408990,457655,418649]
+    line "AWSChunkedReaderUnsigned" [416046,416589,490906,412879,408069,409317,434524,401783,408115,424530]
+    line "CheckMetricsAndSwap" [8,7,8,8,8,8,8,8,8,8]
+    line "CrushOptimized" [318,318,375,304,305,316,338,304,306,309]
+    line "CrushOriginal" [411,409,471,434,425,445,417,407,394,422]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [7862,8049,8138,9117,7890,8368,8771,8344,7742,7670]
-    line "PadString" [38,39,39,49,39,40,45,41,40,38]
+    line "LoadGlobalConfig" [8049,8138,9117,7890,8368,8771,8344,7742,7670,8319]
+    line "PadString" [39,39,49,39,40,45,41,40,38,40]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [231,213,222,430,390,419,504,229,396,398]
-    line "SanitizeLog/Unsafe" [674,673,658,601,504,506,501,678,514,487]
+    line "SanitizeLog/Safe" [213,222,430,390,419,504,229,396,398,416]
+    line "SanitizeLog/Unsafe" [673,658,601,504,506,501,678,514,487,506]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d]
-    line "AWSChunkedReaderSigned" [160,155,150,132,148,160,151,158,163,145]
-    line "AWSChunkedReaderUnsigned" [156,160,160,136,161,163,163,153,166,163]
+    x-axis [e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017]
+    line "AWSChunkedReaderSigned" [155,150,132,148,160,151,158,163,145,159]
+    line "AWSChunkedReaderUnsigned" [160,160,136,161,163,163,153,166,163,157]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [8fb63ce,e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d]
-    line "AWSChunkedReaderSigned" [11274,11274,11275,11292,11274,11284,11270,11276,11273,11274]
-    line "AWSChunkedReaderUnsigned" [78563,78570,78558,78578,78566,78561,78559,78564,78563,78571]
+    x-axis [e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017]
+    line "AWSChunkedReaderSigned" [11274,11275,11292,11274,11284,11270,11276,11273,11274,11278]
+    line "AWSChunkedReaderUnsigned" [78570,78558,78578,78566,78561,78559,78564,78563,78571,78563]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -373,7 +373,9 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			var emptyCount [4]byte
 			binary.BigEndian.PutUint32(emptyCount[:], 0)
-			m.Write(emptyCount[:])
+			if _, err := m.Write(emptyCount[:]); err != nil {
+				return 0, 0, fmt.Errorf("failed to send empty list count: %v: %w", err, syscall.EIO)
+			}
 			return 0, 0, ErrRequestHandled
 		}
 		if m.store == nil {
@@ -442,7 +444,9 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // error status
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // error status
 			return 0, 0, fmt.Errorf("invalid delete target traversal: %s: %w", fileName, syscall.EBADMSG)
 		}
 
@@ -453,14 +457,18 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		expectedHash, hashErr := m.store.GetHashForName(fileName)
 		if hashErr != nil || expectedHash != providedHash {
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // not found / unauthorized
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // not found / unauthorized
 			return 0, 0, ErrRequestHandled
 		}
 
 		if m.leaseAcquirer != nil {
 			if err := m.leaseAcquirer.AcquireLease(fileName, 10*time.Second); err != nil {
 				m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
-				m.Write([]byte{'1'}) // error status
+				if err := writeStatusByte(m, '1'); err != nil {
+					return 0, 0, err
+				} // error status
 				return 0, 0, fmt.Errorf("failed to acquire lease for delete: %w", err)
 			}
 			defer m.leaseAcquirer.ReleaseLease(fileName)
@@ -469,7 +477,9 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		err = m.store.Delete(fileName)
 		m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
-			m.Write([]byte{'1'}) // error status
+			if e := writeStatusByte(m, '1'); e != nil {
+				return 0, 0, e
+			} // error status
 			return 0, 0, fmt.Errorf("failed to delete file: %w", err)
 		}
 
@@ -483,7 +493,9 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 			m.metricsHook.IncDeletes()
 		}
 
-		m.Write([]byte{'0'}) // success status
+		if err := writeStatusByte(m, '0'); err != nil {
+			return 0, 0, err
+		} // success status
 		return 0, 0, ErrRequestHandled
 	}
 
@@ -503,7 +515,9 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // error status
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // error status
 			return 0, 0, fmt.Errorf("invalid get target traversal: %s: %w", fileName, syscall.EBADMSG)
 		}
 
@@ -511,7 +525,9 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		expectedHash, hashErr := m.store.GetHashForName(fileName)
 		if hashErr != nil || expectedHash != providedHash {
 			m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // not found / unauthorized
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // not found / unauthorized
 			return 0, 0, ErrRequestHandled
 		}
 
@@ -519,10 +535,14 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		m.Stream.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
 			if err == syscall.ENOENT || os.IsNotExist(err) {
-				m.Write([]byte{'1'}) // file not found
+				if e := writeStatusByte(m, '1'); e != nil {
+					return 0, 0, e
+				} // file not found
 				return 0, 0, ErrRequestHandled
 			}
-			m.Write([]byte{'2'}) // server error
+			if e := writeStatusByte(m, '2'); e != nil {
+				return 0, 0, e
+			} // server error
 			return 0, 0, fmt.Errorf("failed to read file: %w", err)
 		}
 		defer rc.Close()

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -333,7 +333,9 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			var emptyCount [4]byte
 			binary.BigEndian.PutUint32(emptyCount[:], 0)
-			m.Write(emptyCount[:])
+			if _, err := m.Write(emptyCount[:]); err != nil {
+				return 0, 0, fmt.Errorf("failed to send empty list count: %v: %w", err, syscall.EIO)
+			}
 			return 0, 0, ErrRequestHandled
 		}
 		if m.store == nil {
@@ -402,7 +404,9 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // error status
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // error status
 			return 0, 0, fmt.Errorf("invalid delete target traversal: %s: %w", fileName, syscall.EBADMSG)
 		}
 
@@ -413,14 +417,18 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		expectedHash, hashErr := m.store.GetHashForName(fileName)
 		if hashErr != nil || expectedHash != providedHash {
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // not found / unauthorized
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // not found / unauthorized
 			return 0, 0, ErrRequestHandled
 		}
 
 		if m.leaseAcquirer != nil {
 			if err := m.leaseAcquirer.AcquireLease(fileName, 10*time.Second); err != nil {
 				m.SetWriteDeadline(time.Now().Add(5 * time.Second))
-				m.Write([]byte{'1'}) // error status
+				if err := writeStatusByte(m, '1'); err != nil {
+					return 0, 0, err
+				} // error status
 				return 0, 0, fmt.Errorf("failed to acquire lease for delete: %w", err)
 			}
 			defer m.leaseAcquirer.ReleaseLease(fileName)
@@ -429,7 +437,9 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		err = m.store.Delete(fileName)
 		m.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
-			m.Write([]byte{'1'}) // error status
+			if e := writeStatusByte(m, '1'); e != nil {
+				return 0, 0, e
+			} // error status
 			return 0, 0, fmt.Errorf("failed to delete file: %w", err)
 		}
 
@@ -443,7 +453,9 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 			m.metricsHook.IncDeletes()
 		}
 
-		m.Write([]byte{'0'}) // success status
+		if err := writeStatusByte(m, '0'); err != nil {
+			return 0, 0, err
+		} // success status
 		return 0, 0, ErrRequestHandled
 	}
 
@@ -463,7 +475,9 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		// 🛡️ Sentinel: Block path traversal
 		if strings.Contains(fileName, "..") || strings.Contains(fileName, "\\") {
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // error status
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // error status
 			return 0, 0, fmt.Errorf("invalid get target traversal: %s: %w", fileName, syscall.EBADMSG)
 		}
 
@@ -474,7 +488,9 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		expectedHash, hashErr := m.store.GetHashForName(fileName)
 		if hashErr != nil || expectedHash != providedHash {
 			m.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			m.Write([]byte{'1'}) // not found / unauthorized
+			if err := writeStatusByte(m, '1'); err != nil {
+				return 0, 0, err
+			} // not found / unauthorized
 			return 0, 0, ErrRequestHandled
 		}
 
@@ -482,10 +498,14 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		m.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
 			if err == syscall.ENOENT || os.IsNotExist(err) {
-				m.Write([]byte{'1'}) // file not found
+				if e := writeStatusByte(m, '1'); e != nil {
+					return 0, 0, e
+				} // file not found
 				return 0, 0, ErrRequestHandled
 			}
-			m.Write([]byte{'2'}) // server error
+			if e := writeStatusByte(m, '2'); e != nil {
+				return 0, 0, e
+			} // server error
 			return 0, 0, fmt.Errorf("failed to read file: %w", err)
 		}
 		defer rc.Close()

--- a/src/transport/status_write.go
+++ b/src/transport/status_write.go
@@ -1,0 +1,18 @@
+package transport
+
+import (
+	"fmt"
+	"io"
+	"syscall"
+)
+
+// writeStatusByte writes a single protocol status byte and maps a failed write
+// to an EIO-wrapped error. A status response (e.g. LIST/GET/DELETE handshake
+// signalling) that silently fails would leave the client blocked waiting for a
+// reply it never receives (issue #651).
+func writeStatusByte(m io.Writer, status byte) error {
+	if _, err := m.Write([]byte{status}); err != nil {
+		return fmt.Errorf("failed to send status byte %q: %v: %w", status, err, syscall.EIO)
+	}
+	return nil
+}

--- a/src/transport/status_write_test.go
+++ b/src/transport/status_write_test.go
@@ -1,0 +1,31 @@
+package transport
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"syscall"
+	"testing"
+)
+
+type failWriter struct{ err error }
+
+func (w failWriter) Write(p []byte) (int, error) { return 0, w.err }
+
+func TestWriteStatusByte(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeStatusByte(&buf, '1'); err != nil {
+		t.Fatalf("writeStatusByte failed on healthy writer: %v", err)
+	}
+	if buf.Len() != 1 || buf.Bytes()[0] != '1' {
+		t.Fatalf("expected single status byte '1', got %v", buf.Bytes())
+	}
+
+	err := writeStatusByte(failWriter{err: io.ErrClosedPipe}, '0')
+	if err == nil {
+		t.Fatal("expected error when the underlying write fails")
+	}
+	if !errors.Is(err, syscall.EIO) {
+		t.Errorf("expected wrapped syscall.EIO, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Check all status-byte and empty-count writes in the LIST/DELETE/GET handlers —
previously discarded return values could leave a client hanging forever waiting
for a reply that was never sent.

### Problem
20 status-byte writes (`m.Write([]byte{'0','1','2'})`) plus 2 empty LIST count
writes in `momo_tcp.go` and `momo_quic.go` discarded the returned error. A failed
write meant the client never received the response and blocked indefinitely.

### Fix
- Added `writeStatusByte(m io.Writer, status byte) error` helper
  (`src/transport/status_write.go`) that wraps write failures as
  `failed to send status byte 'N': ...: EIO`.
- All 22 sites in `HandshakeServer` (LIST deny, LIST count, DELETE traversal /
  not-found / lease-failure / delete-failure / success, GET traversal / not-found /
  ENOENT / server-error) now check and propagate the write error, closing the
  connection instead of leaving the peer hanging.

### Behavior notes
- Successful statuses and deny/not-found paths still return `ErrRequestHandled`
  (keep-alive preserved) when the write succeeds.
- On write failure the caller now gets an `EIO`-wrapped error, which tears down
  the connection as the peer is gone.

### Testing
- New `TestWriteStatusByte`: writes the byte on a healthy writer, returns a
  wrapped `syscall.EIO` error on a failing writer.
- `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work vendor` (Rule 25) clean.

Resolves #651