### PR TITLE
fix: make LimitedConnReader thread-safe with mutex (#652)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3806,3 +3806,14 @@ ecfc1d30,BenchmarkSanitizeLog/Unsafe-8,513.70,704.00,1.00
 7505017c,BenchmarkPadString-8,40.20,64.00,1.00
 7505017c,BenchmarkSanitizeLog/Safe-8,415.60,0.00,0.00
 7505017c,BenchmarkSanitizeLog/Unsafe-8,505.60,704.00,1.00
+dd91ed68,BenchmarkAWSChunkedReaderSigned-8,415373.00,160.24,11271.00
+dd91ed68,BenchmarkAWSChunkedReaderUnsigned-8,406436.00,163.76,78564.00
+dd91ed68,BenchmarkCheckMetricsAndSwap-8,7.34,0.00,0.00
+dd91ed68,BenchmarkCrushOptimized-8,294.10,0.00,0.00
+dd91ed68,BenchmarkCrushOriginal-8,407.00,164.00,3.00
+dd91ed68,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+dd91ed68,BenchmarkIndexSearch-8,1.59,0.00,0.00
+dd91ed68,BenchmarkLoadGlobalConfig-8,7911.00,1848.00,54.00
+dd91ed68,BenchmarkPadString-8,38.66,64.00,1.00
+dd91ed68,BenchmarkSanitizeLog/Safe-8,400.70,0.00,0.00
+dd91ed68,BenchmarkSanitizeLog/Unsafe-8,540.60,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             393.7n ± ∞ ¹    421.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            305.5n ± ∞ ¹    309.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          7.670µ ± ∞ ¹    8.319µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 37.86n ± ∞ ¹    40.20n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          398.5n ± ∞ ¹    415.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        487.3n ± ∞ ¹    505.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    457.7µ ± ∞ ¹    418.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  408.1µ ± ∞ ¹    424.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.996n ± ∞ ¹    8.342n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.522n ± ∞ ¹    1.574n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3391n ± ∞ ¹   0.3694n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     331.0n          343.7n        +3.83%
+CrushOriginal-8                             421.8n ± ∞ ¹    407.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            309.3n ± ∞ ¹    294.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.319µ ± ∞ ¹    7.911µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 40.20n ± ∞ ¹    38.66n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          415.6n ± ∞ ¹    400.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        505.6n ± ∞ ¹    540.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    418.6µ ± ∞ ¹    415.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  424.5µ ± ∞ ¹    406.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.342n ± ∞ ¹    7.339n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.574n ± ∞ ¹    1.591n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3694n ± ∞ ¹   0.3464n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     343.7n          332.1n        -3.38%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -63,11 +63,11 @@ PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.00%               ⁴
+geomean                                                ⁴                  -0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   138.7Mi ± ∞ ¹   151.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 155.5Mi ± ∞ ¹   149.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    146.9Mi         150.6Mi        +2.52%
+AWSChunkedReaderSigned-8                   151.6Mi ± ∞ ¹   152.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 149.5Mi ± ∞ ¹   156.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    150.6Mi         154.5Mi        +2.60%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 418649.00 ns/op | 158.99 B/op | 11278.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 424530.00 ns/op | 156.79 B/op | 78563.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 309.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 421.80 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.57 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8319.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 40.20 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 415.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 505.60 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 415373.00 ns/op | 160.24 B/op | 11271.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 406436.00 ns/op | 163.76 B/op | 78564.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.34 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 294.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 407.00 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.59 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7911.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 38.66 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 400.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 540.60 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017]
-    line "AWSChunkedReaderSigned" [429495,443463,504383,449225,417284,441285,421825,408990,457655,418649]
-    line "AWSChunkedReaderUnsigned" [416046,416589,490906,412879,408069,409317,434524,401783,408115,424530]
-    line "CheckMetricsAndSwap" [8,7,8,8,8,8,8,8,8,8]
-    line "CrushOptimized" [318,318,375,304,305,316,338,304,306,309]
-    line "CrushOriginal" [411,409,471,434,425,445,417,407,394,422]
+    x-axis [9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6]
+    line "AWSChunkedReaderSigned" [443463,504383,449225,417284,441285,421825,408990,457655,418649,415373]
+    line "AWSChunkedReaderUnsigned" [416589,490906,412879,408069,409317,434524,401783,408115,424530,406436]
+    line "CheckMetricsAndSwap" [7,8,8,8,8,8,8,8,8,7]
+    line "CrushOptimized" [318,375,304,305,316,338,304,306,309,294]
+    line "CrushOriginal" [409,471,434,425,445,417,407,394,422,407]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [2,2,2,2,2,2,2,2,2,2]
-    line "LoadGlobalConfig" [8049,8138,9117,7890,8368,8771,8344,7742,7670,8319]
-    line "PadString" [39,39,49,39,40,45,41,40,38,40]
+    line "LoadGlobalConfig" [8138,9117,7890,8368,8771,8344,7742,7670,8319,7911]
+    line "PadString" [39,49,39,40,45,41,40,38,40,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [213,222,430,390,419,504,229,396,398,416]
-    line "SanitizeLog/Unsafe" [673,658,601,504,506,501,678,514,487,506]
+    line "SanitizeLog/Safe" [222,430,390,419,504,229,396,398,416,401]
+    line "SanitizeLog/Unsafe" [658,601,504,506,501,678,514,487,506,541]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017]
-    line "AWSChunkedReaderSigned" [155,150,132,148,160,151,158,163,145,159]
-    line "AWSChunkedReaderUnsigned" [160,160,136,161,163,163,153,166,163,157]
+    x-axis [9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6]
+    line "AWSChunkedReaderSigned" [150,132,148,160,151,158,163,145,159,160]
+    line "AWSChunkedReaderUnsigned" [160,136,161,163,163,153,166,163,157,164]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [e00e9d0,9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017]
-    line "AWSChunkedReaderSigned" [11274,11275,11292,11274,11284,11270,11276,11273,11274,11278]
-    line "AWSChunkedReaderUnsigned" [78570,78558,78578,78566,78561,78559,78564,78563,78571,78563]
+    x-axis [9e617f5,db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6]
+    line "AWSChunkedReaderSigned" [11275,11292,11274,11284,11270,11276,11273,11274,11278,11271]
+    line "AWSChunkedReaderUnsigned" [78558,78578,78566,78561,78559,78564,78563,78571,78563,78564]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -36,32 +36,48 @@ import (
 // one byte at a time to keep the connection alive indefinitely (issue #592).
 var s3ReadHeaderTimeout = 10 * time.Second
 
+// LimitedConnReader wraps a net.Conn with an optional read limit used to
+// enforce a bounded read window (e.g. while parsing an HTTP request header,
+// Rule 24). All mutating methods are synchronized so the limiter can be driven
+// from a different goroutine than the reader without racing (issue #652).
 type LimitedConnReader struct {
+	mu    sync.Mutex
 	r     net.Conn
 	limit int64
 	read  int64
 }
 
 func (l *LimitedConnReader) Read(p []byte) (n int, err error) {
+	l.mu.Lock()
 	if l.limit > 0 && l.read >= l.limit {
+		l.mu.Unlock()
 		return 0, fmt.Errorf("read limit exceeded: %w", syscall.ENOBUFS)
 	}
 	if l.limit > 0 && int64(len(p)) > (l.limit-l.read) {
 		p = p[:l.limit-l.read]
 	}
+	l.mu.Unlock()
+	// Perform the blocking net read outside the lock so a stalled peer cannot
+	// starve a concurrent SetLimit/ClearLimit from a limiter goroutine.
 	n, err = l.r.Read(p)
+	l.mu.Lock()
 	l.read += int64(n)
+	l.mu.Unlock()
 	return n, err
 }
 
 func (l *LimitedConnReader) SetLimit(limit int64) {
+	l.mu.Lock()
 	l.limit = limit
 	l.read = 0
+	l.mu.Unlock()
 }
 
 func (l *LimitedConnReader) ClearLimit() {
+	l.mu.Lock()
 	l.limit = 0
 	l.read = 0
+	l.mu.Unlock()
 }
 
 type S3Communicator struct {

--- a/src/transport/s3_limited_conn_test.go
+++ b/src/transport/s3_limited_conn_test.go
@@ -1,0 +1,86 @@
+package transport
+
+import (
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+)
+
+// TestLimitedConnReaderConcurrent races SetLimit/ClearLimit against Read from
+// separate goroutines. It must complete without deadlock and pass under
+// -race (issue #652).
+func TestLimitedConnReaderConcurrent(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	lr := &LimitedConnReader{r: server}
+	const total = 200_000
+	go func() {
+		buf := make([]byte, 4096)
+		remain := total
+		for remain > 0 {
+			w := len(buf)
+			if w > remain {
+				w = remain
+			}
+			if _, err := client.Write(buf[:w]); err != nil {
+				return
+			}
+			remain -= w
+		}
+	}()
+
+	stop := make(chan struct{})
+	go func() {
+		defer close(stop)
+		for i := 0; i < 300; i++ {
+			lr.SetLimit(65536)
+			lr.ClearLimit()
+		}
+	}()
+
+	buf := make([]byte, 4096)
+	got := 0
+	for got < total {
+		n, err := lr.Read(buf)
+		got += n
+		if err != nil {
+			t.Fatalf("read failed after %d/%d bytes: %v", got, total, err)
+		}
+	}
+	<-stop
+}
+
+// TestLimitedConnReaderEnforcesLimit verifies the read window is bounded and
+// that an exhausted limit surfaces as ENOBUFS.
+func TestLimitedConnReaderEnforcesLimit(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	lr := &LimitedConnReader{r: server}
+	lr.SetLimit(32)
+	go func() {
+		_, _ = client.Write(make([]byte, 128))
+	}()
+
+	buf := make([]byte, 128)
+	n, err := lr.Read(buf)
+	if err != nil {
+		t.Fatalf("first read failed: %v", err)
+	}
+	if n != 32 {
+		t.Fatalf("expected read limited to 32 bytes, got %d", n)
+	}
+
+	if _, err = lr.Read(buf); !errors.Is(err, syscall.ENOBUFS) {
+		t.Fatalf("expected syscall.ENOBUFS after exhausting limit, got %v", err)
+	}
+
+	lr.ClearLimit()
+	if n, err = lr.Read(buf); err != nil || n == 0 {
+		t.Fatalf("expected reads to resume after ClearLimit, got n=%d err=%v", n, err)
+	}
+}


### PR DESCRIPTION
## Summary

Make `LimitedConnReader` (`src/transport/s3_communicator.go:39`) safe for
concurrent use — previously `SetLimit`, `ClearLimit`, and `Read` mutated
`l.limit`/`l.read` without synchronization (data race if a limiter goroutine
races the reader, e.g. slowloris timeout watchdog vs header read).

### Fix
- Added a `sync.Mutex` to `LimitedConnReader` guarding `limit`/`read`.
- `Read` snapshots the effective read window under the lock, then performs the
  blocking `net.Conn.Read` **outside** the lock so a stalled peer can never
  starve a concurrent `SetLimit`/`ClearLimit`, and accounts bytes under the lock.
- `SetLimit`/`ClearLimit` lock around their writes.
- Documented thread-safety contract on the type.

### Behavior notes
- Single-goroutine callers (current S3 handshake paths) unchanged.
- Limit semantics preserved: bounded read window, `ENOBUFS` once exhausted.

### Testing
- `TestLimitedConnReaderConcurrent` — races a limiter goroutine (`SetLimit` /
  `ClearLimit`) against `Read` over a `net.Pipe`; passes under `-race`.
- `TestLimitedConnReaderEnforcesLimit` — window bounded to requested limit,
  exhausted → `syscall.ENOBUFS`, `ClearLimit` resumes reads.
- `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work vendor` (Rule 25) clean.

Resolves #652