### PR TITLE
fix: clear S3 header read limit immediately after ReadRequest (#653)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3828,3 +3828,14 @@ cd534591,BenchmarkLoadGlobalConfig-8,7590.00,1848.00,54.00
 cd534591,BenchmarkPadString-8,36.48,64.00,1.00
 cd534591,BenchmarkSanitizeLog/Safe-8,395.70,0.00,0.00
 cd534591,BenchmarkSanitizeLog/Unsafe-8,481.70,704.00,1.00
+b8259521,BenchmarkAWSChunkedReaderSigned-8,445617.00,149.37,11282.00
+b8259521,BenchmarkAWSChunkedReaderUnsigned-8,449617.00,148.04,78577.00
+b8259521,BenchmarkCheckMetricsAndSwap-8,8.23,0.00,0.00
+b8259521,BenchmarkCrushOptimized-8,357.90,0.00,0.00
+b8259521,BenchmarkCrushOriginal-8,440.90,164.00,3.00
+b8259521,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+b8259521,BenchmarkIndexSearch-8,1.49,0.00,0.00
+b8259521,BenchmarkLoadGlobalConfig-8,8718.00,1848.00,54.00
+b8259521,BenchmarkPadString-8,44.19,64.00,1.00
+b8259521,BenchmarkSanitizeLog/Safe-8,419.40,0.00,0.00
+b8259521,BenchmarkSanitizeLog/Unsafe-8,602.10,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             407.0n ± ∞ ¹    388.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            294.1n ± ∞ ¹    287.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          7.911µ ± ∞ ¹    7.590µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 38.66n ± ∞ ¹    36.48n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          400.7n ± ∞ ¹    395.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        540.6n ± ∞ ¹    481.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    415.4µ ± ∞ ¹    403.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  406.4µ ± ∞ ¹    393.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.339n ± ∞ ¹    8.023n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.591n ± ∞ ¹    1.469n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3464n ± ∞ ¹   0.3399n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     332.1n          321.1n        -3.29%
+CrushOriginal-8                             399.4n ± ∞ ¹    440.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            315.3n ± ∞ ¹    357.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.670µ ± ∞ ¹    8.718µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 38.56n ± ∞ ¹    44.19n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          437.3n ± ∞ ¹    419.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        501.6n ± ∞ ¹    602.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    433.3µ ± ∞ ¹    445.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  407.6µ ± ∞ ¹    449.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       8.160n ± ∞ ¹    8.229n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.756n ± ∞ ¹    1.491n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3457n ± ∞ ¹   0.3480n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     340.6n          359.9n        +5.69%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.00Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.00%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   152.8Mi ± ∞ ¹   157.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 156.2Mi ± ∞ ¹   161.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    154.5Mi         159.3Mi        +3.14%
+AWSChunkedReaderSigned-8                   146.5Mi ± ∞ ¹   142.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 155.7Mi ± ∞ ¹   141.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    151.0Mi         141.8Mi        -6.11%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 403249.00 ns/op | 165.06 B/op | 11265.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 393596.00 ns/op | 169.11 B/op | 78564.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 8.02 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 287.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 388.60 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7590.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 36.48 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 395.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 481.70 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 445617.00 ns/op | 149.37 B/op | 11282.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 449617.00 ns/op | 148.04 B/op | 78577.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.23 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 357.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 440.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8718.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 44.19 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 419.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 602.10 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459]
-    line "AWSChunkedReaderSigned" [504383,449225,417284,441285,421825,408990,457655,418649,415373,403249]
-    line "AWSChunkedReaderUnsigned" [490906,412879,408069,409317,434524,401783,408115,424530,406436,393596]
-    line "CheckMetricsAndSwap" [8,8,8,8,8,8,8,8,7,8]
-    line "CrushOptimized" [375,304,305,316,338,304,306,309,294,287]
-    line "CrushOriginal" [471,434,425,445,417,407,394,422,407,389]
+    x-axis [50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952]
+    line "AWSChunkedReaderSigned" [449225,417284,441285,421825,408990,457655,418649,415373,403249,445617]
+    line "AWSChunkedReaderUnsigned" [412879,408069,409317,434524,401783,408115,424530,406436,393596,449617]
+    line "CheckMetricsAndSwap" [8,8,8,8,8,8,8,7,8,8]
+    line "CrushOptimized" [304,305,316,338,304,306,309,294,287,358]
+    line "CrushOriginal" [434,425,445,417,407,394,422,407,389,441]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,2,2,2,2,1]
-    line "LoadGlobalConfig" [9117,7890,8368,8771,8344,7742,7670,8319,7911,7590]
-    line "PadString" [49,39,40,45,41,40,38,40,39,36]
+    line "IndexSearch" [2,2,2,2,2,2,2,2,1,1]
+    line "LoadGlobalConfig" [7890,8368,8771,8344,7742,7670,8319,7911,7590,8718]
+    line "PadString" [39,40,45,41,40,38,40,39,36,44]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [430,390,419,504,229,396,398,416,401,396]
-    line "SanitizeLog/Unsafe" [601,504,506,501,678,514,487,506,541,482]
+    line "SanitizeLog/Safe" [390,419,504,229,396,398,416,401,396,419]
+    line "SanitizeLog/Unsafe" [504,506,501,678,514,487,506,541,482,602]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459]
-    line "AWSChunkedReaderSigned" [132,148,160,151,158,163,145,159,160,165]
-    line "AWSChunkedReaderUnsigned" [136,161,163,163,153,166,163,157,164,169]
+    x-axis [50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952]
+    line "AWSChunkedReaderSigned" [148,160,151,158,163,145,159,160,165,149]
+    line "AWSChunkedReaderUnsigned" [161,163,163,153,166,163,157,164,169,148]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [db4c2df,50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459]
-    line "AWSChunkedReaderSigned" [11292,11274,11284,11270,11276,11273,11274,11278,11271,11265]
-    line "AWSChunkedReaderUnsigned" [78578,78566,78561,78559,78564,78563,78571,78563,78564,78564]
+    x-axis [50e5f5b,a6c683c,dcc5290,c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952]
+    line "AWSChunkedReaderSigned" [11274,11284,11270,11276,11273,11274,11278,11271,11265,11282]
+    line "AWSChunkedReaderUnsigned" [78566,78561,78559,78564,78563,78571,78563,78564,78564,78577]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -453,6 +453,7 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 	m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout)) // 🛡️ Slowloris mitigation (issue #592)
 	req, err := http.ReadRequest(m.reader)
 	m.conn.SetReadDeadline(time.Time{})
+	m.connReader.ClearLimit() // clear immediately so body streaming is never limited (issue #653 regression)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to read handshake request: %v: %w", err, syscall.EBADMSG)
 	}
@@ -1591,6 +1592,7 @@ func (m *S3Communicator) ReceiveMetadata() (meta common.FileMetadata, err error)
 		m.conn.SetReadDeadline(time.Now().Add(s3ReadHeaderTimeout)) // 🛡️ Slowloris mitigation (issue #592)
 		req, err := http.ReadRequest(m.reader)
 		m.conn.SetReadDeadline(time.Time{})
+		m.connReader.ClearLimit() // clear immediately so body streaming is never limited (issue #653 regression)
 		if err != nil {
 			return common.FileMetadata{}, fmt.Errorf("ReceiveMetadata ReadRequest failed: %v: %w", err, syscall.EBADMSG)
 		}


### PR DESCRIPTION
## Summary

Hotfix regression on master from PR #879 merge: keep the `defer
m.connReader.ClearLimit()` panic-safety from #879, but ALSO clear the limit
immediately after `http.ReadRequest` so the unbounded body-streaming path is
never limited.

### Problem
#879 added `defer m.connReader.ClearLimit()` but dropped the immediate clear.
The 65536-byte header limit then stayed active for the rest of
`HandshakeServer`/`ReceiveMetadata`, so signed/unsigned streaming PUT bodies
failed with `read limit exceeded: no buffer space available` → master `Go`
workflow failed. Issue #653 was auto-closed by the merge; reopened for this fix.

### Fix
Restore an immediate `m.connReader.ClearLimit()` right after `ReadRequest` in
both sites (limit applies only to header parsing), keeping the deferred clear as
panic insurance. Double-clear is idempotent.

### Testing
- Failing tests on master base reproduced locally (`TestS3Communicator_Streaming*`),
  then pass with the fix (7/7).
- `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work vendor` (Rule 25) clean.

Resolves #653