### PR TITLE
fix: decouple S3 gateway SigV4 access/secret keys from auth token (#656)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3872,3 +3872,14 @@ aba2e7e8,BenchmarkSanitizeLog/Unsafe-8,510.90,704.00,1.00
 0f5fff91,BenchmarkPadString-8,52.70,64.00,1.00
 0f5fff91,BenchmarkSanitizeLog/Safe-8,418.30,0.00,0.00
 0f5fff91,BenchmarkSanitizeLog/Unsafe-8,531.90,704.00,1.00
+a7dbb734,BenchmarkAWSChunkedReaderSigned-8,403588.00,164.92,11270.00
+a7dbb734,BenchmarkAWSChunkedReaderUnsigned-8,393243.00,169.26,78563.00
+a7dbb734,BenchmarkCheckMetricsAndSwap-8,7.47,0.00,0.00
+a7dbb734,BenchmarkCrushOptimized-8,283.80,0.00,0.00
+a7dbb734,BenchmarkCrushOriginal-8,395.50,164.00,3.00
+a7dbb734,BenchmarkIndexDirectTracking-8,0.32,0.00,0.00
+a7dbb734,BenchmarkIndexSearch-8,2.69,0.00,0.00
+a7dbb734,BenchmarkLoadGlobalConfig-8,7563.00,1848.00,54.00
+a7dbb734,BenchmarkPadString-8,37.33,64.00,1.00
+a7dbb734,BenchmarkSanitizeLog/Safe-8,222.50,0.00,0.00
+a7dbb734,BenchmarkSanitizeLog/Unsafe-8,643.30,704.00,1.00

--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -80,6 +80,13 @@ tombstone_retention=86400
 # s3_access_key=AKIAIOSFODNN7EXAMPLE       # notsecret
 # s3_secret_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY  # notsecret
 # s3_path_style=false
+#
+# Optional: dedicated SigV4 credentials for inbound S3 gateway clients.
+# When set, external S3 clients must present s3_server_access_key and sign
+# with s3_server_secret_key instead of the momo auth token (issue #656).
+# Both keys must be configured together and are limited to 64 bytes.
+# s3_server_access_key=AKIAIOSFODNN7EXAMPLE       # notsecret
+# s3_server_secret_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY  # notsecret
 # Raw device backend example:
 # backend=raw
 # raw_device_path=/dev/sda1

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ The configuration file uses a standard INI-style format. The parser is flexible 
 This section contains cluster-wide settings that affect all daemons.
 
 -   **`auth_token`**
-    -   **Description:** A shared secret token used for authentication between clients and servers. All nodes in the cluster must share the same token. For S3-compatible protocols, this token is used as the AWS access key ID. Tokens longer than 64 bytes are rejected with `EINVAL` at startup.
+    -   **Description:** A shared secret token used for authentication between clients and servers. All nodes in the cluster must share the same token. For S3-compatible protocols, this token is used as the AWS access key ID unless `s3_server_access_key`/`s3_server_secret_key` are configured (issue #656). Tokens longer than 64 bytes are rejected with `EINVAL` at startup.
     -   **Type:** String (exactly 64 bytes when null-padded; max 64 bytes)
     -   **Default:** None (required)
     -   **Example:** `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6` <!-- notsecret -->
@@ -335,6 +335,16 @@ This section controls the Content-Addressable Storage (CAS) engine, including ba
 
 -   **`s3_secret_key`**
     -   **Description:** S3 secret access key. Only used when `backend = s3`.
+    -   **Type:** String
+    -   **Default:** (none)
+
+-   **`s3_server_access_key`**
+    -   **Description:** SigV4 access key ID accepted by this node's S3 gateway for inbound external clients (issue #656). When set, inbound SigV4 requests must present this access key and be signed with `s3_server_secret_key`, decoupling gateway credentials from the momo auth token. Must be configured together with `s3_server_secret_key`. When unset, the legacy single-token mode applies (access key and secret both derived from the global auth token).
+    -   **Type:** String
+    -   **Default:** (none)
+
+-   **`s3_server_secret_key`**
+    -   **Description:** SigV4 secret key used to verify inbound SigV4 signatures against this node's S3 gateway (issue #656). Only meaningful together with `s3_server_access_key`.
     -   **Type:** String
     -   **Default:** (none)
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             410.6n ± ∞ ¹    382.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            302.9n ± ∞ ¹    301.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.040µ ± ∞ ¹    8.190µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 39.58n ± ∞ ¹    52.70n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          415.5n ± ∞ ¹    418.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        510.9n ± ∞ ¹    531.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    433.3µ ± ∞ ¹    418.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  430.4µ ± ∞ ¹    404.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.742n ± ∞ ¹    7.521n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.591n ± ∞ ¹    1.688n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3308n ± ∞ ¹   0.3397n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     337.1n          344.4n        +2.16%
+CrushOriginal-8                             382.3n ± ∞ ¹    395.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            301.1n ± ∞ ¹    283.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.190µ ± ∞ ¹    7.563µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 52.70n ± ∞ ¹    37.33n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          418.3n ± ∞ ¹    222.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        531.9n ± ∞ ¹    643.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    418.8µ ± ∞ ¹    403.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  404.4µ ± ∞ ¹    393.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.521n ± ∞ ¹    7.466n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.688n ± ∞ ¹    2.688n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3397n ± ∞ ¹   0.3243n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     344.4n          327.7n        -4.83%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.01%               ⁴
+geomean                                                ⁴                  -0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   146.5Mi ± ∞ ¹   151.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 147.5Mi ± ∞ ¹   157.0Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    147.0Mi         154.2Mi        +4.94%
+AWSChunkedReaderSigned-8                   151.6Mi ± ∞ ¹   157.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 157.0Mi ± ∞ ¹   161.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    154.2Mi         159.3Mi        +3.31%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 418811.00 ns/op | 158.93 B/op | 11272.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 404420.00 ns/op | 164.58 B/op | 78569.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.52 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 301.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 382.30 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.34 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8190.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 52.70 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 418.30 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 531.90 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 403588.00 ns/op | 164.92 B/op | 11270.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 393243.00 ns/op | 169.26 B/op | 78563.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.47 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 283.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 395.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.69 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7563.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 37.33 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 222.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 643.30 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9]
-    line "AWSChunkedReaderSigned" [421825,408990,457655,418649,415373,403249,445617,408424,433346,418811]
-    line "AWSChunkedReaderUnsigned" [434524,401783,408115,424530,406436,393596,449617,408148,430389,404420]
-    line "CheckMetricsAndSwap" [8,8,8,8,7,8,8,9,8,8]
-    line "CrushOptimized" [338,304,306,309,294,287,358,356,303,301]
-    line "CrushOriginal" [417,407,394,422,407,389,441,568,411,382]
+    x-axis [ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73]
+    line "AWSChunkedReaderSigned" [408990,457655,418649,415373,403249,445617,408424,433346,418811,403588]
+    line "AWSChunkedReaderUnsigned" [401783,408115,424530,406436,393596,449617,408148,430389,404420,393243]
+    line "CheckMetricsAndSwap" [8,8,8,7,8,8,9,8,8,7]
+    line "CrushOptimized" [304,306,309,294,287,358,356,303,301,284]
+    line "CrushOriginal" [407,394,422,407,389,441,568,411,382,396]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,2,1,1,2,2,2]
-    line "LoadGlobalConfig" [8344,7742,7670,8319,7911,7590,8718,10767,8040,8190]
-    line "PadString" [41,40,38,40,39,36,44,55,40,53]
+    line "IndexSearch" [2,2,2,2,1,1,2,2,2,3]
+    line "LoadGlobalConfig" [7742,7670,8319,7911,7590,8718,10767,8040,8190,7563]
+    line "PadString" [40,38,40,39,36,44,55,40,53,37]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [229,396,398,416,401,396,419,499,416,418]
-    line "SanitizeLog/Unsafe" [678,514,487,506,541,482,602,485,511,532]
+    line "SanitizeLog/Safe" [396,398,416,401,396,419,499,416,418,222]
+    line "SanitizeLog/Unsafe" [514,487,506,541,482,602,485,511,532,643]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9]
-    line "AWSChunkedReaderSigned" [158,163,145,159,160,165,149,163,154,159]
-    line "AWSChunkedReaderUnsigned" [153,166,163,157,164,169,148,163,155,165]
+    x-axis [ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73]
+    line "AWSChunkedReaderSigned" [163,145,159,160,165,149,163,154,159,165]
+    line "AWSChunkedReaderUnsigned" [166,163,157,164,169,148,163,155,165,169]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [c169bb5,ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9]
-    line "AWSChunkedReaderSigned" [11276,11273,11274,11278,11271,11265,11282,11278,11284,11272]
-    line "AWSChunkedReaderUnsigned" [78564,78563,78571,78563,78564,78564,78577,78562,78561,78569]
+    x-axis [ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73]
+    line "AWSChunkedReaderSigned" [11273,11274,11278,11271,11265,11282,11278,11284,11272,11270]
+    line "AWSChunkedReaderUnsigned" [78563,78571,78563,78564,78564,78577,78562,78561,78569,78563]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -548,6 +548,8 @@ func loadStorageConfig(section *ini.Section) (ConfigurationStorage, error) {
 	cfg.S3Bucket = section.Key("s3_bucket").String()
 	cfg.S3AccessKey = section.Key("s3_access_key").String()
 	cfg.S3SecretKey = section.Key("s3_secret_key").String()
+	cfg.S3ServerAccessKey = section.Key("s3_server_access_key").String()
+	cfg.S3ServerSecretKey = section.Key("s3_server_secret_key").String()
 	cfg.S3PathStyle, err = section.Key("s3_path_style").Bool()
 	if err != nil {
 		cfg.S3PathStyle = true
@@ -559,6 +561,18 @@ func loadStorageConfig(section *ini.Section) (ConfigurationStorage, error) {
 	}
 
 	cfg.RawDevicePath = section.Key("raw_device_path").String()
+
+	// issue #656: dedicated S3 gateway SigV4 credentials must be set as a pair
+	// and stay within the wire field bounds (PadString rejects >64 bytes).
+	if (cfg.S3ServerAccessKey == "") != (cfg.S3ServerSecretKey == "") {
+		return ConfigurationStorage{}, fmt.Errorf("'s3_server_access_key' and 's3_server_secret_key' must be configured together: %w", syscall.EINVAL)
+	}
+	if len(cfg.S3ServerAccessKey) > AuthTokenLength {
+		return ConfigurationStorage{}, fmt.Errorf("'s3_server_access_key' length exceeds maximum allowed length of %d bytes", AuthTokenLength)
+	}
+	if len(cfg.S3ServerSecretKey) > AuthTokenLength {
+		return ConfigurationStorage{}, fmt.Errorf("'s3_server_secret_key' length exceeds maximum allowed length of %d bytes", AuthTokenLength)
+	}
 
 	return cfg, nil
 }

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -195,6 +195,53 @@ func TestGetConfig_StorageBackends_Valid(t *testing.T) {
 	})
 }
 
+// TestGetConfig_S3GatewayCredentials covers the issue #656 dedicated S3 gateway
+// SigV4 credential pair validation and parsing.
+func TestGetConfig_S3GatewayCredentials(t *testing.T) {
+	mk := func(t *testing.T, storage string) string {
+		t.Helper()
+		tmpDir := t.TempDir()
+		tmpfile := filepath.Join(tmpDir, "momo.conf")
+		if err := os.WriteFile(tmpfile, []byte(validConfig+"\n[storage]\n"+storage), 0666); err != nil {
+			t.Fatalf("Failed to write config: %v", err)
+		}
+		return tmpfile
+	}
+
+	t.Run("pair parsed", func(t *testing.T) {
+		cfg, err := GetConfig(mk(t, "backend = local\ns3_server_access_key = AKIAIOSFODNN7EXAMPLE\ns3_server_secret_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"))
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+		if cfg.Storage.S3ServerAccessKey != "AKIAIOSFODNN7EXAMPLE" {
+			t.Errorf("unexpected S3ServerAccessKey %q", cfg.Storage.S3ServerAccessKey)
+		}
+		if cfg.Storage.S3ServerSecretKey != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+			t.Errorf("unexpected S3ServerSecretKey %q", cfg.Storage.S3ServerSecretKey)
+		}
+	})
+
+	t.Run("single key rejected", func(t *testing.T) {
+		_, err := GetConfig(mk(t, "backend = local\ns3_server_access_key = AKIAIOSFODNN7EXAMPLE\n"))
+		if err == nil {
+			t.Fatal("expected error when only access key is set")
+		}
+		if !strings.Contains(err.Error(), "must be configured together") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("overlong key rejected", func(t *testing.T) {
+		_, err := GetConfig(mk(t, "backend = local\ns3_server_access_key = AKIAIOSFODNN7EXAMPLE\ns3_server_secret_key = "+strings.Repeat("k", 65)+"\n"))
+		if err == nil {
+			t.Fatal("expected error for overlong secret key")
+		}
+		if !strings.Contains(err.Error(), "s3_server_secret_key") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 // TestLoadDaemons_MissingFieldsDeterministic ensures that when multiple required
 // daemon fields are missing, the reported error is deterministic across runs
 // (map iteration order must not influence the chosen field, issue #644).

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -190,6 +190,17 @@ type ConfigurationStorage struct {
 	S3AccessKey string
 	// S3SecretKey is the S3 secret access key for authentication.
 	S3SecretKey string
+	// S3ServerAccessKey is the SigV4 access key ID accepted by this node's S3
+	// gateway for inbound external clients. When set, inbound SigV4 requests
+	// must present this access key and be signed with S3ServerSecretKey,
+	// decoupling gateway credentials from the momo auth token (issue #656).
+	// When empty, the legacy single-token mode applies: access key and secret
+	// are both derived from the global auth token.
+	S3ServerAccessKey string
+	// S3ServerSecretKey is the SigV4 secret key used to verify inbound SigV4
+	// signatures against this node's S3 gateway. Only meaningful together with
+	// S3ServerAccessKey (issue #656).
+	S3ServerSecretKey string
 	// S3PathStyle uses path-style addressing (bucket in URL path) instead of virtual-host style.
 	S3PathStyle bool
 	// S3Insecure allows an http:// S3 endpoint (cleartext). Defaults to false;

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -249,6 +249,13 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 				bcComm.SetConfiguredBucket(cfg.Storage.S3Bucket)
 			}
 
+			// Inject dedicated S3 gateway SigV4 credentials (issue #656). When
+			// configured, inbound SigV4 requests must present these access/secret
+			// keys instead of the momo auth token.
+			if scComm, ok := comm.(interface{ SetSigV4GatewayCredentials(string, string) }); ok {
+				scComm.SetSigV4GatewayCredentials(cfg.Storage.S3ServerAccessKey, cfg.Storage.S3ServerSecretKey)
+			}
+
 			// Inject metrics hook for download/delete/error instrumentation
 			if mhComm, ok := comm.(interface{ SetMetricsHook(transport.MetricsHook) }); ok {
 				mhComm.SetMetricsHook(metricsCollector)

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -132,6 +132,15 @@ type S3Communicator struct {
 	// sigV4 holds the per-chunk verification context derived during SigV4
 	// verification for signed streaming PUTs (issue #773).
 	sigV4 *streamingSigningCtx
+
+	// sigV4AccessKey and sigV4SecretKey are the dedicated S3 gateway SigV4
+	// credentials (issue #656). When both are non-empty, inbound SigV4 requests
+	// must present sigV4AccessKey and be signed with sigV4SecretKey, decoupling
+	// gateway credentials from the momo auth token. When empty, the legacy
+	// single-token mode applies (access key and secret both derived from the
+	// global auth token).
+	sigV4AccessKey string
+	sigV4SecretKey string
 }
 
 func NewS3Communicator(conn net.Conn) *S3Communicator {
@@ -146,6 +155,17 @@ func NewS3Communicator(conn net.Conn) *S3Communicator {
 
 func (m *S3Communicator) SetStore(store storage.Store) {
 	m.store = store
+}
+
+// SetSigV4GatewayCredentials sets the dedicated SigV4 access/secret key pair
+// this node's S3 gateway accepts from inbound external clients (issue #656).
+// When both are non-empty the gateway requires inbound SigV4 requests to
+// present the access key and be signed with the secret key; the momo auth
+// token is then never used as either. Calling with empty values restores the
+// legacy single-token mode (access key and secret derived from the auth token).
+func (m *S3Communicator) SetSigV4GatewayCredentials(accessKey, secretKey string) {
+	m.sigV4AccessKey = accessKey
+	m.sigV4SecretKey = secretKey
 }
 
 // SetConfiguredBucket sets the single bucket name exposed by the S3 gateway for
@@ -492,19 +512,39 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		return 0, 0, fmt.Errorf("incomplete presigned auth query parameters: %w", syscall.EBADMSG)
 	}
 
-	tokenBuf := []byte(common.PadString(token, common.AuthTokenLength))
-	if subtle.ConstantTimeCompare(tokenBuf, expectedAuthToken) == 1 {
+	// issue #656: when dedicated S3 gateway SigV4 credentials are configured,
+	// inbound SigV4 requests must present the gateway access key and be signed
+	// with the gateway secret key. Otherwise the legacy single-token mode holds
+	// (access key and secret both derived from the momo auth token).
+	sigV4GatewayCreds := isSigV4 && m.sigV4AccessKey != ""
+
+	if sigV4GatewayCreds {
+		want := []byte(common.PadString(common.TrimNullBytesString([]byte(m.sigV4AccessKey)), common.AuthTokenLength))
+		if subtle.ConstantTimeCompare([]byte(common.PadString(token, common.AuthTokenLength)), want) != 1 {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusForbidden, "AccessDenied", "Access Denied.", "")
+			return 0, 0, syscall.EACCES
+		}
+		// External S3 client using gateway SigV4 credentials is never a peer.
 		m.isPeer = false
-	} else if peerToken := common.DerivePeerToken(expectedAuthToken); subtle.ConstantTimeCompare(tokenBuf, peerToken) == 1 {
-		m.isPeer = true
 	} else {
-		m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-		writeS3Error(m.conn, http.StatusForbidden, "AccessDenied", "Access Denied.", "")
-		return 0, 0, syscall.EACCES
+		tokenBuf := []byte(common.PadString(token, common.AuthTokenLength))
+		if subtle.ConstantTimeCompare(tokenBuf, expectedAuthToken) == 1 {
+			m.isPeer = false
+		} else if peerToken := common.DerivePeerToken(expectedAuthToken); subtle.ConstantTimeCompare(tokenBuf, peerToken) == 1 {
+			m.isPeer = true
+		} else {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusForbidden, "AccessDenied", "Access Denied.", "")
+			return 0, 0, syscall.EACCES
+		}
 	}
 
 	if isSigV4 {
 		secretKey := common.TrimNullBytesString(expectedAuthToken)
+		if sigV4GatewayCreds {
+			secretKey = common.TrimNullBytesString([]byte(m.sigV4SecretKey))
+		}
 		if !verifySigV4Signature(req, authHeader, secretKey) {
 			log.Printf("AUDIT: SigV4 signature verification failed from %s", m.conn.RemoteAddr())
 			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))

--- a/src/transport/s3_communicator_presigned_test.go
+++ b/src/transport/s3_communicator_presigned_test.go
@@ -250,3 +250,118 @@ func TestS3Communicator_PresignedDELETE(t *testing.T) {
 		t.Errorf("expected 204 No Content, got: %s", respStr)
 	}
 }
+
+// buildPresignedGatewayRequest builds a presigned GET signed with a secretKey
+// while presenting a distinct accessKey in X-Amz-Credential (issue #656).
+func buildPresignedGatewayRequest(req *http.Request, payloadHash, accessKey, secretKey string) string {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	region := "us-east-1"
+
+	signedHeaders := "host"
+	presign := &url.Values{}
+	presign.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	presign.Set("X-Amz-Credential", accessKey+"/"+dateStamp+"/"+region+"/s3/aws4_request")
+	presign.Set("X-Amz-Date", amzDate)
+	presign.Set("X-Amz-Expires", "3600")
+	presign.Set("X-Amz-SignedHeaders", signedHeaders)
+
+	req.URL = &url.URL{Scheme: "http", Host: "127.0.0.1:4440", Path: req.URL.Path, RawQuery: presign.Encode()}
+	req.Host = "127.0.0.1:4440"
+
+	canonicalRequest, err := buildCanonicalRequest(req, signedHeaders, payloadHash)
+	if err != nil {
+		panic(err)
+	}
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+	signingKey := deriveSigningKey(secretKey, dateStamp, region)
+	q := req.URL.Query()
+	q.Set("X-Amz-Signature", computeSignature(signingKey, stringToSign))
+	req.URL.RawQuery = q.Encode()
+
+	var sb strings.Builder
+	sb.WriteString(req.Method + " " + req.URL.RequestURI() + " HTTP/1.1\r\n")
+	sb.WriteString("Host: " + req.Host + "\r\n")
+	if payloadHash != "" {
+		sb.WriteString("X-Amz-Content-Sha256: " + payloadHash + "\r\n")
+	}
+	sb.WriteString("\r\n")
+	return sb.String()
+}
+
+func TestS3Communicator_PresignedGET_GatewayCredentials(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	token := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	accessKey := "AKIAIOSFODNN7EXAMPLE"
+	secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	expected := []byte(common.PadString(token, common.AuthTokenLength))
+
+	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/bucket/hello.txt"}}
+	rawReq := buildPresignedGatewayRequest(req, emptyStringSHA256, accessKey, secretKey)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		clientConn.Write([]byte(rawReq))
+		buf := make([]byte, 4096)
+		for {
+			if _, err := clientConn.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	mock := &mockStore{
+		getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+			return io.NopCloser(bytes.NewReader([]byte("data"))), common.FileMetadata{Name: "hello.txt", Hash: "hash1", Size: 4}, nil
+		},
+	}
+
+	comm := NewS3Communicator(serverConn)
+	comm.SetStore(mock)
+	comm.SetSigV4GatewayCredentials(accessKey, secretKey)
+	if _, _, err := comm.HandshakeServer(expected); err != ErrRequestHandled {
+		t.Fatalf("expected ErrRequestHandled for presigned GET with gateway creds, got: %v", err)
+	}
+}
+
+func TestS3Communicator_PresignedGET_GatewayCredentialsWrongSecret(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	token := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	accessKey := "AKIAIOSFODNN7EXAMPLE"
+	secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	expected := []byte(common.PadString(token, common.AuthTokenLength))
+
+	// Signed with the momo auth token secret, but gateway expects secretKey.
+	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/bucket/hello.txt"}}
+	rawReq := buildPresignedGatewayRequest(req, emptyStringSHA256, accessKey, token)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		clientConn.Write([]byte(rawReq))
+		buf := make([]byte, 4096)
+		for {
+			if _, err := clientConn.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	comm := NewS3Communicator(serverConn)
+	comm.SetSigV4GatewayCredentials(accessKey, secretKey)
+	_, _, err := comm.HandshakeServer(expected)
+	if err == nil {
+		t.Fatal("presigned GET with wrong gateway secret should be rejected")
+	}
+	if !errors.Is(err, syscall.EACCES) {
+		t.Fatalf("Expected EACCES, got: %v", err)
+	}
+}

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -176,6 +176,123 @@ func TestS3Communicator_SigV4InvalidSignature(t *testing.T) {
 	}
 }
 
+// signedSigV4PUT builds an AWS SigV4-signed PUT request header for the S3
+// gateway using distinct accessKey (Credential scope) and secretKey (HMAC
+// signing secret). Mirrors TestS3Communicator_AWSV4Auth but parameterizes the
+// two keys so the issue #656 gateway-credentials split can be exercised.
+func signedSigV4PUT(accessKey, secretKey, host string) string {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	region := "us-east-1"
+	payloadHash := "dummyhash"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := "PUT\n/test-file2.txt\n\nhost:" + host + "\nx-amz-content-sha256:" + payloadHash + "\nx-amz-date:" + amzDate + "\n\n" + signedHeaders + "\n" + payloadHash
+	stringToSign := buildStringToSign(canonicalRequest, amzDate, dateStamp, region)
+	signingKey := deriveSigningKey(secretKey, dateStamp, region)
+	signature := computeSignature(signingKey, stringToSign)
+
+	authHeader := "AWS4-HMAC-SHA256 Credential=" + accessKey + "/" + dateStamp + "/" + region + "/s3/aws4_request, SignedHeaders=" + signedHeaders + ", Signature=" + signature
+
+	return "PUT /test-file2.txt HTTP/1.1\r\n" +
+		"Host: " + host + "\r\n" +
+		"Authorization: " + authHeader + "\r\n" +
+		"X-Amz-Date: " + amzDate + "\r\n" +
+		"X-Amz-Content-Sha256: " + payloadHash + "\r\n" +
+		"Content-Length: 2048\r\n\r\n"
+}
+
+// runS3Handshake pipes reqBody into a handshake. When expectErr is true the
+// call must fail with syscall.EACCES.
+func runS3Handshake(t *testing.T, reqBody, authToken string, creds *sigV4GatewayCreds, expectErr bool) {
+	t.Helper()
+	expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	go func() {
+		clientConn.Write([]byte(reqBody))
+		buf := make([]byte, 1024)
+		for {
+			_, err := clientConn.Read(buf)
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	comm := NewS3Communicator(serverConn)
+	if creds != nil {
+		comm.SetSigV4GatewayCredentials(creds.accessKey, creds.secretKey)
+	}
+	_, _, err := comm.HandshakeServer(expectedAuthToken)
+	if expectErr {
+		if err == nil {
+			t.Fatal("HandshakeServer should have been rejected")
+		}
+		if !errors.Is(err, syscall.EACCES) {
+			t.Fatalf("Expected EACCES, got: %v", err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("HandshakeServer failed: %v", err)
+	}
+}
+
+type sigV4GatewayCreds struct {
+	accessKey string
+	secretKey string
+}
+
+func TestS3Communicator_SigV4GatewayCredentials_Valid(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	accessKey := "AKIAIOSFODNN7EXAMPLE"                                             // notsecret
+	secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"                         // notsecret
+
+	// Signed with the gateway pair (access key and secret are distinct).
+	runS3Handshake(t, signedSigV4PUT(accessKey, secretKey, "127.0.0.1:4440"), authToken,
+		&sigV4GatewayCreds{accessKey: accessKey, secretKey: secretKey}, false)
+}
+
+func TestS3Communicator_SigV4GatewayCredentials_WrongSecret(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	accessKey := "AKIAIOSFODNN7EXAMPLE"
+	secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+	// Request signed with the momo auth token as secret, not the gateway secret.
+	runS3Handshake(t, signedSigV4PUT(accessKey, authToken, "127.0.0.1:4440"), authToken,
+		&sigV4GatewayCreds{accessKey: accessKey, secretKey: secretKey}, true)
+}
+
+func TestS3Communicator_SigV4GatewayCredentials_WrongAccessKey(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	accessKey := "AKIAIOSFODNN7EXAMPLE"
+	secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+	// Request presents the momo auth token as access key while gateway expects AKIA...
+	runS3Handshake(t, signedSigV4PUT(authToken, secretKey, "127.0.0.1:4440"), authToken,
+		&sigV4GatewayCreds{accessKey: accessKey, secretKey: secretKey}, true)
+}
+
+func TestS3Communicator_SigV4GatewayCredentials_LegacyStillWorks(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+	// No gateway creds configured → legacy single-token mode: access key and
+	// secret are both the auth token.
+	runS3Handshake(t, signedSigV4PUT(authToken, authToken, "127.0.0.1:4440"), authToken, nil, false)
+}
+
 func TestS3Communicator_HashTraversalValidation(t *testing.T) {
 	defer verifyNoLeaks(t)
 


### PR DESCRIPTION
## Summary

The S3 gateway used the **momo auth token as both** the SigV4 access key
(`Credential`/`X-Amz-Credential` identity) and the secret key (HMAC signing
secret), so compromising one compromised both (issue #656).

### Fix: dedicated gateway SigV4 credential pair

- **New config keys** (`[storage]` section, parsed in `src/common/config.go`,
  fields in `src/common/struct.go`):
  - `s3_server_access_key`
  - `s3_server_secret_key`
  - Validated at load: must be set together, and each ≤64 bytes (wire-field
    bound; `PadString` panics above it).
- **Behavior**: when the pair is configured, inbound SigV4 requests must
  present `s3_server_access_key` (constant-time compare) and be signed with
  `s3_server_secret_key`. The momo auth token is then never used as either key.
  Legacy single-token mode is preserved when the pair is unset (backward
  compatible; zero churn to existing S3 clients configured with
  token == access == secret).
- **Wiring**: `S3Communicator.SetSigV4GatewayCredentials(accessKey, secretKey)`
  injected by the daemon accept path (`src/server/server.go`) from
  `cfg.Storage`, alongside `SetStore`/`SetConfiguredBucket`.
- **Bearer/momo-peer auth**: unchanged — still validated against the global
  auth token / derived peer token. SigV4 with gateway creds is always treated
  as an external (non-peer) client, matching the primary-client semantics.

### Testing

- `TestS3Communicator_SigV4GatewayCredentials_{Valid,WrongSecret,WrongAccessKey,LegacyStillWorks}`:
  distinct access/secret pair accepted; request signed with the auth token as
  secret rejected (`EACCES`); request presenting the token as access key
  rejected; legacy single-token mode still works.
- `TestS3Communicator_PresignedGET_GatewayCredentials{,_WrongSecret}`: presigned
  query-auth path honours the split pair.
- `TestGetConfig_S3GatewayCredentials`: pair parsed; single key (access without
  secret) rejected with "must be configured together"; overlong (>64B) key
  rejected.
- `go build ./...`, `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work
  vendor` (Rule 25) clean.

### Docs
`conf/momo.conf` sample + `docs/CONFIGURATION.md` updated with the new keys,
including the `auth_token` description note.

Resolves #656