### PR TITLE
fix: validate plaintext handshake timestamp freshness to block replays (#657)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3883,3 +3883,14 @@ a7dbb734,BenchmarkLoadGlobalConfig-8,7563.00,1848.00,54.00
 a7dbb734,BenchmarkPadString-8,37.33,64.00,1.00
 a7dbb734,BenchmarkSanitizeLog/Safe-8,222.50,0.00,0.00
 a7dbb734,BenchmarkSanitizeLog/Unsafe-8,643.30,704.00,1.00
+380ee51a,BenchmarkAWSChunkedReaderSigned-8,429229.00,155.07,11273.00
+380ee51a,BenchmarkAWSChunkedReaderUnsigned-8,403247.00,165.06,78558.00
+380ee51a,BenchmarkCheckMetricsAndSwap-8,8.96,0.00,0.00
+380ee51a,BenchmarkCrushOptimized-8,300.90,0.00,0.00
+380ee51a,BenchmarkCrushOriginal-8,423.40,164.00,3.00
+380ee51a,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+380ee51a,BenchmarkIndexSearch-8,2.81,0.00,0.00
+380ee51a,BenchmarkLoadGlobalConfig-8,7976.00,1848.00,54.00
+380ee51a,BenchmarkPadString-8,39.35,64.00,1.00
+380ee51a,BenchmarkSanitizeLog/Safe-8,228.90,0.00,0.00
+380ee51a,BenchmarkSanitizeLog/Unsafe-8,668.30,704.00,1.00

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ The configuration file uses a standard INI-style format. The parser is flexible 
 This section contains cluster-wide settings that affect all daemons.
 
 -   **`auth_token`**
-    -   **Description:** A shared secret token used for authentication between clients and servers. All nodes in the cluster must share the same token. For S3-compatible protocols, this token is used as the AWS access key ID unless `s3_server_access_key`/`s3_server_secret_key` are configured (issue #656). Tokens longer than 64 bytes are rejected with `EINVAL` at startup.
+    -   **Description:** A shared secret token used for authentication between clients and servers. All nodes in the cluster must share the same token. For S3-compatible protocols, this token is used as the AWS access key ID unless `s3_server_access_key`/`s3_server_secret_key` are configured (issue #656). Tokens longer than 64 bytes are rejected with `EINVAL` at startup. On the plaintext (non-challenge-response) native handshake, the client sends a UnixNano timestamp that the server validates within ±15 minutes to block replayed handshakes (issue #657).
     -   **Type:** String (exactly 64 bytes when null-padded; max 64 bytes)
     -   **Default:** None (required)
     -   **Example:** `a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6` <!-- notsecret -->

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             382.3n ± ∞ ¹    395.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            301.1n ± ∞ ¹    283.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.190µ ± ∞ ¹    7.563µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 52.70n ± ∞ ¹    37.33n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          418.3n ± ∞ ¹    222.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        531.9n ± ∞ ¹    643.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    418.8µ ± ∞ ¹    403.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  404.4µ ± ∞ ¹    393.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.521n ± ∞ ¹    7.466n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.688n ± ∞ ¹    2.688n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3397n ± ∞ ¹   0.3243n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     344.4n          327.7n        -4.83%
+CrushOriginal-8                             395.5n ± ∞ ¹    423.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            283.8n ± ∞ ¹    300.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.563µ ± ∞ ¹    7.976µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 37.33n ± ∞ ¹    39.35n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          222.5n ± ∞ ¹    228.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        643.3n ± ∞ ¹    668.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    403.6µ ± ∞ ¹    429.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  393.2µ ± ∞ ¹    403.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.466n ± ∞ ¹    8.960n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.688n ± ∞ ¹    2.805n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3243n ± ∞ ¹   0.3522n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     327.7n          349.1n        +6.51%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -63,11 +63,11 @@ PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
 AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.00%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   151.6Mi ± ∞ ¹   157.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 157.0Mi ± ∞ ¹   161.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    154.2Mi         159.3Mi        +3.31%
+AWSChunkedReaderSigned-8                   157.3Mi ± ∞ ¹   147.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 161.4Mi ± ∞ ¹   157.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    159.3Mi         152.6Mi        -4.24%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 403588.00 ns/op | 164.92 B/op | 11270.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 393243.00 ns/op | 169.26 B/op | 78563.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.47 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 283.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 395.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.69 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7563.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 37.33 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 222.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 643.30 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 429229.00 ns/op | 155.07 B/op | 11273.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 403247.00 ns/op | 165.06 B/op | 78558.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.96 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 300.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 423.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.81 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7976.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 39.35 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 228.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 668.30 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73]
-    line "AWSChunkedReaderSigned" [408990,457655,418649,415373,403249,445617,408424,433346,418811,403588]
-    line "AWSChunkedReaderUnsigned" [401783,408115,424530,406436,393596,449617,408148,430389,404420,393243]
-    line "CheckMetricsAndSwap" [8,8,8,7,8,8,9,8,8,7]
-    line "CrushOptimized" [304,306,309,294,287,358,356,303,301,284]
-    line "CrushOriginal" [407,394,422,407,389,441,568,411,382,396]
+    x-axis [650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51]
+    line "AWSChunkedReaderSigned" [457655,418649,415373,403249,445617,408424,433346,418811,403588,429229]
+    line "AWSChunkedReaderUnsigned" [408115,424530,406436,393596,449617,408148,430389,404420,393243,403247]
+    line "CheckMetricsAndSwap" [8,8,7,8,8,9,8,8,7,9]
+    line "CrushOptimized" [306,309,294,287,358,356,303,301,284,301]
+    line "CrushOriginal" [394,422,407,389,441,568,411,382,396,423]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,2,2,1,1,2,2,2,3]
-    line "LoadGlobalConfig" [7742,7670,8319,7911,7590,8718,10767,8040,8190,7563]
-    line "PadString" [40,38,40,39,36,44,55,40,53,37]
+    line "IndexSearch" [2,2,2,1,1,2,2,2,3,3]
+    line "LoadGlobalConfig" [7670,8319,7911,7590,8718,10767,8040,8190,7563,7976]
+    line "PadString" [38,40,39,36,44,55,40,53,37,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [396,398,416,401,396,419,499,416,418,222]
-    line "SanitizeLog/Unsafe" [514,487,506,541,482,602,485,511,532,643]
+    line "SanitizeLog/Safe" [398,416,401,396,419,499,416,418,222,229]
+    line "SanitizeLog/Unsafe" [487,506,541,482,602,485,511,532,643,668]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73]
-    line "AWSChunkedReaderSigned" [163,145,159,160,165,149,163,154,159,165]
-    line "AWSChunkedReaderUnsigned" [166,163,157,164,169,148,163,155,165,169]
+    x-axis [650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51]
+    line "AWSChunkedReaderSigned" [145,159,160,165,149,163,154,159,165,155]
+    line "AWSChunkedReaderUnsigned" [163,157,164,169,148,163,155,165,169,165]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ecfc1d3,650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73]
-    line "AWSChunkedReaderSigned" [11273,11274,11278,11271,11265,11282,11278,11284,11272,11270]
-    line "AWSChunkedReaderUnsigned" [78563,78571,78563,78564,78564,78577,78562,78561,78569,78563]
+    x-axis [650994d,7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51]
+    line "AWSChunkedReaderSigned" [11274,11278,11271,11265,11282,11278,11284,11272,11270,11273]
+    line "AWSChunkedReaderUnsigned" [78571,78563,78564,78564,78577,78562,78561,78569,78563,78558]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/client/oprf.go
+++ b/src/client/oprf.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"syscall"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	momocrypto "github.com/alsotoes/momo/src/crypto"
@@ -35,7 +36,7 @@ func deriveOPRFContentKey(cfg common.Configuration, tagHex string, serverId int)
 	}
 	defer comm.Close()
 
-	results, err := comm.SendOPRFEval(cfg.Global.AuthToken, 0, blinded, threshold)
+	results, err := comm.SendOPRFEval(cfg.Global.AuthToken, time.Now().UnixNano(), blinded, threshold)
 	if err != nil {
 		// Fail closed: no convergent fallback (spec requirement).
 		return nil, fmt.Errorf("oprf: evaluation failed: %w", err)

--- a/src/momo.go
+++ b/src/momo.go
@@ -107,7 +107,7 @@ func Run() {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		client.Connect(&wg, cfg, *filePathPtr, *remotePathPtr, serverId, common.DummyEpoch, 0, cfg.Global.ReplicationFactor)
+		client.Connect(&wg, cfg, *filePathPtr, *remotePathPtr, serverId, time.Now().UnixNano(), 0, cfg.Global.ReplicationFactor)
 		wg.Wait()
 	case "server":
 		if err := runServer(context.Background(), cfg, *serverIdPtr); err != nil {

--- a/src/server/cas_integration_test.go
+++ b/src/server/cas_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/alsotoes/momo/src/common"
 	"github.com/alsotoes/momo/src/storage"
@@ -151,7 +152,7 @@ func TestCAS_MultiNode_Integration(t *testing.T) {
 		comm := transport.NewMomoTCPCommunicator(conn)
 
 		// Handshake
-		_, err = comm.HandshakeClient(authToken, common.DummyEpoch, 0)
+		_, err = comm.HandshakeClient(authToken, time.Now().UnixNano(), 0)
 		if err != nil {
 			t.Fatalf("Handshake failed: %v", err)
 		}

--- a/src/server/server_daemon_test.go
+++ b/src/server/server_daemon_test.go
@@ -187,7 +187,7 @@ func TestDaemonReal(t *testing.T) {
 	defer conn.Close()
 
 	comm := transport.NewMomoTCPCommunicator(conn)
-	if _, err := comm.HandshakeClient(authToken, 1234567890123456789, 0); err != nil {
+	if _, err := comm.HandshakeClient(authToken, time.Now().UnixNano(), 0); err != nil {
 		t.Fatalf("Handshake failed: %v", err)
 	}
 
@@ -263,7 +263,7 @@ func startDaemonForForwardTest(t *testing.T) (*transport.MomoTCPCommunicator, fu
 	}
 
 	comm := transport.NewMomoTCPCommunicator(conn)
-	if _, err := comm.HandshakeClient(authToken, common.DummyEpoch, 0); err != nil {
+	if _, err := comm.HandshakeClient(authToken, time.Now().UnixNano(), 0); err != nil {
 		cancel()
 		conn.Close()
 		t.Fatalf("Handshake failed: %v", err)

--- a/src/server/server_test.go
+++ b/src/server/server_test.go
@@ -60,9 +60,11 @@ func handleConnection(t *testing.T, connection net.Conn, cfg common.Configuratio
 
 	// The rest of the logic from the original Daemon function
 	repState := GetReplicationState()
-	// If it's a direct client connection (timestamp == 0 in this simplified test), use local state.
-	// In the real Daemon, we use common.DummyEpoch.
-	if timestamp == 0 || timestamp == common.DummyEpoch {
+	// Direct (non-peer) client connections use local state, mirroring the real
+	// Daemon's IsPeer() decision (CVE-007). The timestamp-freshness check now
+	// rejects the fixed DummyEpoch sentinel (issue #657), so this simplified
+	// harness must not key primary/secondary off the timestamp value.
+	if !comm.IsPeer() {
 		replicationMode = repState.New
 	}
 
@@ -176,8 +178,7 @@ func TestDaemonLogic(t *testing.T) {
 
 			// Test Execution
 			client.Write([]byte(common.PadString(authToken, common.AuthTokenLength)))
-			// ⚡ Bolt: Use DummyEpoch to signal that we are the primary in this test
-			timestamp := strconv.FormatInt(common.DummyEpoch, 10)
+			timestamp := strconv.FormatInt(time.Now().UnixNano(), 10)
 			client.Write([]byte(timestamp))
 			// ⚡ Bolt: Send the 84th byte (RequestedMode = 0)
 			client.Write([]byte("0"))

--- a/src/transport/factory_test.go
+++ b/src/transport/factory_test.go
@@ -267,7 +267,7 @@ func TestMomoQUICCommunicator_Metadata_And_Payload(t *testing.T) {
 	}
 	defer clientComm.Close()
 
-	if _, err := clientComm.HandshakeClient(authToken, 0, 0); err != nil {
+	if _, err := clientComm.HandshakeClient(authToken, time.Now().UnixNano(), 0); err != nil {
 		t.Fatalf("Client handshake failed: %v", err)
 	}
 
@@ -364,7 +364,7 @@ func TestMomoQUICCommunicator_RejectsEmptyHash(t *testing.T) {
 	}
 	defer clientComm.Close()
 
-	if _, err := clientComm.HandshakeClient(authToken, 0, 0); err != nil {
+	if _, err := clientComm.HandshakeClient(authToken, time.Now().UnixNano(), 0); err != nil {
 		t.Fatalf("Client handshake failed: %v", err)
 	}
 
@@ -485,7 +485,7 @@ func runNativeQUICTest(t *testing.T, requestedMode int, clientFn func(Communicat
 	}
 	var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
 	copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(tokenToSend, common.AuthTokenLength))
-	copy(handshakeBuf[common.AuthTokenLength:], common.PadString("1557906926566451195", common.TimestampLength))
+	copy(handshakeBuf[common.AuthTokenLength:], common.PadString(strconv.FormatInt(time.Now().UnixNano(), 10), common.TimestampLength))
 	handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode)
 
 	if _, err := clientComm.Write(handshakeBuf[:]); err != nil {

--- a/src/transport/momo_quic.go
+++ b/src/transport/momo_quic.go
@@ -353,6 +353,14 @@ func (m *MomoQUICCommunicator) HandshakeServer(expectedAuthToken []byte) (reques
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to parse timestamp: %v: %w", err, syscall.EBADMSG)
 		}
+		// 🛡️ issue #657: reject replayed handshakes carrying a stale timestamp.
+		// The plaintext token+timestamp frame has no other anti-replay mechanism
+		// (the challenge-response path already uses a random per-connection
+		// challenge).
+		if !checkHandshakeTimestampFresh(timestamp) {
+			log.Printf("AUDIT: Handshake rejected stale timestamp from %s (freshness)", m.RemoteAddr())
+			return 0, 0, fmt.Errorf("handshake timestamp is not fresh: %w", syscall.EACCES)
+		}
 
 		if requestedModeByte == 'L' || requestedModeByte == 'D' || requestedModeByte == 'G' || requestedModeByte == 'O' {
 			requestedMode = int(requestedModeByte)

--- a/src/transport/momo_tcp.go
+++ b/src/transport/momo_tcp.go
@@ -21,6 +21,26 @@ import (
 
 const hashLength = 64
 
+// momoHandshakeMaxSkew bounds how far a plaintext handshake timestamp may
+// deviate from the server clock (replay protection, issue #657). It matches
+// the SigV4 skew window so a multi-hop peer-forwarded chain (which relays the
+// origin timestamp unchanged) is never rejected by normal intra-cluster clock
+// drift, while stale/forged replayed handshakes are dropped.
+const momoHandshakeMaxSkew = 15 * time.Minute
+
+// checkHandshakeTimestampFresh reports whether a plaintext handshake timestamp
+// (UnixNano, wire format) is within the acceptable skew of the server clock.
+// Zero/negative values (garbage or the fixed DummyEpoch sentinel) are stale and
+// rejected.
+func checkHandshakeTimestampFresh(ts int64) bool {
+	now := time.Now().UnixNano()
+	d := time.Duration(ts - now)
+	if d < 0 {
+		d = -d
+	}
+	return d <= momoHandshakeMaxSkew
+}
+
 // MomoTCPCommunicator implements the Communicator interface for the legacy Momo TCP protocol.
 type MomoTCPCommunicator struct {
 	*common.IdleTimeoutConn
@@ -312,6 +332,14 @@ func (m *MomoTCPCommunicator) HandshakeServer(expectedAuthToken []byte) (request
 		timestamp, err = common.SafeParseInt(bufferTimestamp)
 		if err != nil {
 			return 0, 0, fmt.Errorf("failed to parse timestamp: %v: %w", err, syscall.EBADMSG)
+		}
+		// 🛡️ issue #657: reject replayed handshakes carrying a stale
+		// timestamp. The plaintext token+timestamp frame has no other
+		// anti-replay mechanism (the challenge-response path already uses a
+		// random per-connection challenge).
+		if !checkHandshakeTimestampFresh(timestamp) {
+			log.Printf("AUDIT: Handshake rejected stale timestamp from %s (freshness)", m.RemoteAddr())
+			return 0, 0, fmt.Errorf("handshake timestamp is not fresh: %w", syscall.EACCES)
 		}
 
 		if requestedModeByte == 'L' || requestedModeByte == 'D' || requestedModeByte == 'G' || requestedModeByte == 'O' {

--- a/src/transport/momo_tcp_test.go
+++ b/src/transport/momo_tcp_test.go
@@ -331,7 +331,7 @@ func runNativeTCPTest(t *testing.T, requestedMode int, clientFn func(net.Conn), 
 	}
 	var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
 	copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(tokenToSend, common.AuthTokenLength))
-	copy(handshakeBuf[common.AuthTokenLength:], common.PadString("1557906926566451195", common.TimestampLength))
+	copy(handshakeBuf[common.AuthTokenLength:], common.PadString(strconv.FormatInt(time.Now().UnixNano(), 10), common.TimestampLength))
 	handshakeBuf[common.AuthTokenLength+common.TimestampLength] = byte(requestedMode)
 
 	if _, err := conn.Write(handshakeBuf[:]); err != nil {
@@ -551,5 +551,59 @@ func TestMomoTCPCommunicator_SendMetadataCRLF(t *testing.T) {
 	}
 	if !errors.Is(err, syscall.EBADMSG) {
 		t.Errorf("Expected EBADMSG error, got: %v", err)
+	}
+}
+
+// TestMomoTCPHandshakeTimestampFreshness verifies issue #657: the plaintext
+// handshake path rejects a stale timestamp (replay) and accepts a fresh one.
+func TestMomoTCPHandshakeTimestampFreshness(t *testing.T) {
+	tests := []struct {
+		name      string
+		timestamp int64
+		wantErr   bool
+	}{
+		{name: "fresh accepted", timestamp: time.Now().UnixNano()},
+		{name: "stale rejected", timestamp: time.Now().Add(-time.Hour).UnixNano(), wantErr: true},
+		{name: "future rejected", timestamp: time.Now().Add(time.Hour).UnixNano(), wantErr: true},
+		{name: "zero rejected", timestamp: 0, wantErr: true},
+	}
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6" // notsecret
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedAuthToken := []byte(common.PadString(authToken, common.AuthTokenLength))
+
+			var handshakeBuf [common.AuthTokenLength + common.TimestampLength + 1]byte
+			copy(handshakeBuf[0:common.AuthTokenLength], common.PadString(authToken, common.AuthTokenLength))
+			copy(handshakeBuf[common.AuthTokenLength:], common.PadString(strconv.FormatInt(tc.timestamp, 10), common.TimestampLength))
+			handshakeBuf[common.AuthTokenLength+common.TimestampLength] = '0'
+
+			clientConn, serverConn := net.Pipe()
+			defer clientConn.Close()
+			defer serverConn.Close()
+
+			go func() {
+				clientConn.Write(handshakeBuf[:])
+				buf := make([]byte, 1024)
+				// Read until the mock server stops writing (single SendReplicationMode byte).
+				_, _ = clientConn.Read(buf)
+			}()
+
+			comm := NewMomoTCPCommunicator(serverConn)
+			_, _, err := comm.HandshakeServer(expectedAuthToken)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected handshake to be rejected")
+				}
+				if !errors.Is(err, syscall.EACCES) {
+					t.Fatalf("expected EACCES, got: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("handshake failed: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

The plaintext momo handshake (token + timestamp + mode, used when
challenge-response/TLS is off) parsed the client timestamp but never validated
it for freshness, so a captured handshake could be replayed verbatim (issue
#657). The challenge-response path already uses a random per-connection
challenge; only the plaintext path needed this.

### Fix
- **Server-side freshness gate** in the plaintext `HandshakeServer` branches of
  `MomoTCPCommunicator` (`momo_tcp.go`) and `MomoQUICCommunicator`
  (`momo_quic.go`): after parsing the UnixNano timestamp, reject it unless it
  is within `momoHandshakeMaxSkew` (±15 min, matching the existing SigV4 skew
  window and tolerating multi-hop chain relays that forward the origin
  timestamp). Rejects stale, future, zero, and garbage timestamps with
  `EACCES`. Challenge-response branch untouched.
- **Client senders now send a fresh timestamp** instead of the fixed
  `DummyEpoch` sentinel or `0`:
  - `momo.go:110` (CLI `client`) `DummyEpoch` → `time.Now().UnixNano()`, which
    also fixes the relayed splay-peer handshake in `client.go:250`.
  - `client/oprf.go:38` `SendOPRFEval(..., 0, ...)` → fresh timestamp (mode
    `'O'` OPRF handshake is subject to the same gate).
  - Server-forwarded/`replication.go` handshakes already use fresh timestamps.
- **Tests updated** from fixed/stale handshake timestamps to fresh ones
  (`momo_tcp_test.go`, `factory_test.go` QUIC flows, `server_test.go`,
  `server_daemon_test.go`, `cas_integration_test.go`). `server_test.go`'s
  simplified daemon now keys primary/secondary off `comm.IsPeer()` (matching
  production) instead of the DummyEpoch timestamp.

### Security note
`DummyEpoch` remains as a sentinel for the **S3** external-client path
(`s3_communicator.go:1145`), which is a separate HTTP handshake not covered by
this momo plaintext gate; the S3 server overrides `finalTs` to `now` for
non-peer clients anyway.

### Testing
- `TestMomoTCPHandshakeTimestampFreshness`: fresh accepted; stale/future/zero
  rejected (`EACCES`).
- Full suite: `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work vendor`
  (Rule 25) clean.

### Docs
`docs/CONFIGURATION.md` `auth_token` description notes the ±15 min plaintext
freshness validation.

Resolves #657