### PR TITLE
fix: make replication semaphore acquire context-aware to prevent goroutine leak (#659)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3905,3 +3905,14 @@ a7dbb734,BenchmarkSanitizeLog/Unsafe-8,643.30,704.00,1.00
 2b0ec48f,BenchmarkPadString-8,37.64,64.00,1.00
 2b0ec48f,BenchmarkSanitizeLog/Safe-8,221.00,0.00,0.00
 2b0ec48f,BenchmarkSanitizeLog/Unsafe-8,633.80,704.00,1.00
+328c8f79,BenchmarkAWSChunkedReaderSigned-8,419399.00,158.70,11279.00
+328c8f79,BenchmarkAWSChunkedReaderUnsigned-8,392490.00,169.58,78559.00
+328c8f79,BenchmarkCheckMetricsAndSwap-8,7.15,0.00,0.00
+328c8f79,BenchmarkCrushOptimized-8,289.60,0.00,0.00
+328c8f79,BenchmarkCrushOriginal-8,392.10,164.00,3.00
+328c8f79,BenchmarkIndexDirectTracking-8,0.35,0.00,0.00
+328c8f79,BenchmarkIndexSearch-8,2.94,0.00,0.00
+328c8f79,BenchmarkLoadGlobalConfig-8,7727.00,1848.00,54.00
+328c8f79,BenchmarkPadString-8,39.28,64.00,1.00
+328c8f79,BenchmarkSanitizeLog/Safe-8,212.00,0.00,0.00
+328c8f79,BenchmarkSanitizeLog/Unsafe-8,643.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             423.4n ± ∞ ¹    386.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            300.9n ± ∞ ¹    316.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          7.976µ ± ∞ ¹    7.514µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 39.35n ± ∞ ¹    37.64n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          228.9n ± ∞ ¹    221.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        668.3n ± ∞ ¹    633.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    429.2µ ± ∞ ¹    404.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  403.2µ ± ∞ ¹    392.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       8.960n ± ∞ ¹    7.227n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.805n ± ∞ ¹    2.723n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3522n ± ∞ ¹   0.3240n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     349.1n          329.0n        -5.74%
+CrushOriginal-8                             386.5n ± ∞ ¹    392.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            316.1n ± ∞ ¹    289.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.514µ ± ∞ ¹    7.727µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 37.64n ± ∞ ¹    39.28n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          221.0n ± ∞ ¹    212.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        633.8n ± ∞ ¹    643.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    404.0µ ± ∞ ¹    419.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  392.4µ ± ∞ ¹    392.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.227n ± ∞ ¹    7.153n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.723n ± ∞ ¹    2.937n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3240n ± ∞ ¹   0.3492n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     329.0n          333.5n        +1.36%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,7 +62,7 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   147.9Mi ± ∞ ¹   157.1Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 157.4Mi ± ∞ ¹   161.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    152.6Mi         159.4Mi        +4.49%
+AWSChunkedReaderSigned-8                   157.1Mi ± ∞ ¹   151.3Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 161.8Mi ± ∞ ¹   161.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    159.4Mi         156.5Mi        -1.87%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 403967.00 ns/op | 164.77 B/op | 11273.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 392414.00 ns/op | 169.62 B/op | 78562.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.23 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 316.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 386.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.72 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7514.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 37.64 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 221.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 633.80 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 419399.00 ns/op | 158.70 B/op | 11279.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 392490.00 ns/op | 169.58 B/op | 78559.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.15 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 289.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 392.10 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.35 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.94 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7727.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 39.28 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 212.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 643.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48]
-    line "AWSChunkedReaderSigned" [418649,415373,403249,445617,408424,433346,418811,403588,429229,403967]
-    line "AWSChunkedReaderUnsigned" [424530,406436,393596,449617,408148,430389,404420,393243,403247,392414]
-    line "CheckMetricsAndSwap" [8,7,8,8,9,8,8,7,9,7]
-    line "CrushOptimized" [309,294,287,358,356,303,301,284,301,316]
-    line "CrushOriginal" [422,407,389,441,568,411,382,396,423,386]
+    x-axis [dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7]
+    line "AWSChunkedReaderSigned" [415373,403249,445617,408424,433346,418811,403588,429229,403967,419399]
+    line "AWSChunkedReaderUnsigned" [406436,393596,449617,408148,430389,404420,393243,403247,392414,392490]
+    line "CheckMetricsAndSwap" [7,8,8,9,8,8,7,9,7,7]
+    line "CrushOptimized" [294,287,358,356,303,301,284,301,316,290]
+    line "CrushOriginal" [407,389,441,568,411,382,396,423,386,392]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,1,1,2,2,2,3,3,3]
-    line "LoadGlobalConfig" [8319,7911,7590,8718,10767,8040,8190,7563,7976,7514]
-    line "PadString" [40,39,36,44,55,40,53,37,39,38]
+    line "IndexSearch" [2,1,1,2,2,2,3,3,3,3]
+    line "LoadGlobalConfig" [7911,7590,8718,10767,8040,8190,7563,7976,7514,7727]
+    line "PadString" [39,36,44,55,40,53,37,39,38,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [416,401,396,419,499,416,418,222,229,221]
-    line "SanitizeLog/Unsafe" [506,541,482,602,485,511,532,643,668,634]
+    line "SanitizeLog/Safe" [401,396,419,499,416,418,222,229,221,212]
+    line "SanitizeLog/Unsafe" [541,482,602,485,511,532,643,668,634,643]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48]
-    line "AWSChunkedReaderSigned" [159,160,165,149,163,154,159,165,155,165]
-    line "AWSChunkedReaderUnsigned" [157,164,169,148,163,155,165,169,165,170]
+    x-axis [dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7]
+    line "AWSChunkedReaderSigned" [160,165,149,163,154,159,165,155,165,159]
+    line "AWSChunkedReaderUnsigned" [164,169,148,163,155,165,169,165,170,170]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [7505017,dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48]
-    line "AWSChunkedReaderSigned" [11278,11271,11265,11282,11278,11284,11272,11270,11273,11273]
-    line "AWSChunkedReaderUnsigned" [78563,78564,78564,78577,78562,78561,78569,78563,78558,78562]
+    x-axis [dd91ed6,cd53459,b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7]
+    line "AWSChunkedReaderSigned" [11271,11265,11282,11278,11284,11272,11270,11273,11273,11279]
+    line "AWSChunkedReaderUnsigned" [78564,78564,78577,78562,78561,78569,78563,78558,78562,78559]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/replication.go
+++ b/src/server/replication.go
@@ -70,6 +70,19 @@ func SetReplicationState(newMode int, timestamp int64) common.ReplicationData {
 	return replicationState
 }
 
+// acquireConnectionSlot reserves a slot in the bounded concurrency semaphore.
+// It returns false without blocking if ctx is canceled before a slot frees up,
+// so a shutdown never leaves the accept loop stuck on a full semaphore
+// (issue #659). The caller must close/abandon any already-accepted connection.
+func acquireConnectionSlot(ctx context.Context, sem chan struct{}) bool {
+	select {
+	case sem <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // ChangeReplicationModeServer listens for connections on a dedicated port and updates the replication mode of the server.
 //
 // When a client connects, it sends a JSON object containing the new replication mode.
@@ -145,8 +158,13 @@ func ChangeReplicationModeServer(ctx context.Context, cfg common.Configuration, 
 			}
 		}
 
-		// Acquire semaphore slot before spinning up a new goroutine
-		sem <- struct{}{}
+		// Acquire semaphore slot before spinning up a new goroutine. Blocking
+		// without a ctx.Done() branch would leak this goroutine if the
+		// semaphore were full and the context canceled (issue #659).
+		if !acquireConnectionSlot(ctx, sem) {
+			connection.Close()
+			return nil // Shutting down gracefully
+		}
 
 		go func() {
 			defer func() { <-sem }() // Release semaphore slot when done

--- a/src/server/replication_test.go
+++ b/src/server/replication_test.go
@@ -3,6 +3,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"io"
@@ -289,5 +290,44 @@ func TestReleasePayloadOnlyReturnsFixedCapacity(t *testing.T) {
 		if c != payloadPoolCapacity {
 			t.Errorf("client put cap=%d (idx %d), want fixed %d", c, i, payloadPoolCapacity)
 		}
+	}
+}
+
+// TestAcquireConnectionSlot_ContextCancel verifies issue #659: acquiring a
+// semaphore slot must not block forever when the context is canceled and the
+// semaphore is full.
+func TestAcquireConnectionSlot_ContextCancel(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // fill the single slot
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool, 1)
+	go func() { done <- acquireConnectionSlot(ctx, sem) }()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("expected acquireConnectionSlot to return false on canceled context")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquireConnectionSlot blocked forever despite canceled context")
+	}
+}
+
+// TestAcquireConnectionSlot_Success verifies a free slot is acquired and
+// released correctly.
+func TestAcquireConnectionSlot_Success(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	ok := acquireConnectionSlot(context.Background(), sem)
+	if !ok {
+		t.Fatal("expected slot to be acquired when the semaphore is empty")
+	}
+	// Release so the test doesn't leak the slot.
+	select {
+	case <-sem:
+	default:
+		t.Fatal("expected acquired slot to be releasable")
 	}
 }


### PR DESCRIPTION
## Summary

```src/server/replication.go:149
sem <- struct{}{}
```

was a blocking send in the `ChangeReplicationModeServer` accept loop with no
`select` on `ctx.Done()`. If the 1000-slot semaphore were full, the accept loop
goroutine would block forever on this send even after the context was canceled,
leaking the goroutine (issue #659).

### Fix
- Extracted the acquire into a small, testable helper
  `acquireConnectionSlot(ctx, sem) bool` that uses
  `select { case sem <- struct{}{} ...; case <-ctx.Done(): return false }`.
- The accept loop calls it and, on cancellation, closes the just-accepted
  connection and returns nil (graceful shutdown). Slot release in the handler
  (`defer func() { <-sem }()`) is unchanged.

### Testing
- `TestAcquireConnectionSlot_ContextCancel`: fills the semaphore, cancels the
  context, and asserts the acquire returns promptly (no block) — directly
  covering the reported leak without spinning up 1000 live connections.
- `TestAcquireConnectionSlot_Success`: acquires/releases from an empty
  semaphore.
- `go build ./...`, `go test ./...` (15 pkgs), `go vet`, `gofmt`, `go work
  vendor` (Rule 25) clean.

Resolves #659