### PR TITLE
fix: cache os.Hostname() once instead of per metrics scrape

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3938,3 +3938,14 @@ ceb7e432,BenchmarkSanitizeLog/Unsafe-8,707.40,704.00,1.00
 911b55cf,BenchmarkPadString-8,38.86,64.00,1.00
 911b55cf,BenchmarkSanitizeLog/Safe-8,218.50,0.00,0.00
 911b55cf,BenchmarkSanitizeLog/Unsafe-8,1259.00,704.00,1.00
+e897bdb4,BenchmarkAWSChunkedReaderSigned-8,495010.00,134.46,11295.00
+e897bdb4,BenchmarkAWSChunkedReaderUnsigned-8,476646.00,139.64,78563.00
+e897bdb4,BenchmarkCheckMetricsAndSwap-8,10.49,0.00,0.00
+e897bdb4,BenchmarkCrushOptimized-8,352.70,0.00,0.00
+e897bdb4,BenchmarkCrushOriginal-8,534.60,164.00,3.00
+e897bdb4,BenchmarkIndexDirectTracking-8,0.42,0.00,0.00
+e897bdb4,BenchmarkIndexSearch-8,3.48,0.00,0.00
+e897bdb4,BenchmarkLoadGlobalConfig-8,9243.00,1848.00,54.00
+e897bdb4,BenchmarkPadString-8,46.31,64.00,1.00
+e897bdb4,BenchmarkSanitizeLog/Safe-8,262.10,0.00,0.00
+e897bdb4,BenchmarkSanitizeLog/Unsafe-8,758.90,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             539.4n ± ∞ ¹    406.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            430.0n ± ∞ ¹    319.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          9.958µ ± ∞ ¹    8.163µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 53.40n ± ∞ ¹    38.86n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          237.9n ± ∞ ¹    218.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        823.2n ± ∞ ¹   1259.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    501.7µ ± ∞ ¹    560.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  480.7µ ± ∞ ¹    559.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       10.39n ± ∞ ¹    11.87n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.794n ± ∞ ¹    3.134n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3362n ± ∞ ¹   0.4390n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     411.2n          412.0n        +0.19%
+CrushOriginal-8                             406.5n ± ∞ ¹    534.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            319.5n ± ∞ ¹    352.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.163µ ± ∞ ¹    9.243µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 38.86n ± ∞ ¹    46.31n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          218.5n ± ∞ ¹    262.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                       1259.0n ± ∞ ¹    758.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    560.4µ ± ∞ ¹    495.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  559.9µ ± ∞ ¹    476.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       11.87n ± ∞ ¹    10.49n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.134n ± ∞ ¹    3.484n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4390n ± ∞ ¹   0.4231n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     412.0n          412.3n        +0.08%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.76Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.76Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.01%               ⁴
+geomean                                                ⁴                  -0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   126.5Mi ± ∞ ¹   113.3Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 132.1Mi ± ∞ ¹   113.4Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    129.3Mi         113.3Mi        -12.33%
+AWSChunkedReaderSigned-8                   113.3Mi ± ∞ ¹   128.2Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 113.4Mi ± ∞ ¹   133.2Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    113.3Mi         130.7Mi        +15.32%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 560369.00 ns/op | 118.78 B/op | 11298.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 559938.00 ns/op | 118.87 B/op | 78598.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 11.87 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 319.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 406.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.13 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8163.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 38.86 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 218.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1259.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 495010.00 ns/op | 134.46 B/op | 11295.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 476646.00 ns/op | 139.64 B/op | 78563.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.49 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 352.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 534.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.42 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.48 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9243.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 46.31 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 262.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 758.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c]
-    line "AWSChunkedReaderSigned" [445617,408424,433346,418811,403588,429229,403967,419399,528932,560369]
-    line "AWSChunkedReaderUnsigned" [449617,408148,430389,404420,393243,403247,392414,392490,437150,559938]
-    line "CheckMetricsAndSwap" [8,9,8,8,7,9,7,7,9,12]
-    line "CrushOptimized" [358,356,303,301,284,301,316,290,369,320]
-    line "CrushOriginal" [441,568,411,382,396,423,386,392,431,406]
+    x-axis [1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb]
+    line "AWSChunkedReaderSigned" [408424,433346,418811,403588,429229,403967,419399,528932,560369,495010]
+    line "AWSChunkedReaderUnsigned" [408148,430389,404420,393243,403247,392414,392490,437150,559938,476646]
+    line "CheckMetricsAndSwap" [9,8,8,7,9,7,7,9,12,10]
+    line "CrushOptimized" [356,303,301,284,301,316,290,369,320,353]
+    line "CrushOriginal" [568,411,382,396,423,386,392,431,406,535]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [1,2,2,2,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [8718,10767,8040,8190,7563,7976,7514,7727,8630,8163]
-    line "PadString" [44,55,40,53,37,39,38,39,42,39]
+    line "IndexSearch" [2,2,2,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [10767,8040,8190,7563,7976,7514,7727,8630,8163,9243]
+    line "PadString" [55,40,53,37,39,38,39,42,39,46]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [419,499,416,418,222,229,221,212,221,218]
-    line "SanitizeLog/Unsafe" [602,485,511,532,643,668,634,643,707,1259]
+    line "SanitizeLog/Safe" [499,416,418,222,229,221,212,221,218,262]
+    line "SanitizeLog/Unsafe" [485,511,532,643,668,634,643,707,1259,759]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c]
-    line "AWSChunkedReaderSigned" [149,163,154,159,165,155,165,159,126,119]
-    line "AWSChunkedReaderUnsigned" [148,163,155,165,169,165,170,170,152,119]
+    x-axis [1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb]
+    line "AWSChunkedReaderSigned" [163,154,159,165,155,165,159,126,119,134]
+    line "AWSChunkedReaderUnsigned" [163,155,165,169,165,170,170,152,119,140]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [b825952,1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c]
-    line "AWSChunkedReaderSigned" [11282,11278,11284,11272,11270,11273,11273,11279,11281,11298]
-    line "AWSChunkedReaderUnsigned" [78577,78562,78561,78569,78563,78558,78562,78559,78557,78598]
+    x-axis [1623d7a,aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb]
+    line "AWSChunkedReaderSigned" [11278,11284,11272,11270,11273,11273,11279,11281,11298,11295]
+    line "AWSChunkedReaderUnsigned" [78562,78561,78569,78563,78558,78562,78559,78557,78598,78563]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/metrics_exporter.go
+++ b/src/server/metrics_exporter.go
@@ -25,12 +25,21 @@ type MetricsCollector struct {
 	bytesUploaded     atomic.Uint64
 	bytesDownloaded   atomic.Uint64
 	startTime         time.Time
+	hostname          string
 }
 
 // NewMetricsCollector creates a new MetricsCollector.
+// The process hostname is resolved once at construction and cached, so it is
+// not re-fetched via a syscall on every /metrics scrape.
 func NewMetricsCollector() *MetricsCollector {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+		log.Printf("AUDIT: os.Hostname() failed: %v", err)
+	}
 	return &MetricsCollector{
 		startTime: time.Now(),
+		hostname:  hostname,
 	}
 }
 
@@ -106,14 +115,9 @@ func (m *MetricsCollector) writeMetrics(w io.Writer) {
 	fmt.Fprintf(w, "# TYPE momo_gc_runs_total counter\n")
 	fmt.Fprintf(w, "momo_gc_runs_total %d\n", memStats.NumGC)
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "unknown"
-		log.Printf("AUDIT: os.Hostname() failed: %v", err)
-	}
 	fmt.Fprintf(w, "# HELP momo_build_info Build information.\n")
 	fmt.Fprintf(w, "# TYPE momo_build_info gauge\n")
-	fmt.Fprintf(w, "momo_build_info{hostname=\"%s\"} 1\n", hostname)
+	fmt.Fprintf(w, "momo_build_info{hostname=\"%s\"} 1\n", m.hostname)
 }
 
 func (m *MetricsCollector) handler(w http.ResponseWriter, r *http.Request) {

--- a/src/server/metrics_exporter_test.go
+++ b/src/server/metrics_exporter_test.go
@@ -62,6 +62,24 @@ func TestMetricsCollector_ZeroValue(t *testing.T) {
 	}
 }
 
+func TestMetricsCollector_HostnameCached(t *testing.T) {
+	mc := NewMetricsCollector()
+
+	if mc.hostname == "" {
+		t.Errorf("Expected cached hostname to be non-empty, got %q", mc.hostname)
+	}
+
+	out1 := captureMetricsOutput(mc)
+	out2 := captureMetricsOutput(mc)
+
+	want := `momo_build_info{hostname="` + mc.hostname + `"} 1`
+	for name, output := range map[string]string{"first": out1, "second": out2} {
+		if !strings.Contains(output, want) {
+			t.Errorf("Expected %s scrape to contain %q, got output:\n%s", name, want, output)
+		}
+	}
+}
+
 func captureMetricsOutput(mc *MetricsCollector) string {
 	var buf strings.Builder
 	mc.writeMetrics(&buf)


### PR DESCRIPTION
Resolves #661

## Summary
`MetricsCollector.writeMetrics` (re)invoked `os.Hostname()`, a blocking syscall, on **every** `/metrics` scrape. Fix caches the hostname once at construction time in `NewMetricsCollector`.

## Changes
- `src/server/metrics_exporter.go`: add `hostname` field to `MetricsCollector`; resolve via `os.Hostname()` once in `NewMetricsCollector` (fallback `"unknown"` + single AUDIT log on failure). `writeMetrics` now emits the cached value.
- `src/server/metrics_exporter_test.go`: add `TestMetricsCollector_HostnameCached` asserting cached hostname non-empty and stable across repeated scrapes.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `go work vendor` produces no diff (Rules 25, 65).

## Changelog
- v-next: metrics — resolve `os.Hostname()` once at startup instead of on every scrape.