### PR TITLE
fix: use securely auto-seeded math/rand/v2 for peer shuffle

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3960,3 +3960,14 @@ f387a04c,BenchmarkLoadGlobalConfig-8,10867.00,1848.00,54.00
 f387a04c,BenchmarkPadString-8,55.99,64.00,1.00
 f387a04c,BenchmarkSanitizeLog/Safe-8,255.10,0.00,0.00
 f387a04c,BenchmarkSanitizeLog/Unsafe-8,960.50,704.00,1.00
+8d767e8a,BenchmarkAWSChunkedReaderSigned-8,627798.00,106.02,11297.00
+8d767e8a,BenchmarkAWSChunkedReaderUnsigned-8,637979.00,104.33,78602.00
+8d767e8a,BenchmarkCheckMetricsAndSwap-8,10.48,0.00,0.00
+8d767e8a,BenchmarkCrushOptimized-8,535.70,0.00,0.00
+8d767e8a,BenchmarkCrushOriginal-8,629.50,164.00,3.00
+8d767e8a,BenchmarkIndexDirectTracking-8,0.50,0.00,0.00
+8d767e8a,BenchmarkIndexSearch-8,3.44,0.00,0.00
+8d767e8a,BenchmarkLoadGlobalConfig-8,11980.00,1848.00,54.00
+8d767e8a,BenchmarkPadString-8,62.53,64.00,1.00
+8d767e8a,BenchmarkSanitizeLog/Safe-8,335.60,0.00,0.00
+8d767e8a,BenchmarkSanitizeLog/Unsafe-8,1005.00,704.00,1.00

--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3971,3 +3971,14 @@ f387a04c,BenchmarkSanitizeLog/Unsafe-8,960.50,704.00,1.00
 8d767e8a,BenchmarkPadString-8,62.53,64.00,1.00
 8d767e8a,BenchmarkSanitizeLog/Safe-8,335.60,0.00,0.00
 8d767e8a,BenchmarkSanitizeLog/Unsafe-8,1005.00,704.00,1.00
+13cb3b42,BenchmarkAWSChunkedReaderSigned-8,438813.00,151.68,11272.00
+13cb3b42,BenchmarkAWSChunkedReaderUnsigned-8,417363.00,159.48,78562.00
+13cb3b42,BenchmarkCheckMetricsAndSwap-8,7.61,0.00,0.00
+13cb3b42,BenchmarkCrushOptimized-8,370.40,0.00,0.00
+13cb3b42,BenchmarkCrushOriginal-8,460.40,164.00,3.00
+13cb3b42,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+13cb3b42,BenchmarkIndexSearch-8,2.97,0.00,0.00
+13cb3b42,BenchmarkLoadGlobalConfig-8,7965.00,1848.00,54.00
+13cb3b42,BenchmarkPadString-8,38.96,64.00,1.00
+13cb3b42,BenchmarkSanitizeLog/Safe-8,233.90,0.00,0.00
+13cb3b42,BenchmarkSanitizeLog/Unsafe-8,654.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             558.1n ± ∞ ¹    629.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            417.4n ± ∞ ¹    535.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          10.87µ ± ∞ ¹    11.98µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 55.99n ± ∞ ¹    62.53n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          255.1n ± ∞ ¹    335.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        960.5n ± ∞ ¹   1005.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    559.6µ ± ∞ ¹    627.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  549.8µ ± ∞ ¹    638.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       10.32n ± ∞ ¹    10.48n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.965n ± ∞ ¹    3.440n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4118n ± ∞ ¹   0.4955n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     444.7n          510.2n        +14.72%
+CrushOriginal-8                             629.5n ± ∞ ¹    460.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            535.7n ± ∞ ¹    370.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                         11.980µ ± ∞ ¹    7.965µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 62.53n ± ∞ ¹    38.96n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          335.6n ± ∞ ¹    233.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                       1005.0n ± ∞ ¹    654.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    627.8µ ± ∞ ¹    438.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  638.0µ ± ∞ ¹    417.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      10.480n ± ∞ ¹    7.609n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               3.440n ± ∞ ¹    2.971n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4955n ± ∞ ¹   0.3582n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     510.2n          357.0n        -30.03%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.05Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.76Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.76Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.01%               ⁴
+geomean                                                ⁴                  -0.02%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   113.4Mi ± ∞ ¹   101.1Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                115.45Mi ± ∞ ¹   99.50Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    114.4Mi         100.3Mi        -12.35%
+                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
+                           │             B/s             │      B/s        vs base                 │
+AWSChunkedReaderSigned-8                   101.1Mi ± ∞ ¹    144.7Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 99.50Mi ± ∞ ¹   152.09Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    100.3Mi          148.3Mi        +47.88%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 627798.00 ns/op | 106.02 B/op | 11297.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 637979.00 ns/op | 104.33 B/op | 78602.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.48 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 535.70 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 629.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 3.44 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 11980.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 62.53 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 335.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 1005.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 438813.00 ns/op | 151.68 B/op | 11272.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 417363.00 ns/op | 159.48 B/op | 78562.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.61 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 370.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 460.40 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 7965.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 38.96 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 233.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 654.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8]
-    line "AWSChunkedReaderSigned" [418811,403588,429229,403967,419399,528932,560369,495010,559620,627798]
-    line "AWSChunkedReaderUnsigned" [404420,393243,403247,392414,392490,437150,559938,476646,549790,637979]
-    line "CheckMetricsAndSwap" [8,7,9,7,7,9,12,10,10,10]
-    line "CrushOptimized" [301,284,301,316,290,369,320,353,417,536]
-    line "CrushOriginal" [382,396,423,386,392,431,406,535,558,630]
+    x-axis [a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4]
+    line "AWSChunkedReaderSigned" [403588,429229,403967,419399,528932,560369,495010,559620,627798,438813]
+    line "AWSChunkedReaderUnsigned" [393243,403247,392414,392490,437150,559938,476646,549790,637979,417363]
+    line "CheckMetricsAndSwap" [7,9,7,7,9,12,10,10,10,8]
+    line "CrushOptimized" [284,301,316,290,369,320,353,417,536,370]
+    line "CrushOriginal" [396,423,386,392,431,406,535,558,630,460]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [8190,7563,7976,7514,7727,8630,8163,9243,10867,11980]
-    line "PadString" [53,37,39,38,39,42,39,46,56,63]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [7563,7976,7514,7727,8630,8163,9243,10867,11980,7965]
+    line "PadString" [37,39,38,39,42,39,46,56,63,39]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [418,222,229,221,212,221,218,262,255,336]
-    line "SanitizeLog/Unsafe" [532,643,668,634,643,707,1259,759,960,1005]
+    line "SanitizeLog/Safe" [222,229,221,212,221,218,262,255,336,234]
+    line "SanitizeLog/Unsafe" [643,668,634,643,707,1259,759,960,1005,654]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8]
-    line "AWSChunkedReaderSigned" [159,165,155,165,159,126,119,134,119,106]
-    line "AWSChunkedReaderUnsigned" [165,169,165,170,170,152,119,140,121,104]
+    x-axis [a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4]
+    line "AWSChunkedReaderSigned" [165,155,165,159,126,119,134,119,106,152]
+    line "AWSChunkedReaderUnsigned" [169,165,170,170,152,119,140,121,104,159]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8]
-    line "AWSChunkedReaderSigned" [11272,11270,11273,11273,11279,11281,11298,11295,11317,11297]
-    line "AWSChunkedReaderUnsigned" [78569,78563,78558,78562,78559,78557,78598,78563,78578,78602]
+    x-axis [a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4]
+    line "AWSChunkedReaderSigned" [11270,11273,11273,11279,11281,11298,11295,11317,11297,11272]
+    line "AWSChunkedReaderUnsigned" [78563,78558,78562,78559,78557,78598,78563,78578,78602,78562]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
-                           │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             534.6n ± ∞ ¹    558.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            352.7n ± ∞ ¹    417.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          9.243µ ± ∞ ¹   10.867µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 46.31n ± ∞ ¹    55.99n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          262.1n ± ∞ ¹    255.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        758.9n ± ∞ ¹    960.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    495.0µ ± ∞ ¹    559.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  476.6µ ± ∞ ¹    549.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       10.49n ± ∞ ¹    10.32n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.484n ± ∞ ¹    2.965n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4231n ± ∞ ¹   0.4118n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     412.3n          444.7n        +7.86%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
+                           │           sec/op            │    sec/op      vs base                 │
+CrushOriginal-8                             558.1n ± ∞ ¹    629.5n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            417.4n ± ∞ ¹    535.7n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          10.87µ ± ∞ ¹    11.98µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 55.99n ± ∞ ¹    62.53n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          255.1n ± ∞ ¹    335.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        960.5n ± ∞ ¹   1005.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    559.6µ ± ∞ ¹    627.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  549.8µ ± ∞ ¹    638.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       10.32n ± ∞ ¹    10.48n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.965n ± ∞ ¹    3.440n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4118n ± ∞ ¹   0.4955n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     444.7n          510.2n        +14.72%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.05Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.05Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.76Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.02%               ⁴
+geomean                                                ⁴                  -0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   128.2Mi ± ∞ ¹   113.4Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 133.2Mi ± ∞ ¹   115.5Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    130.7Mi         114.4Mi        -12.43%
+AWSChunkedReaderSigned-8                   113.4Mi ± ∞ ¹   101.1Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                115.45Mi ± ∞ ¹   99.50Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                    114.4Mi         100.3Mi        -12.35%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 559620.00 ns/op | 118.94 B/op | 11317.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 549790.00 ns/op | 121.06 B/op | 78578.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 10.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 417.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 558.10 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.41 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.96 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 10867.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 55.99 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 255.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 960.50 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 627798.00 ns/op | 106.02 B/op | 11297.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 637979.00 ns/op | 104.33 B/op | 78602.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 10.48 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 535.70 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 629.50 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.50 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 3.44 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 11980.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 62.53 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 335.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 1005.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04]
-    line "AWSChunkedReaderSigned" [433346,418811,403588,429229,403967,419399,528932,560369,495010,559620]
-    line "AWSChunkedReaderUnsigned" [430389,404420,393243,403247,392414,392490,437150,559938,476646,549790]
-    line "CheckMetricsAndSwap" [8,8,7,9,7,7,9,12,10,10]
-    line "CrushOptimized" [303,301,284,301,316,290,369,320,353,417]
-    line "CrushOriginal" [411,382,396,423,386,392,431,406,535,558]
+    x-axis [0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8]
+    line "AWSChunkedReaderSigned" [418811,403588,429229,403967,419399,528932,560369,495010,559620,627798]
+    line "AWSChunkedReaderUnsigned" [404420,393243,403247,392414,392490,437150,559938,476646,549790,637979]
+    line "CheckMetricsAndSwap" [8,7,9,7,7,9,12,10,10,10]
+    line "CrushOptimized" [301,284,301,316,290,369,320,353,417,536]
+    line "CrushOriginal" [382,396,423,386,392,431,406,535,558,630]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [2,2,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [8040,8190,7563,7976,7514,7727,8630,8163,9243,10867]
-    line "PadString" [40,53,37,39,38,39,42,39,46,56]
+    line "IndexSearch" [2,3,3,3,3,3,3,3,3,3]
+    line "LoadGlobalConfig" [8190,7563,7976,7514,7727,8630,8163,9243,10867,11980]
+    line "PadString" [53,37,39,38,39,42,39,46,56,63]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [416,418,222,229,221,212,221,218,262,255]
-    line "SanitizeLog/Unsafe" [511,532,643,668,634,643,707,1259,759,960]
+    line "SanitizeLog/Safe" [418,222,229,221,212,221,218,262,255,336]
+    line "SanitizeLog/Unsafe" [532,643,668,634,643,707,1259,759,960,1005]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04]
-    line "AWSChunkedReaderSigned" [154,159,165,155,165,159,126,119,134,119]
-    line "AWSChunkedReaderUnsigned" [155,165,169,165,170,170,152,119,140,121]
+    x-axis [0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8]
+    line "AWSChunkedReaderSigned" [159,165,155,165,159,126,119,134,119,106]
+    line "AWSChunkedReaderUnsigned" [165,169,165,170,170,152,119,140,121,104]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [aba2e7e,0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04]
-    line "AWSChunkedReaderSigned" [11284,11272,11270,11273,11273,11279,11281,11298,11295,11317]
-    line "AWSChunkedReaderUnsigned" [78561,78569,78563,78558,78562,78559,78557,78598,78563,78578]
+    x-axis [0f5fff9,a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8]
+    line "AWSChunkedReaderSigned" [11272,11270,11273,11273,11279,11281,11298,11295,11317,11297]
+    line "AWSChunkedReaderUnsigned" [78569,78563,78558,78562,78559,78557,78598,78563,78578,78602]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/p2p/peer_map.go
+++ b/src/p2p/peer_map.go
@@ -1,22 +1,41 @@
 package p2p
 
 import (
-	"math/rand/v2"
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
 	"sort"
 	"sync"
+	"time"
 )
 
 // PeerMap is a thread-safe map of peers keyed by peer ID.
 type PeerMap struct {
 	mu    sync.RWMutex
 	peers map[int32]*Peer
+	rng   *rand.Rand
 }
 
 // NewPeerMap creates a new empty PeerMap.
 func NewPeerMap() *PeerMap {
 	return &PeerMap{
 		peers: make(map[int32]*Peer),
+		rng:   newSecureRand(),
 	}
+}
+
+// newSecureRand returns a per-instance rand.Rand seeded from crypto/rand.
+// The prior seed (time.Now().UnixNano()) was predictable; a per-instance RNG
+// seeded securely preserves node-local isolation without shared global state.
+func newSecureRand() *rand.Rand {
+	var seedBytes [8]byte
+	if _, err := crand.Read(seedBytes[:]); err != nil {
+		// crypto/rand almost never fails; fall back to a time-based seed rather
+		// than panic (Zero-Crash Pattern). Still per-instance and mutex-guarded.
+		return rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+	seed := int64(binary.LittleEndian.Uint64(seedBytes[:]))
+	return rand.New(rand.NewSource(seed))
 }
 
 // Add adds or replaces a peer in the map.
@@ -129,7 +148,7 @@ func (m *PeerMap) RandomPeers(k int, excludeID int32) []*Peer {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	rand.Shuffle(len(alive), func(i, j int) {
+	m.rng.Shuffle(len(alive), func(i, j int) {
 		alive[i], alive[j] = alive[j], alive[i]
 	})
 

--- a/src/p2p/peer_map.go
+++ b/src/p2p/peer_map.go
@@ -1,24 +1,21 @@
 package p2p
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync"
-	"time"
 )
 
 // PeerMap is a thread-safe map of peers keyed by peer ID.
 type PeerMap struct {
 	mu    sync.RWMutex
 	peers map[int32]*Peer
-	rng   *rand.Rand
 }
 
 // NewPeerMap creates a new empty PeerMap.
 func NewPeerMap() *PeerMap {
 	return &PeerMap{
 		peers: make(map[int32]*Peer),
-		rng:   rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -132,7 +129,7 @@ func (m *PeerMap) RandomPeers(k int, excludeID int32) []*Peer {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.rng.Shuffle(len(alive), func(i, j int) {
+	rand.Shuffle(len(alive), func(i, j int) {
 		alive[i], alive[j] = alive[j], alive[i]
 	})
 

--- a/src/p2p/peer_map_test.go
+++ b/src/p2p/peer_map_test.go
@@ -156,6 +156,22 @@ func TestPeerMap_AliveCount(t *testing.T) {
 	}
 }
 
+func TestPeerMap_RngInitialized(t *testing.T) {
+	// The per-instance RNG is the concurrency-safe selection source; ensure it
+	// is always constructed (never nil) and distinct per PeerMap instance.
+	a := NewPeerMap()
+	b := NewPeerMap()
+	if a.rng == nil {
+		t.Fatal("expected PeerMap a to have an initialized rng")
+	}
+	if b.rng == nil {
+		t.Fatal("expected PeerMap b to have an initialized rng")
+	}
+	if a.rng == b.rng {
+		t.Fatal("expected independent rng instances per PeerMap")
+	}
+}
+
 func TestPeerMap_RandomPeers(t *testing.T) {
 	m := NewPeerMap()
 	for i := int32(1); i <= 10; i++ {


### PR DESCRIPTION
Resolves #663

## Summary
`PeerMap.rng` was seeded with `time.Now().UnixNano()`, which is predictable: an attacker who knows approximate process start time can predict random peer selection (`RandomPeers`). Seeded the per-instance RNG securely from `crypto/rand` at construction, preserving node-local isolation and the existing mutex-guarded concurrency model.

## Changes
- `src/p2p/peer_map.go`: new `newSecureRand()` seeds `*rand.Rand` from `crypto/rand` (fallback to time-based seed on crypto failure per Zero-Crash Pattern). `rng` stays per-instance, used only under `PeerMap.mu`.
- `src/p2p/peer_map_test.go`: add `TestPeerMap_RngInitialized` asserting non-nil + independent RNG per instance.

> Note: initial revision used global `math/rand/v2`; reverted per reviewer (shared global state / contention) to a securely-seeded per-instance RNG.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `GOARCH=386 go build ./src/p2p/...` passes.
- `go work vendor` no diff (Rules 25, 65).

## Changelog
- v-next: p2p — replace predictable `time.Now()`-seeded RNG with `crypto/rand`-seeded per-instance RNG for peer selection.