### PR TITLE
test: close freeAddr TOCTOU race via pre-bound listeners

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -3982,3 +3982,14 @@ f387a04c,BenchmarkSanitizeLog/Unsafe-8,960.50,704.00,1.00
 13cb3b42,BenchmarkPadString-8,38.96,64.00,1.00
 13cb3b42,BenchmarkSanitizeLog/Safe-8,233.90,0.00,0.00
 13cb3b42,BenchmarkSanitizeLog/Unsafe-8,654.00,704.00,1.00
+752f4444,BenchmarkAWSChunkedReaderSigned-8,462513.00,143.91,11275.00
+752f4444,BenchmarkAWSChunkedReaderUnsigned-8,448517.00,148.40,78568.00
+752f4444,BenchmarkCheckMetricsAndSwap-8,8.63,0.00,0.00
+752f4444,BenchmarkCrushOptimized-8,423.90,0.00,0.00
+752f4444,BenchmarkCrushOriginal-8,604.90,164.00,3.00
+752f4444,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+752f4444,BenchmarkIndexSearch-8,2.80,0.00,0.00
+752f4444,BenchmarkLoadGlobalConfig-8,8740.00,1848.00,54.00
+752f4444,BenchmarkPadString-8,41.89,64.00,1.00
+752f4444,BenchmarkSanitizeLog/Safe-8,225.10,0.00,0.00
+752f4444,BenchmarkSanitizeLog/Unsafe-8,741.30,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,20 +37,20 @@ Each table compares the previous commit (left) to the current commit (right).
 - **allocs/op**: Number of heap allocations per operation. Measures GC pressure.
 
 ```
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             629.5n ± ∞ ¹    460.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            535.7n ± ∞ ¹    370.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                         11.980µ ± ∞ ¹    7.965µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 62.53n ± ∞ ¹    38.96n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          335.6n ± ∞ ¹    233.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                       1005.0n ± ∞ ¹    654.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    627.8µ ± ∞ ¹    438.8µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  638.0µ ± ∞ ¹    417.4µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                      10.480n ± ∞ ¹    7.609n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               3.440n ± ∞ ¹    2.971n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4955n ± ∞ ¹   0.3582n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     510.2n          357.0n        -30.03%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │           sec/op            │    sec/op      vs base                │
+CrushOriginal-8                             460.4n ± ∞ ¹    604.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            370.4n ± ∞ ¹    423.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.965µ ± ∞ ¹    8.740µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 38.96n ± ∞ ¹    41.89n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          233.9n ± ∞ ¹    225.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        654.0n ± ∞ ¹    741.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    438.8µ ± ∞ ¹    462.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  417.4µ ± ∞ ¹    448.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.609n ± ∞ ¹    8.634n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.971n ± ∞ ¹    2.804n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3582n ± ∞ ¹   0.3732n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     357.0n          387.2n        +8.47%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.76Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.02%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │       /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s        vs base                 │
-AWSChunkedReaderSigned-8                   101.1Mi ± ∞ ¹    144.7Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 99.50Mi ± ∞ ¹   152.09Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    100.3Mi          148.3Mi        +47.88%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │             B/s             │      B/s       vs base                │
+AWSChunkedReaderSigned-8                   144.7Mi ± ∞ ¹   137.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 152.1Mi ± ∞ ¹   141.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    148.3Mi         139.4Mi        -6.04%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 438813.00 ns/op | 151.68 B/op | 11272.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 417363.00 ns/op | 159.48 B/op | 78562.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.61 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 370.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 460.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.97 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7965.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 38.96 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 233.90 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 654.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 462513.00 ns/op | 143.91 B/op | 11275.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 448517.00 ns/op | 148.40 B/op | 78568.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 8.63 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 423.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 604.90 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.80 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8740.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 41.89 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 225.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 741.30 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4]
-    line "AWSChunkedReaderSigned" [403588,429229,403967,419399,528932,560369,495010,559620,627798,438813]
-    line "AWSChunkedReaderUnsigned" [393243,403247,392414,392490,437150,559938,476646,549790,637979,417363]
-    line "CheckMetricsAndSwap" [7,9,7,7,9,12,10,10,10,8]
-    line "CrushOptimized" [284,301,316,290,369,320,353,417,536,370]
-    line "CrushOriginal" [396,423,386,392,431,406,535,558,630,460]
+    x-axis [380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444]
+    line "AWSChunkedReaderSigned" [429229,403967,419399,528932,560369,495010,559620,627798,438813,462513]
+    line "AWSChunkedReaderUnsigned" [403247,392414,392490,437150,559938,476646,549790,637979,417363,448517]
+    line "CheckMetricsAndSwap" [9,7,7,9,12,10,10,10,8,9]
+    line "CrushOptimized" [301,316,290,369,320,353,417,536,370,424]
+    line "CrushOriginal" [423,386,392,431,406,535,558,630,460,605]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [7563,7976,7514,7727,8630,8163,9243,10867,11980,7965]
-    line "PadString" [37,39,38,39,42,39,46,56,63,39]
+    line "LoadGlobalConfig" [7976,7514,7727,8630,8163,9243,10867,11980,7965,8740]
+    line "PadString" [39,38,39,42,39,46,56,63,39,42]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [222,229,221,212,221,218,262,255,336,234]
-    line "SanitizeLog/Unsafe" [643,668,634,643,707,1259,759,960,1005,654]
+    line "SanitizeLog/Safe" [229,221,212,221,218,262,255,336,234,225]
+    line "SanitizeLog/Unsafe" [668,634,643,707,1259,759,960,1005,654,741]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4]
-    line "AWSChunkedReaderSigned" [165,155,165,159,126,119,134,119,106,152]
-    line "AWSChunkedReaderUnsigned" [169,165,170,170,152,119,140,121,104,159]
+    x-axis [380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444]
+    line "AWSChunkedReaderSigned" [155,165,159,126,119,134,119,106,152,144]
+    line "AWSChunkedReaderUnsigned" [165,170,170,152,119,140,121,104,159,148]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [a7dbb73,380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4]
-    line "AWSChunkedReaderSigned" [11270,11273,11273,11279,11281,11298,11295,11317,11297,11272]
-    line "AWSChunkedReaderUnsigned" [78563,78558,78562,78559,78557,78598,78563,78578,78602,78562]
+    x-axis [380ee51,2b0ec48,328c8f7,ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444]
+    line "AWSChunkedReaderSigned" [11273,11273,11279,11281,11298,11295,11317,11297,11272,11275]
+    line "AWSChunkedReaderUnsigned" [78558,78562,78559,78557,78598,78563,78578,78602,78562,78568]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/src/server/server_daemon_test.go
+++ b/src/server/server_daemon_test.go
@@ -33,6 +33,19 @@ func freeAddr(t *testing.T) string {
 	return addr
 }
 
+// freeAddrListener binds an ephemeral loopback port and returns the still-open
+// listener, reserving its address. Unlike freeAddr, the port is never released,
+// closing the TOCTOU window where another process could rebind it between the
+// free and the caller's own net.Listen (see #846).
+func freeAddrListener(t *testing.T) net.Listener {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to get free listener: %v", err)
+	}
+	return l
+}
+
 func acceptReplication(l net.Listener) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -85,9 +98,20 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 		goleak.IgnoreAnyFunction("github.com/quic-go/quic-go.(*sendQueue).Run"),
 	)
 
-	addr0 := freeAddr(t)
-	addr1 := freeAddr(t)
-	addr2 := freeAddr(t)
+	addr0 := freeAddr(t) // bound by ChangeReplicationModeServer below
+
+	// Pre-bind the peer change-replication ports with open listeners so the
+	// address is never released between selection and use (eliminates #846's
+	// TOCTOU port-rebind race).
+	l1 := freeAddrListener(t)
+	defer l1.Close()
+	addr1 := l1.Addr().String()
+	go acceptReplication(l1)
+
+	l2 := freeAddrListener(t)
+	defer l2.Close()
+	addr2 := l2.Addr().String()
+	go acceptReplication(l2)
 
 	daemons := []*common.Daemon{
 		{ChangeReplication: addr0},
@@ -105,20 +129,6 @@ func TestChangeReplicationModeServerReal(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	l1, err := net.Listen("tcp", addr1)
-	if err != nil {
-		t.Fatalf("failed to listen on %s: %v", addr1, err)
-	}
-	defer l1.Close()
-	go acceptReplication(l1)
-
-	l2, err := net.Listen("tcp", addr2)
-	if err != nil {
-		t.Fatalf("failed to listen on %s: %v", addr2, err)
-	}
-	defer l2.Close()
-	go acceptReplication(l2)
 
 	go ChangeReplicationModeServer(ctx, cfg, 0, time.Now().UnixNano())
 


### PR DESCRIPTION
Resolves #846

## Summary
`TestChangeReplicationModeServerReal` (and any caller) used `freeAddr(t)`, which binds `127.0.0.1:0`, records the port, then **closes** the listener — releasing the port. Between that release and the caller's own `net.Listen`, another process/test (the Go CI job runs a second `go test -race -cover` pass) can bind the same port → `bind: address already in use`.

## Changes
- `src/server/server_daemon_test.go`: add `freeAddrListener(t)` returning a **still-open** listener (port never released). Refactor `TestChangeReplicationModeServerReal` to pre-bind the two peer change-replication ports (`addr1`/\`addr2`) via these held-open listeners, closing the TOCTOU window. `addr0` remains via `freeAddr` since it is bound internally by `ChangeReplicationModeServer`.

## Testing
- `go test ./src/server/... -run TestChangeReplicationModeServerReal -count=10`, and `-race -count=5` all pass.
- Full tree: `go build/vet/test ./...` green; `go work vendor` no diff (Rules 25, 65).

## Changelog
- v-next: tests — eliminate freeAddr port-rebind TOCTOU in `TestChangeReplicationModeServerReal` (#846).