### PR TITLE
spec: core-integrity-verification change proposal (issue #903)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -4026,3 +4026,14 @@ f664e80a,BenchmarkLoadGlobalConfig-8,7608.00,1848.00,54.00
 f664e80a,BenchmarkPadString-8,38.76,64.00,1.00
 f664e80a,BenchmarkSanitizeLog/Safe-8,224.00,0.00,0.00
 f664e80a,BenchmarkSanitizeLog/Unsafe-8,650.40,704.00,1.00
+2435361a,BenchmarkAWSChunkedReaderSigned-8,445480.00,149.41,11271.00
+2435361a,BenchmarkAWSChunkedReaderUnsigned-8,429616.00,154.93,78567.00
+2435361a,BenchmarkCheckMetricsAndSwap-8,9.57,0.00,0.00
+2435361a,BenchmarkCrushOptimized-8,312.40,0.00,0.00
+2435361a,BenchmarkCrushOriginal-8,424.60,164.00,3.00
+2435361a,BenchmarkIndexDirectTracking-8,0.36,0.00,0.00
+2435361a,BenchmarkIndexSearch-8,2.82,0.00,0.00
+2435361a,BenchmarkLoadGlobalConfig-8,8334.00,1848.00,54.00
+2435361a,BenchmarkPadString-8,48.20,64.00,1.00
+2435361a,BenchmarkSanitizeLog/Safe-8,276.20,0.00,0.00
+2435361a,BenchmarkSanitizeLog/Unsafe-8,671.40,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
                            │           sec/op            │    sec/op      vs base                 │
-CrushOriginal-8                             473.9n ± ∞ ¹    395.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-CrushOptimized-8                            313.3n ± ∞ ¹    299.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          9.546µ ± ∞ ¹    7.608µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-PadString-8                                 48.56n ± ∞ ¹    38.76n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          239.7n ± ∞ ¹    224.0n ± ∞ ¹        ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        860.8n ± ∞ ¹    650.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    490.0µ ± ∞ ¹    418.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  502.8µ ± ∞ ¹    400.2µ ± ∞ ¹        ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       9.935n ± ∞ ¹    7.404n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.968n ± ∞ ¹    2.756n ± ∞ ¹        ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.4654n ± ∞ ¹   0.3233n ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                     404.9n          333.2n        -17.71%
+CrushOriginal-8                             395.4n ± ∞ ¹    424.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
+CrushOptimized-8                            299.8n ± ∞ ¹    312.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          7.608µ ± ∞ ¹    8.334µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+PadString-8                                 38.76n ± ∞ ¹    48.20n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          224.0n ± ∞ ¹    276.2n ± ∞ ¹        ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        650.4n ± ∞ ¹    671.4n ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    418.1µ ± ∞ ¹    445.5µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  400.2µ ± ∞ ¹    429.6µ ± ∞ ¹        ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.404n ± ∞ ¹    9.572n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexSearch-8                               2.756n ± ∞ ¹    2.822n ± ∞ ¹        ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3233n ± ∞ ¹   0.3618n ± ∞ ¹        ~ (p=1.000 n=1) ²
+geomean                                     333.2n          371.3n        +11.43%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.04Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.74Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.01Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.03%               ⁴
+geomean                                                ⁴                  +0.00%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -91,11 +91,11 @@ geomean                                                ³                +0.00% 
 ² all samples are equal
 ³ summaries must be >0 to compute geomean
 
-                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt       │
-                           │             B/s             │      B/s       vs base                 │
-AWSChunkedReaderSigned-8                   129.5Mi ± ∞ ¹   151.8Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 126.3Mi ± ∞ ¹   158.6Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
-geomean                                    127.9Mi         155.2Mi        +21.34%
+                           │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
+                           │             B/s             │      B/s       vs base                │
+AWSChunkedReaderSigned-8                   151.8Mi ± ∞ ¹   142.5Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 158.6Mi ± ∞ ¹   147.8Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    155.2Mi         145.1Mi        -6.50%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 418132.00 ns/op | 159.18 B/op | 11270.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 400163.00 ns/op | 166.33 B/op | 78560.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 299.80 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 395.40 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.32 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 2.76 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 7608.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 38.76 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 224.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 650.40 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 445480.00 ns/op | 149.41 B/op | 11271.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 429616.00 ns/op | 154.93 B/op | 78567.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 9.57 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 312.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 424.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.36 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 2.82 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8334.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 48.20 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 276.20 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 671.40 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444,cb26eec,1facfff,f664e80]
-    line "AWSChunkedReaderSigned" [528932,560369,495010,559620,627798,438813,462513,460953,489981,418132]
-    line "AWSChunkedReaderUnsigned" [437150,559938,476646,549790,637979,417363,448517,448767,502752,400163]
-    line "CheckMetricsAndSwap" [9,12,10,10,10,8,9,9,10,7]
-    line "CrushOptimized" [369,320,353,417,536,370,424,329,313,300]
-    line "CrushOriginal" [431,406,535,558,630,460,605,462,474,395]
+    x-axis [911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444,cb26eec,1facfff,f664e80,2435361]
+    line "AWSChunkedReaderSigned" [560369,495010,559620,627798,438813,462513,460953,489981,418132,445480]
+    line "AWSChunkedReaderUnsigned" [559938,476646,549790,637979,417363,448517,448767,502752,400163,429616]
+    line "CheckMetricsAndSwap" [12,10,10,10,8,9,9,10,7,10]
+    line "CrushOptimized" [320,353,417,536,370,424,329,313,300,312]
+    line "CrushOriginal" [406,535,558,630,460,605,462,474,395,425]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
     line "IndexSearch" [3,3,3,3,3,3,3,3,3,3]
-    line "LoadGlobalConfig" [8630,8163,9243,10867,11980,7965,8740,9209,9546,7608]
-    line "PadString" [42,39,46,56,63,39,42,51,49,39]
+    line "LoadGlobalConfig" [8163,9243,10867,11980,7965,8740,9209,9546,7608,8334]
+    line "PadString" [39,46,56,63,39,42,51,49,39,48]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [221,218,262,255,336,234,225,309,240,224]
-    line "SanitizeLog/Unsafe" [707,1259,759,960,1005,654,741,781,861,650]
+    line "SanitizeLog/Safe" [218,262,255,336,234,225,309,240,224,276]
+    line "SanitizeLog/Unsafe" [1259,759,960,1005,654,741,781,861,650,671]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444,cb26eec,1facfff,f664e80]
-    line "AWSChunkedReaderSigned" [126,119,134,119,106,152,144,144,136,159]
-    line "AWSChunkedReaderUnsigned" [152,119,140,121,104,159,148,148,132,166]
+    x-axis [911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444,cb26eec,1facfff,f664e80,2435361]
+    line "AWSChunkedReaderSigned" [119,134,119,106,152,144,144,136,159,149]
+    line "AWSChunkedReaderUnsigned" [119,140,121,104,159,148,148,132,166,155]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [ceb7e43,911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444,cb26eec,1facfff,f664e80]
-    line "AWSChunkedReaderSigned" [11281,11298,11295,11317,11297,11272,11275,11298,11308,11270]
-    line "AWSChunkedReaderUnsigned" [78557,78598,78563,78578,78602,78562,78568,78562,78579,78560]
+    x-axis [911b55c,e897bdb,f387a04,8d767e8,13cb3b4,752f444,cb26eec,1facfff,f664e80,2435361]
+    line "AWSChunkedReaderSigned" [11298,11295,11317,11297,11272,11275,11298,11308,11270,11271]
+    line "AWSChunkedReaderUnsigned" [78598,78563,78578,78602,78562,78568,78562,78579,78560,78567]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/openspec/changes/core-integrity-verification/proposal.md
+++ b/openspec/changes/core-integrity-verification/proposal.md
@@ -1,0 +1,59 @@
+# Change: Core Integrity Verification (protocol-agnostic)
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/903
+
+## Why
+Integrity today is split across layers with inconsistent reach. `Hash` (SHA-256)
+is the authoritative content-address and is verified in the shared `getFile`
+ingest path for every surface — protocol-agnostic and correct. But additive
+`x-amz-checksum-*` verification lives in the S3 surface adapter
+(`transport.ChecksumFinalizer`), and SIP-verified digests are not re-checked at
+replication hops or on retrieval. To make integrity a first-class property of
+the **storage/ingest core** — independent of which client protocol delivers
+bytes (commodity protocol, no lock-in) — we need a protocol-agnostic integrity
+contract and a central verifier. Any new surface then inherits identical
+guarantees without touching shared logic.
+
+## What Changes
+- **Add a protocol-agnostic integrity contract** to `common.FileMetadata`:
+  additive `Checksums []ChecksumRef{Algo, Value}`, layered on the authoritative
+  SHA-256 `Hash` (content-address unchanged; additive only).
+- **Centralize verification at the store/ingest layer**, so all surfaces
+  (s3-*, momo-tcp, momo-quic) verify identically; every replication hop
+  re-verifies on receive; retrieval (`store.Get`) can detect stale/bit-rot.
+- **Surfaces become adapters**: S3 `x-amz-checksum-*` maps into `ChecksumRef`;
+  the S3-specific parse/arm/finalize mechanism (`parseChecksum`,
+  `FinalizeIntegrityChecksum`) moves into the adapter and out of shared logic.
+- **Reuse the `ChecksumFinalizer` seam** introduced by #902 as the extension
+  point, generalizing it beyond S3.
+- Verification runs only when a client supplies a checksum (inert otherwise) —
+  no double-hash on the common path.
+
+## Additive-only wire/metadata
+The fixed momo wire framing fields (`Name`/`Hash`/`Size`/`RemotePath`/`ModTime`)
+remain authoritative and unchanged. `S3Headers`/`Checksums` are additive extras
+carried between peers only by the existing optional `X-Momo-S3-Meta` header;
+peers that ignore extras store/echo nothing and are unaffected.
+
+## Non-Goals
+- Changing the dedup content-address: SHA-256 `Hash` stays the address;
+  checksums are never independently addressable.
+- Any breaking protocol change or storage-schema rewrite.
+- Per-`UploadPart` per-part checksums (final assembled checksum verification only).
+- Enabled-by-default re-verification on every `store.Get` in all deployments
+  (opt-in bit-rot checking only, to avoid perf regression).
+
+## Scope
+Standalone integrity-architecture item (issue #903). Independent of the #820
+umbrella (P1/P3/P4/P5 tiers are tracked separately). Depends on #902 (P2
+checksums merged), which provides the `ChecksumFinalizer` extension point.
+
+## Impacted areas
+- `common/struct.go` (`FileMetadata`: `Checksums` field), `common` marshaling.
+- `storage/storage.go` CAS store: optional verifier call on `Put`/`Get`;
+  sidecar persistence of `Checksums`.
+- `server/file.go` (`getFile`): invoke the generic verifier.
+- `transport/communicator.go` (`ChecksumFinalizer` seam), `transport/s3_communicator.go`
+  (adapter mapping `x-amz-checksum-*` → `ChecksumRef`).
+- `docs/COMPATIBILITY.md`, `docs/ARCHITECTURE.md` parity updates.
+- Tests: surface adapters, ingest verifier, replication re-verify, bit-rot `Get`.

--- a/openspec/changes/core-integrity-verification/specs/core-integrity-verification/spec.md
+++ b/openspec/changes/core-integrity-verification/specs/core-integrity-verification/spec.md
@@ -1,0 +1,70 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/903
+
+# core-integrity-verification Specification
+
+## Purpose
+Make integrity verification a property of the **storage/ingest core**, not of any
+surface protocol. Add a protocol-agnostic additive checksum contract to
+`FileMetadata`, centralize verification so every ingress and replication hop
+gets the same guarantee, and demote surfaces (s3-*, momo-tcp, momo-quic) to pure
+adapters that map their client protocols onto the core contract. This removes
+protocol lock-in and lets any future surface inherit integrity unchanged.
+
+## ADDED Requirements
+
+### Requirement: protocol-agnostic integrity contract
+The system SHALL model additive integrity digests in `common.FileMetadata` as a
+list of `ChecksumRef{Algo, Value}` alongside the authoritative SHA-256 `Hash`.
+`Hash` SHALL remain the sole content-addressable identifier; `Checksums` are
+additive and MUST NOT be independently addressable.
+
+#### Scenario: carry a checksum additively
+- **GIVEN** an object stored with an additive checksum and valid auth
+- **WHEN** its metadata is read or forwarded to a peer
+- **THEN** the SHA-256 `Hash` is unchanged and the checksum is preserved as an additive field/header
+
+#### Scenario: additive-only wire change
+- **GIVEN** a peer that does not support additive checksums
+- **WHEN** it receives forwarded object metadata
+- **THEN** it stores/echoes no checksum and continues to operate unaffected
+
+### Requirement: centralized ingest verification
+The system SHALL verify every supplied additive checksum in the shared ingest
+path (`getFile`/store), independent of the ingress surface, and reject a
+mismatch by not persisting the object.
+
+#### Scenario: any-surface mismatch rejected
+- **GIVEN** an upload (via an S3 or native transport) carrying a wrong additive checksum and valid auth
+- **WHEN** the shared ingest path processes it
+- **THEN** the upload is rejected (no object persisted)
+
+#### Scenario: no-checksum inert
+- **GIVEN** an upload with no additive checksum and valid auth
+- **WHEN** the shared ingest path processes it
+- **THEN** verification adds no work on the common path and the upload proceeds on SHA-256 `Hash` alone
+
+### Requirement: replication hop re-verification
+The system SHALL re-verify an additive checksum at every replication hop that
+receives object bytes, so integrity holds end-to-end across a chain/splay fan-out.
+
+#### Scenario: replica rejects tamper
+- **GIVEN** a replication hop whose received bytes do not match the carried additive checksum
+- **WHEN** the hop ingests the forwarded bytes
+- **THEN** the hop rejects the write (object not persisted on that replica)
+
+### Requirement: surface adapters
+The system SHALL keep client-protocol specifics (e.g. S3 `x-amz-checksum-*`
+header parse/arm/encode) inside surface adapters, mapping them onto the core
+contract, not into shared logic.
+
+#### Scenario: S3 adapter maps checksum
+- **GIVEN** an S3 PUT with `x-amz-checksum-sha256` and valid auth
+- **WHEN** the S3 adapter ingests it
+- **THEN** it maps the header into the core `ChecksumRef` and the centralized verifier consumes it
+
+## UNCHANGED Behavior
+- SHA-256 `Hash` remains the content-address + dedup key; ETag unchanged.
+- Fixed momo wire framing fields (`Name`/`Hash`/`Size`/`RemotePath`/`ModTime`)
+  unchanged; checksum extras are additive only.
+- aws-chunked trailing-checksum form (`x-amz-trailer`) still unsupported.
+- Per-`UploadPart` per-part checksums still out of scope (assembled checksum only).

--- a/openspec/changes/core-integrity-verification/tasks.md
+++ b/openspec/changes/core-integrity-verification/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Core Integrity Verification (#903)
+
+## 1. Phase 1: data model
+- [ ] Define `ChecksumRef{Algo, Value}`; add `FileMetadata.Checksums []ChecksumRef`
+- [ ] Marshaling for additivite carry (feed `X-Momo-S3-Meta` / metadata path)
+
+## 2. Phase 2: centralized verifier
+- [ ] Generic verifier at store/ingest layer; invoke from shared `getFile`
+- [ ] Confirm inert (no double-hash) when no additive checksum supplied
+- [ ] Re-verify on replication-hop ingest
+
+## 3. Phase 3: retrieval bit-rot check (opt-in)
+- [ ] `store.Get` optional verification path (opt-in, default off)
+
+## 4. Phase 4: surface adaptation
+- [ ] Map S3 `x-amz-checksum-*` → `ChecksumRef`; migrate `parseChecksum`/
+      `FinalizeIntegrityChecksum` specifics into the S3 adapter
+- [ ] Generalize `transport.ChecksumFinalizer` seam beyond S3; keep native surface no-op
+
+## 5. Phase 5: docs + tests + gates
+- [ ] Update `docs/ARCHITECTURE.md`, `docs/COMPATIBILITY.md` (parity, Rule 27)
+- [ ] Tests: ingest mismatch (any surface), no-checksum inert, replica reject,
+      bit-rot `Get`, S3 adapter mapping, native no-op
+- [ ] `go build/vet/test ./...`, `go test -race`, `go work vendor` no-diff
+- [ ] `benchstat` gate — no regression on measured hot paths


### PR DESCRIPTION
## Issue
https://github.com/alsotoes/momo/issues/903 — **spec documentation only** (no implementation in this PR).

## Change
Adds the OpenSpec change proposal `core-integrity-verification`:
- `proposal.md` — why/what, protocol-agnostic integrity contract, centralized ingest verifier, replication re-verify, surface adapters; non-goals.
- `specs/core-integrity-verification/spec.md` — Requirement/Scenario (Gherkin), top-linked to issue #903 (Rule 11).
- `tasks.md` — phased implementation checklist.

## Intent
Ratification target. Integrity must be a property of the storage/ingest **core**, not any surface protocol — so no client protocol is a lock-in. `Hash` (SHA-256) stays the authoritative content-address; additive checksums are a generalized `ChecksumRef` verified centrally and re-checked at replication hops, with surfaces (s3-*, momo-tcp, momo-quic) as pure adapters.

## Reviewer status
Spec submission — please review/approve so implementation can proceed on this branch. This PR intentionally does **not** `Resolves #903` (issue stays open until implementation merges).

## Testing
Docs-only. No code change. Existing suites unaffected.