### PR TITLE
feat: return 501 for unsupported bucket-config subresources (#912)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -4081,3 +4081,14 @@ b2167d87,BenchmarkSanitizeLog/Unsafe-8,694.70,704.00,1.00
 3de66032,BenchmarkPadString-8,42.18,64.00,1.00
 3de66032,BenchmarkSanitizeLog/Safe-8,243.40,0.00,0.00
 3de66032,BenchmarkSanitizeLog/Unsafe-8,697.90,704.00,1.00
+b28ea7fb,BenchmarkAWSChunkedReaderSigned-8,498069.00,133.64,11296.00
+b28ea7fb,BenchmarkAWSChunkedReaderUnsigned-8,468690.00,142.01,78568.00
+b28ea7fb,BenchmarkCheckMetricsAndSwap-8,11.00,0.00,0.00
+b28ea7fb,BenchmarkCrushOptimized-8,314.40,0.00,0.00
+b28ea7fb,BenchmarkCrushOriginal-8,468.20,164.00,3.00
+b28ea7fb,BenchmarkIndexDirectTracking-8,0.46,0.00,0.00
+b28ea7fb,BenchmarkIndexSearch-8,1.91,0.00,0.00
+b28ea7fb,BenchmarkLoadGlobalConfig-8,9052.00,1848.00,54.00
+b28ea7fb,BenchmarkPadString-8,47.12,64.00,1.00
+b28ea7fb,BenchmarkSanitizeLog/Safe-8,247.60,0.00,0.00
+b28ea7fb,BenchmarkSanitizeLog/Unsafe-8,749.00,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             433.2n ± ∞ ¹    434.5n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            318.0n ± ∞ ¹    363.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.516µ ± ∞ ¹    8.353µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 40.32n ± ∞ ¹    42.18n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          225.2n ± ∞ ¹    243.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        694.7n ± ∞ ¹    697.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    437.1µ ± ∞ ¹    488.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  422.3µ ± ∞ ¹    429.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.571n ± ∞ ¹    7.938n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               2.844n ± ∞ ¹    1.549n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3585n ± ∞ ¹   0.3830n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     352.8n          348.9n        -1.10%
+CrushOriginal-8                             434.5n ± ∞ ¹    468.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            363.1n ± ∞ ¹    314.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          8.353µ ± ∞ ¹    9.052µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 42.18n ± ∞ ¹    47.12n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          243.4n ± ∞ ¹    247.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        697.9n ± ∞ ¹    749.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    488.6µ ± ∞ ¹    498.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  429.7µ ± ∞ ¹    468.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                       7.938n ± ∞ ¹   11.000n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.549n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.3830n ± ∞ ¹   0.4579n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     348.9n          383.2n        +9.83%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.02Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.72Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  -0.01%               ⁴
+geomean                                                ⁴                  +0.01%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   145.2Mi ± ∞ ¹   129.9Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 150.3Mi ± ∞ ¹   147.7Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    147.7Mi         138.5Mi        -6.22%
+AWSChunkedReaderSigned-8                   129.9Mi ± ∞ ¹   127.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 147.7Mi ± ∞ ¹   135.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    138.5Mi         131.4Mi        -5.17%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 488574.00 ns/op | 136.23 B/op | 11282.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 429659.00 ns/op | 154.91 B/op | 78563.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 7.94 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 363.10 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 434.50 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.38 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.55 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 8353.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 42.18 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 243.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 697.90 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 498069.00 ns/op | 133.64 B/op | 11296.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 468690.00 ns/op | 142.01 B/op | 78568.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 11.00 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 314.40 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 468.20 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 9052.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 47.12 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 247.60 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 749.00 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [13cb3b4,752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603]
-    line "AWSChunkedReaderSigned" [438813,462513,460953,489981,418132,447933,454201,498260,437140,488574]
-    line "AWSChunkedReaderUnsigned" [417363,448517,448767,502752,400163,434167,472936,515178,422333,429659]
-    line "CheckMetricsAndSwap" [8,9,9,10,7,8,11,10,8,8]
-    line "CrushOptimized" [370,424,329,313,300,360,327,392,318,363]
-    line "CrushOriginal" [460,605,462,474,395,414,473,508,433,434]
+    x-axis [752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f]
+    line "AWSChunkedReaderSigned" [462513,460953,489981,418132,447933,454201,498260,437140,488574,498069]
+    line "AWSChunkedReaderUnsigned" [448517,448767,502752,400163,434167,472936,515178,422333,429659,468690]
+    line "CheckMetricsAndSwap" [9,9,10,7,8,11,10,8,8,11]
+    line "CrushOptimized" [424,329,313,300,360,327,392,318,363,314]
+    line "CrushOriginal" [605,462,474,395,414,473,508,433,434,468]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,3,2]
-    line "LoadGlobalConfig" [7965,8740,9209,9546,7608,8267,9369,9892,8516,8353]
-    line "PadString" [39,42,51,49,39,40,55,47,40,42]
+    line "IndexSearch" [3,3,3,3,3,3,3,3,2,2]
+    line "LoadGlobalConfig" [8740,9209,9546,7608,8267,9369,9892,8516,8353,9052]
+    line "PadString" [42,51,49,39,40,55,47,40,42,47]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [234,225,309,240,224,240,236,244,225,243]
-    line "SanitizeLog/Unsafe" [654,741,781,861,650,706,809,898,695,698]
+    line "SanitizeLog/Safe" [225,309,240,224,240,236,244,225,243,248]
+    line "SanitizeLog/Unsafe" [741,781,861,650,706,809,898,695,698,749]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [13cb3b4,752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603]
-    line "AWSChunkedReaderSigned" [152,144,144,136,159,149,147,134,152,136]
-    line "AWSChunkedReaderUnsigned" [159,148,148,132,166,153,141,129,158,155]
+    x-axis [752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f]
+    line "AWSChunkedReaderSigned" [144,144,136,159,149,147,134,152,136,134]
+    line "AWSChunkedReaderUnsigned" [148,148,132,166,153,141,129,158,155,142]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [13cb3b4,752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603]
-    line "AWSChunkedReaderSigned" [11272,11275,11298,11308,11270,11298,11294,11296,11294,11282]
-    line "AWSChunkedReaderUnsigned" [78562,78568,78562,78579,78560,78566,78574,78587,78561,78563]
+    x-axis [752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f]
+    line "AWSChunkedReaderSigned" [11275,11298,11308,11270,11298,11294,11296,11294,11282,11296]
+    line "AWSChunkedReaderUnsigned" [78568,78562,78579,78560,78566,78574,78587,78561,78563,78568]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/openspec/changes/s3-p3-bucket-subresource-501/proposal.md
+++ b/openspec/changes/s3-p3-bucket-subresource-501/proposal.md
@@ -1,0 +1,29 @@
+# Change: S3 P3 — 501 for unsupported bucket-config subresources
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/912
+
+## Why
+S3 bucket-config subresource query params (`?versioning` / `?versions`,
+bucket ACLs & policies, `?cors`, `?website`, `?lifecycle`, `?tagging`) are not
+implemented, yet today they fall through to the nearest method handler: e.g.
+`GET /bucket?versioning` misroutes into ListObjectsV2 and
+`PUT /bucket?tagging` misroutes into CreateBucket. Instead of silently
+misbehaving, momo should answer a clean, S3-compliant `501 NotImplemented` —
+the same honest reject-and-document posture already applied to unsupported SSE
+(PR #906 / P1 #907).
+
+## What Changes
+- Add a small set of known-but-unsupported S3 bucket-config subresource query
+  params and intercept them at the S3 dispatch root, addressed at the bucket
+  root (`key == ""`), across all methods (GET/PUT/POST/DELETE).
+- Interception returns S3 error `501` code `NotImplemented` (bounded write, no
+  store dependency) before any object/list/multipart routing.
+- Supported subresources are untouched: `?location`, `list-type`,
+  `uploads`, `uploadId`/`partNumber`, `delete`, and the ListObjectsV2 pagination
+  params continue to route as before.
+
+## Non-Goals
+- Object-level subresource variants (`GET /bucket/key?tagging` =
+  GetObjectTagging, `?versionId` versioning of individual objects) — Tier P4
+  of #820, out of scope for this increment.
+- Any actual implementation of versioning/ACL/policy/CORS/website/lifecycle/tagging.

--- a/openspec/changes/s3-p3-bucket-subresource-501/specs/s3-p3-bucket-subresource-501/spec.md
+++ b/openspec/changes/s3-p3-bucket-subresource-501/specs/s3-p3-bucket-subresource-501/spec.md
@@ -1,0 +1,57 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/912
+
+# s3-p3-bucket-subresource-501 Specification
+
+## Purpose
+Return a clean S3-compliant `501 NotImplemented` for unsupported bucket-config
+subresource query params addressed at the bucket root, instead of letting them
+fall through to the nearest method handler (which misroutes them into
+ListObjectsV2/CreateBucket/GetObject). This is Tier P3 of #820. Only the honest
+reject is in scope; no bucket-config feature is implemented.
+
+## ADDED Requirements
+
+### Requirement: clean rejection of unsupported bucket-config subresources
+The system SHALL intercept a defined set of unsupported bucket-config
+subresource query params when addressed at a bucket root (`key == ""`) for any
+HTTP method, and SHALL respond `501` with the S3 `NotImplemented` error code
+without invoking store operations.
+
+#### Scenario: versioning get rejected
+- **GIVEN** an S3 `GET /bucket?versioning` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no object is read
+
+#### Scenario: tagging put rejected
+- **GIVEN** an S3 `PUT /bucket?tagging` request with valid auth and bucket mode
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no bucket is created
+
+#### Scenario: cors delete rejected
+- **GIVEN** an S3 `DELETE /bucket?cors` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented`
+
+### Requirement: supported subresources unaffected
+The system SHALL continue to route supported subresources exactly as before.
+
+#### Scenario: location and list still served
+- **GIVEN** an S3 `GET /bucket?location` or a list request (`?list-type=2`,
+  pagination params)
+- **WHEN** processed by the gateway
+- **THEN** the existing `200` responses (GetBucketLocation / ListObjectsV2) are returned unchanged
+
+#### Scenario: multipart and batch delete still served
+- **GIVEN** multipart (`?uploads`, `?uploadId`, `?partNumber`) or
+  `POST /bucket?delete` (DeleteObjects) requests
+- **WHEN** processed by the gateway
+- **THEN** the existing handler behavior is unchanged
+
+### Requirement: object-level subresources remain out of scope
+The system SHALL NOT change routing for object-targeted subresources
+(e.g. `GET /bucket/key?tagging`, `?versionId`), which belong to Tier P4.
+
+#### Scenario: object tagging untouched
+- **GIVEN** an S3 `GET /bucket/key?tagging` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** routing behavior is unchanged from before this change

--- a/openspec/changes/s3-p3-bucket-subresource-501/tasks.md
+++ b/openspec/changes/s3-p3-bucket-subresource-501/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: S3 P3 — 501 for unsupported bucket-config subresources (#912)
+
+## 1. Phase 1: interception set + helper
+- [x] Define `unsupportedBucketConfigSubresources` map (versioning/versions,
+      acl, policy, cors, website, lifecycle, tagging, encryption,
+      publicAccessBlock, accelerate, replication, requestPayment, logging,
+      object-lock, notification)
+- [x] Helper to detect a present unsupported subresource from the query values
+
+## 2. Phase 2: dispatch interception
+- [x] Intercept at the S3 dispatch root, bucket-root only (`key == ""`), all methods
+- [x] Respond S3 `501` code `NotImplemented` (bounded write, store-independent)
+- [x] Confirm supported subresources (`location`, `list-type`, `uploads`,
+      `uploadId`/`partNumber`, `delete`, list pagination) still route unchanged
+
+## 3. Phase 3: tests + docs
+- [x] Transport tests: versioning get, tagging put, cors delete → 501 NotImplemented
+- [x] Guard test: `location`, list unaffected
+- [x] Object-level (`GET /bucket/key?tagging`) unchanged
+- [x] `go build/vet/test ./...`, `go test -race`, `go work vendor` no-diff
+- [ ] `benchstat` gate — no regression on measured hot paths

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -651,6 +651,19 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 
 	bucket, key := extractS3BucketAndKey(req)
 
+	// Issue #820 (P3) / #912: reject unsupported bucket-config subresources at
+	// the bucket root with a clean 501 NotImplemented (honest posture), before
+	// any object/list/multipart routing. Supported subresources (location,
+	// list-type, uploads, uploadId/partNumber, delete) are not in the reject set.
+	if key == "" {
+		if op, unsupported := unsupportedBucketConfigSubresource(req.URL.Query()); unsupported {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusNotImplemented, "NotImplemented",
+				fmt.Sprintf("The specified %s operation is not supported by this server.", op), bucket)
+			return 0, 0, fmt.Errorf("unsupported bucket-config subresource %q: %w", op, syscall.ENOTSUP)
+		}
+	}
+
 	// Intercept POST for multipart operations (issue #764)
 	if req.Method == "POST" {
 		q := req.URL.Query()
@@ -1878,6 +1891,43 @@ func (m *S3Communicator) IsPeer() bool {
 
 // extractS3BucketAndKey parses the bucket name and key path from an S3 HTTP request.
 // It supports both virtual-host style and path-style S3 URL schemas.
+// ─── Unsupported bucket-config subresources (P3, #912) ─────────────────────
+// S3 bucket-level configuration operations are not implemented. Issue #820 (P3)
+// / #912: return a clean S3-compliant 501 NotImplemented instead of letting these
+// fall through to the nearest method handler (which misroutes e.g.
+// GET /bucket?versioning into ListObjectsV2 or PUT /bucket?tagging into
+// CreateBucket). Only bucket-root addresses (key == "") are intercepted;
+// object-level variants (GetObjectTagging, ?versionId, etc.) are Tier P4.
+var unsupportedBucketConfigSubresources = map[string]string{
+	"versioning":        "bucket versioning",
+	"versions":          "bucket version listing",
+	"acl":               "bucket access-control lists",
+	"policy":            "bucket policies",
+	"cors":              "CORS configuration",
+	"website":           "static website hosting",
+	"lifecycle":         "lifecycle configuration",
+	"tagging":           "bucket tagging",
+	"encryption":        "bucket encryption",
+	"publicAccessBlock": "public access block",
+	"accelerate":        "transfer acceleration",
+	"replication":       "replication configuration",
+	"requestPayment":    "request-payer configuration",
+	"logging":           "logging configuration",
+	"object-lock":       "object-lock configuration",
+	"notification":      "notification configuration",
+}
+
+// unsupportedBucketConfigSubresource returns the human-readable descriptor of
+// the first unsupported bucket-config subresource present in q, if any.
+func unsupportedBucketConfigSubresource(q url.Values) (string, bool) {
+	for param, _ := range q {
+		if op, ok := unsupportedBucketConfigSubresources[param]; ok {
+			return op, true
+		}
+	}
+	return "", false
+}
+
 func extractS3BucketAndKey(req *http.Request) (bucket string, key string) {
 	// req.Host may include an explicit port (e.g. "mybucket.localhost:9000").
 	// Strip it before host parsing so virtual-host detection still matches.

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -3209,3 +3209,99 @@ func TestS3Communicator_SendOPRFEval_NotEnabled(t *testing.T) {
 		t.Fatal("expected an error when OPRF is not enabled on the server, got nil")
 	}
 }
+
+// TestS3Communicator_BucketConfigSubresource501 verifies the P3 honest posture
+// (issue #912): unsupported S3 bucket-config subresources addressed at the
+// bucket root return a clean 501 NotImplemented instead of falling through to
+// the nearest method handler. Supported bucket-root subresources and
+// object-level subresources (P4) must remain unchanged.
+func TestS3Communicator_BucketConfigSubresource501(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	validTokenReq := func(method, target string) string {
+		return method + " " + target + " HTTP/1.1\r\n" +
+			"Host: 127.0.0.1:4440\r\n" +
+			"Authorization: Bearer " + authToken + "\r\n\r\n"
+	}
+	assertNotImplemented := func(resp string, underlyingErr error) {
+		t.Helper()
+		if underlyingErr == nil {
+			t.Fatal("expected non-nil error for unsupported bucket-config subresource")
+		}
+		if !strings.Contains(resp, "HTTP/1.1 501 Not Implemented") {
+			t.Errorf("expected 501 Not Implemented, got: %s", resp)
+		}
+		if !strings.Contains(resp, "<Code>NotImplemented</Code>") {
+			t.Errorf("expected NotImplemented code, got: %s", resp)
+		}
+	}
+
+	// A bare mock (nil funcs) is safe because interception returns before any
+	// store/method dispatch.
+	tests := []struct {
+		name   string
+		method string
+		target string
+	}{
+		{"versioning get", "GET", "/bucket?versioning"},
+		{"versioning put", "PUT", "/bucket?versioning"},
+		{"tagging put", "PUT", "/bucket?tagging"},
+		{"cors get", "GET", "/bucket?cors"},
+		{"cors delete", "DELETE", "/bucket?cors"},
+		{"lifecycle get", "GET", "/bucket?lifecycle"},
+		{"website delete", "DELETE", "/bucket?website"},
+		{"acl get", "GET", "/bucket?acl"},
+		{"policy put", "PUT", "/bucket?policy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := runS3RequestCaptureBucket(t, validTokenReq(tc.method, tc.target), &mockStore{}, "bucket")
+			assertNotImplemented(resp, err)
+		})
+	}
+
+	// Supported bucket-root subresources must still be served unchanged
+	// (e.g. GetBucketLocation).
+	t.Run("location still served", func(t *testing.T) {
+		resp, err := runS3RequestCaptureBucket(t, validTokenReq("GET", "/bucket?location"), &mockStore{}, "bucket")
+		if err != ErrRequestHandled {
+			t.Fatalf("expected ErrRequestHandled for GetBucketLocation, got: %v", err)
+		}
+		if !strings.Contains(resp, "HTTP/1.1 200 OK") {
+			t.Errorf("expected 200 OK for GetBucketLocation, got: %s", resp)
+		}
+	})
+
+	// ListObjectsV2 at the bucket root must still work.
+	t.Run("list still served", func(t *testing.T) {
+		mock := &mockStore{listFunc: func() ([]common.FileMetadata, error) { return nil, nil }}
+		resp, err := runS3RequestCaptureBucket(t, validTokenReq("GET", "/bucket?list-type=2"), mock, "bucket")
+		if err != ErrRequestHandled {
+			t.Fatalf("expected ErrRequestHandled for list, got: %v", err)
+		}
+		if !strings.Contains(resp, "HTTP/1.1 200 OK") {
+			t.Errorf("expected 200 OK for ListObjectsV2, got: %s", resp)
+		}
+	})
+
+	// Object-level subresources (Tier P4) must NOT be intercepted: they keep the
+	// pre-change routing (GetObject) -> 404 NoSuchKey on a missing object.
+	t.Run("object tagging not intercepted", func(t *testing.T) {
+		mock := &mockStore{
+			getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
+				return nil, common.FileMetadata{}, syscall.ENOENT
+			},
+		}
+		resp, err := runS3RequestCaptureBucket(t, validTokenReq("GET", "/bucket/file.txt?tagging"), mock, "bucket")
+		if err != ErrRequestHandled {
+			t.Fatalf("expected ErrRequestHandled (GetObject path), got: %v", err)
+		}
+		if strings.Contains(resp, "<Code>NotImplemented</Code>") {
+			t.Fatalf("object-level tagging must not be intercepted, got 501:\n%s", resp)
+		}
+		if !strings.Contains(resp, "HTTP/1.1 404 Not Found") {
+			t.Errorf("expected 404 NoSuchKey for object-level tagging (unchanged), got: %s", resp)
+		}
+	})
+}


### PR DESCRIPTION
Resolves #912

## Issue
#912 — Tier P3 (bucket-config family) first increment of #820.

## Problem
S3 bucket-config subresource query params (`?versioning`/`?versions`, ACLs & policies, `?cors`, `?website`, `?lifecycle`, `?tagging`) are unsupported, yet fall through to the nearest method handler: e.g. `GET /bucket?versioning` misroutes into ListObjectsV2 and `PUT /bucket?tagging` misroutes into CreateBucket.

## Fix
Intercept the unsupported bucket-config subresources at the S3 dispatch root, addressed at the bucket root (`key == ""`), across all methods, and return a clean S3-compliant `501` code `NotImplemented` (bounded write, store-independent) — same honest reject posture as SSE (#906 / P1 #907).

- New `unsupportedBucketConfigSubresources` reject set + `unsupportedBucketConfigSubresource(url.Values)` detector in `s3_communicator.go`.
- Intercept placed in `HandshakeServer` right after bucket/key extraction, before any object/list/multipart routing.
- Supported subresources (`?location`, `list-type`, list pagination, `uploads`, `uploadId`/`partNumber`, `delete`) untouched. Object-level variants (e.g. `GET /bucket/key?tagging`, `?versionId`) left for Tier P4.

## OpenSpec change (Rule 73)
`openspec/changes/s3-p3-bucket-subresource-501/` — proposal, spec (ADDED Requirements), tasks.

## Testing
- New `TestS3Communicator_BucketConfigSubresource501`: 9 unsupported subresources → 501 NotImplemented; guards: `location` + list still 200, object-level tagging not intercepted (404 NoSuchKey unchanged).
- `go build ./...`, `go vet ./transport/`, `go test ./...` (30s), `go test ./transport/ -race` — all green; `go work vendor` no-diff.

## Changelog
- `8436a95` — feat: return 501 for unsupported bucket-config subresources (#912)

## Reviewer status
Initial submission.