### PR TITLE
feat: return 501 for unsupported object-level subresources (#914)

### DIFF
--- a/.github/data/benchmark_history.csv
+++ b/.github/data/benchmark_history.csv
@@ -4092,3 +4092,14 @@ b28ea7fb,BenchmarkLoadGlobalConfig-8,9052.00,1848.00,54.00
 b28ea7fb,BenchmarkPadString-8,47.12,64.00,1.00
 b28ea7fb,BenchmarkSanitizeLog/Safe-8,247.60,0.00,0.00
 b28ea7fb,BenchmarkSanitizeLog/Unsafe-8,749.00,704.00,1.00
+985db33d,BenchmarkAWSChunkedReaderSigned-8,465911.00,142.86,11273.00
+985db33d,BenchmarkAWSChunkedReaderUnsigned-8,435995.00,152.66,78577.00
+985db33d,BenchmarkCheckMetricsAndSwap-8,7.74,0.00,0.00
+985db33d,BenchmarkCrushOptimized-8,312.90,0.00,0.00
+985db33d,BenchmarkCrushOriginal-8,437.60,164.00,3.00
+985db33d,BenchmarkIndexDirectTracking-8,0.37,0.00,0.00
+985db33d,BenchmarkIndexSearch-8,1.93,0.00,0.00
+985db33d,BenchmarkLoadGlobalConfig-8,8987.00,1848.00,54.00
+985db33d,BenchmarkPadString-8,43.69,64.00,1.00
+985db33d,BenchmarkSanitizeLog/Safe-8,275.10,0.00,0.00
+985db33d,BenchmarkSanitizeLog/Unsafe-8,709.90,704.00,1.00

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -39,18 +39,18 @@ Each table compares the previous commit (left) to the current commit (right).
 ```
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │           sec/op            │    sec/op      vs base                │
-CrushOriginal-8                             434.5n ± ∞ ¹    468.2n ± ∞ ¹       ~ (p=1.000 n=1) ²
-CrushOptimized-8                            363.1n ± ∞ ¹    314.4n ± ∞ ¹       ~ (p=1.000 n=1) ²
-LoadGlobalConfig-8                          8.353µ ± ∞ ¹    9.052µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-PadString-8                                 42.18n ± ∞ ¹    47.12n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Safe-8                          243.4n ± ∞ ¹    247.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
-SanitizeLog/Unsafe-8                        697.9n ± ∞ ¹    749.0n ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                    488.6µ ± ∞ ¹    498.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                  429.7µ ± ∞ ¹    468.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
-CheckMetricsAndSwap-8                       7.938n ± ∞ ¹   11.000n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexSearch-8                               1.549n ± ∞ ¹    1.912n ± ∞ ¹       ~ (p=1.000 n=1) ²
-IndexDirectTracking-8                      0.3830n ± ∞ ¹   0.4579n ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                     348.9n          383.2n        +9.83%
+CrushOriginal-8                             468.2n ± ∞ ¹    437.6n ± ∞ ¹       ~ (p=1.000 n=1) ²
+CrushOptimized-8                            314.4n ± ∞ ¹    312.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+LoadGlobalConfig-8                          9.052µ ± ∞ ¹    8.987µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+PadString-8                                 47.12n ± ∞ ¹    43.69n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Safe-8                          247.6n ± ∞ ¹    275.1n ± ∞ ¹       ~ (p=1.000 n=1) ²
+SanitizeLog/Unsafe-8                        749.0n ± ∞ ¹    709.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderSigned-8                    498.1µ ± ∞ ¹    465.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                  468.7µ ± ∞ ¹    436.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
+CheckMetricsAndSwap-8                      11.000n ± ∞ ¹    7.740n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexSearch-8                               1.912n ± ∞ ¹    1.925n ± ∞ ¹       ~ (p=1.000 n=1) ²
+IndexDirectTracking-8                      0.4579n ± ∞ ¹   0.3718n ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                     383.2n          356.5n        -6.98%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 
@@ -62,12 +62,12 @@ LoadGlobalConfig-8                         1.805Ki ± ∞ ¹   1.805Ki ± ∞ ¹
 PadString-8                                  64.00 ± ∞ ¹     64.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Safe-8                           0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 SanitizeLog/Unsafe-8                         704.0 ± ∞ ¹     704.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderSigned-8                   11.02Ki ± ∞ ¹   11.03Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
-AWSChunkedReaderUnsigned-8                 76.72Ki ± ∞ ¹   76.73Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderSigned-8                   11.03Ki ± ∞ ¹   11.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
+AWSChunkedReaderUnsigned-8                 76.73Ki ± ∞ ¹   76.74Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
 CheckMetricsAndSwap-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexSearch-8                                0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
 IndexDirectTracking-8                        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                                ⁴                  +0.01%               ⁴
+geomean                                                ⁴                  -0.02%               ⁴
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² all samples are equal
 ³ need >= 4 samples to detect a difference at alpha level 0.05
@@ -93,9 +93,9 @@ geomean                                                ³                +0.00% 
 
                            │ /tmp/old_bench_filtered.txt │      /tmp/new_bench_filtered.txt      │
                            │             B/s             │      B/s       vs base                │
-AWSChunkedReaderSigned-8                   129.9Mi ± ∞ ¹   127.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-AWSChunkedReaderUnsigned-8                 147.7Mi ± ∞ ¹   135.4Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
-geomean                                    138.5Mi         131.4Mi        -5.17%
+AWSChunkedReaderSigned-8                   127.4Mi ± ∞ ¹   136.2Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+AWSChunkedReaderUnsigned-8                 135.4Mi ± ∞ ¹   145.6Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
+geomean                                    131.4Mi         140.8Mi        +7.20%
 ¹ need >= 6 samples for confidence interval at level 0.95
 ² need >= 4 samples to detect a difference at alpha level 0.05
 ```
@@ -108,17 +108,17 @@ three columns: time (speed), bytes (memory), allocs (GC pressure).
 
 | Benchmark | Avg. Time/Op | Avg. Bytes/Op | Avg. Allocs/Op |
 |-----------|--------------|---------------|----------------|
-| BenchmarkAWSChunkedReaderSigned-8 | 498069.00 ns/op | 133.64 B/op | 11296.00 allocs/op |
-| BenchmarkAWSChunkedReaderUnsigned-8 | 468690.00 ns/op | 142.01 B/op | 78568.00 allocs/op |
-| BenchmarkCheckMetricsAndSwap-8 | 11.00 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOptimized-8 | 314.40 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkCrushOriginal-8 | 468.20 ns/op | 164.00 B/op | 3.00 allocs/op |
-| BenchmarkIndexDirectTracking-8 | 0.46 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkIndexSearch-8 | 1.91 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkLoadGlobalConfig-8 | 9052.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
-| BenchmarkPadString-8 | 47.12 ns/op | 64.00 B/op | 1.00 allocs/op |
-| BenchmarkSanitizeLog/Safe-8 | 247.60 ns/op | 0.00 B/op | 0.00 allocs/op |
-| BenchmarkSanitizeLog/Unsafe-8 | 749.00 ns/op | 704.00 B/op | 1.00 allocs/op |
+| BenchmarkAWSChunkedReaderSigned-8 | 465911.00 ns/op | 142.86 B/op | 11273.00 allocs/op |
+| BenchmarkAWSChunkedReaderUnsigned-8 | 435995.00 ns/op | 152.66 B/op | 78577.00 allocs/op |
+| BenchmarkCheckMetricsAndSwap-8 | 7.74 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOptimized-8 | 312.90 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkCrushOriginal-8 | 437.60 ns/op | 164.00 B/op | 3.00 allocs/op |
+| BenchmarkIndexDirectTracking-8 | 0.37 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkIndexSearch-8 | 1.93 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkLoadGlobalConfig-8 | 8987.00 ns/op | 1848.00 B/op | 54.00 allocs/op |
+| BenchmarkPadString-8 | 43.69 ns/op | 64.00 B/op | 1.00 allocs/op |
+| BenchmarkSanitizeLog/Safe-8 | 275.10 ns/op | 0.00 B/op | 0.00 allocs/op |
+| BenchmarkSanitizeLog/Unsafe-8 | 709.90 ns/op | 704.00 B/op | 1.00 allocs/op |
 
 
 ### Performance History
@@ -147,20 +147,20 @@ xychart-beta
     title "Performance Trend (Avg. Time, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Time (ns/op)"
-    x-axis [752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f]
-    line "AWSChunkedReaderSigned" [462513,460953,489981,418132,447933,454201,498260,437140,488574,498069]
-    line "AWSChunkedReaderUnsigned" [448517,448767,502752,400163,434167,472936,515178,422333,429659,468690]
-    line "CheckMetricsAndSwap" [9,9,10,7,8,11,10,8,8,11]
-    line "CrushOptimized" [424,329,313,300,360,327,392,318,363,314]
-    line "CrushOriginal" [605,462,474,395,414,473,508,433,434,468]
+    x-axis [cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f,985db33]
+    line "AWSChunkedReaderSigned" [460953,489981,418132,447933,454201,498260,437140,488574,498069,465911]
+    line "AWSChunkedReaderUnsigned" [448767,502752,400163,434167,472936,515178,422333,429659,468690,435995]
+    line "CheckMetricsAndSwap" [9,10,7,8,11,10,8,8,11,8]
+    line "CrushOptimized" [329,313,300,360,327,392,318,363,314,313]
+    line "CrushOriginal" [462,474,395,414,473,508,433,434,468,438]
     line "IndexDirectTracking" [0,0,0,0,0,0,0,0,0,0]
-    line "IndexSearch" [3,3,3,3,3,3,3,3,2,2]
-    line "LoadGlobalConfig" [8740,9209,9546,7608,8267,9369,9892,8516,8353,9052]
-    line "PadString" [42,51,49,39,40,55,47,40,42,47]
+    line "IndexSearch" [3,3,3,3,3,3,3,2,2,2]
+    line "LoadGlobalConfig" [9209,9546,7608,8267,9369,9892,8516,8353,9052,8987]
+    line "PadString" [51,49,39,40,55,47,40,42,47,44]
     line "ParseReplicationOrder_NoPrealloc" [350,349,357,354,345,225,229,165,232,234]
     line "ParseReplicationOrder_Prealloc" [229,231,237,234,229,108,107,80,110,109]
-    line "SanitizeLog/Safe" [225,309,240,224,240,236,244,225,243,248]
-    line "SanitizeLog/Unsafe" [741,781,861,650,706,809,898,695,698,749]
+    line "SanitizeLog/Safe" [309,240,224,240,236,244,225,243,248,275]
+    line "SanitizeLog/Unsafe" [781,861,650,706,809,898,695,698,749,710]
 ```
 
 #### Memory per Operation (B/op)
@@ -173,9 +173,9 @@ xychart-beta
     title "Memory Trend (Avg. Bytes/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Bytes/Op"
-    x-axis [752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f]
-    line "AWSChunkedReaderSigned" [144,144,136,159,149,147,134,152,136,134]
-    line "AWSChunkedReaderUnsigned" [148,148,132,166,153,141,129,158,155,142]
+    x-axis [cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f,985db33]
+    line "AWSChunkedReaderSigned" [144,136,159,149,147,134,152,136,134,143]
+    line "AWSChunkedReaderUnsigned" [148,132,166,153,141,129,158,155,142,153]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [164,164,164,164,164,164,164,164,164,164]
@@ -199,9 +199,9 @@ xychart-beta
     title "Allocation Trend (Avg. Allocs/Op, Last 10 Commits)"
     x-axis "Commit"
     y-axis "Avg. Allocs/Op"
-    x-axis [752f444,cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f]
-    line "AWSChunkedReaderSigned" [11275,11298,11308,11270,11298,11294,11296,11294,11282,11296]
-    line "AWSChunkedReaderUnsigned" [78568,78562,78579,78560,78566,78574,78587,78561,78563,78568]
+    x-axis [cb26eec,1facfff,f664e80,2435361,d99bc0b,ccb65f3,b2167d8,3de6603,b28ea7f,985db33]
+    line "AWSChunkedReaderSigned" [11298,11308,11270,11298,11294,11296,11294,11282,11296,11273]
+    line "AWSChunkedReaderUnsigned" [78562,78579,78560,78566,78574,78587,78561,78563,78568,78577]
     line "CheckMetricsAndSwap" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOptimized" [0,0,0,0,0,0,0,0,0,0]
     line "CrushOriginal" [3,3,3,3,3,3,3,3,3,3]

--- a/openspec/changes/s3-p4-object-subresource-501/proposal.md
+++ b/openspec/changes/s3-p4-object-subresource-501/proposal.md
@@ -1,0 +1,27 @@
+# Change: S3 P4 — 501 for unsupported object-level subresources
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/914
+
+## Why
+Object-level subresource query params (`?tagging`, `?acl`, `?versionId`,
+`?retention`, `?legal-hold`) on `GET/PUT/DELETE /bucket/key` are not implemented,
+yet today they are silently ignored and misroute to the nearest method handler:
+e.g. `GET /bucket/key?tagging` serves the object bytes as GetObject and
+`PUT /bucket/key?acl` uploads as PutObject. Instead of silently misbehaving,
+momo should answer a clean, S3-compliant `501 NotImplemented` — the same honest
+refuse posture applied to bucket-config subresources (PR #913 / P3 #912) and
+unsupported SSE (PR #906 / P1 #907).
+
+## What Changes
+- Add a small set of known-but-unsupported S3 **object** subresource query
+  params and intercept them at the S3 dispatch root when an object key is
+  addressed (`key != ""`), across all methods (GET/PUT/POST/DELETE).
+- Interception returns S3 error `501` code `NotImplemented` (bounded write, no
+  store dependency) before any object/list/multipart routing.
+- Supported object params are untouched: `?uploadId` and `?partNumber`
+  (multipart) continue to route as before.
+
+## Non-Goals
+- Any actual implementation of object ACLs, tagging, object-lock retention, or
+  object versioning — reject-only honest posture.
+- Bucket-root bucket-config subresources — already handled by #912/#913 (P3).

--- a/openspec/changes/s3-p4-object-subresource-501/specs/s3-p4-object-subresource-501/spec.md
+++ b/openspec/changes/s3-p4-object-subresource-501/specs/s3-p4-object-subresource-501/spec.md
@@ -1,0 +1,52 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/914
+
+# s3-p4-object-subresource-501 Specification
+
+## Purpose
+Return a clean S3-compliant `501 NotImplemented` for unsupported object-level
+subresource query params addressed at an object key, instead of letting them
+fall through to the nearest method handler (which silently misroutes `?tagging`,
+`?acl`, `?versionId`, `?retention`, `?legal-hold` into GetObject/PutObject/
+DeleteObject). This is Tier P4 of #820. Only the honest reject is in scope; no
+object ACL/tagging/versioning/retention feature is implemented.
+
+## ADDED Requirements
+
+### Requirement: clean rejection of unsupported object subresources
+The system SHALL intercept a defined set of unsupported object subresource
+query params when addressed at an object key (`key != ""`) for any HTTP method,
+and SHALL respond `501` with the S3 `NotImplemented` error code without invoking
+store operations.
+
+#### Scenario: tagging get rejected
+- **GIVEN** an S3 `GET /bucket/key?tagging` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no object is read
+
+#### Scenario: acl put rejected
+- **GIVEN** an S3 `PUT /bucket/key?acl` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no object is written
+
+#### Scenario: versioned delete rejected
+- **GIVEN** an S3 `DELETE /bucket/key?versionId=...` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no object is deleted
+
+### Requirement: supported object subresources unaffected
+The system SHALL continue to route supported object params (`?uploadId`,
+`?partNumber`) exactly as before.
+
+#### Scenario: multipart still served
+- **GIVEN** an S3 `PUT /bucket/key?uploadId=X&partNumber=N` (UploadPart) or
+  `GET /bucket/key?uploadId=X` (ListParts) request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the existing handler behavior is unchanged
+
+### Requirement: bucket-root subresources unaffected
+The system SHALL retain the bucket-config rejection introduced in #912/#913.
+
+#### Scenario: bucket-root versioning still rejected
+- **GIVEN** an S3 `GET /bucket?versioning` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented`

--- a/openspec/changes/s3-p4-object-subresource-501/tasks.md
+++ b/openspec/changes/s3-p4-object-subresource-501/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: S3 P4 — 501 for unsupported object-level subresources (#914)
+
+## 1. Phase 1: interception set + helper
+- [x] Define `unsupportedObjectSubresources` map (tagging, acl, versionId,
+      retention, legal-hold)
+- [x] Helper to detect a present unsupported object subresource from the query values
+
+## 2. Phase 2: dispatch interception
+- [x] Intercept at the S3 dispatch root, object-key only (`key != ""`), all methods
+- [x] Respond S3 `501` code `NotImplemented` (bounded write, store-independent)
+- [x] Confirm supported object params (`uploadId`, `partNumber`) still route unchanged
+- [x] Confirm bucket-root bucket-config rejection (#912/#913) retained
+
+## 3. Phase 3: tests + docs
+- [x] Transport tests: tagging get, acl put, versioned delete → 501 NotImplemented
+- [x] Guard test: multipart (`uploadId`/`partNumber`) unaffected
+- [x] Guard test: bucket-root `?versioning` still 501
+- [x] `go build/vet/test ./...`, `go test -race`, `go work vendor` no-diff
+- [ ] `benchstat` gate — no regression on measured hot paths (CI)

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -664,6 +664,19 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 		}
 	}
 
+	// Issue #820 (P4) / #914: reject unsupported object-level subresources at an
+	// object key with a clean 501 NotImplemented (honest posture), before any
+	// object/list/multipart routing. Supported object params (uploadId,
+	// partNumber) are not in the reject set.
+	if key != "" {
+		if op, unsupported := unsupportedObjectSubresource(req.URL.Query()); unsupported {
+			m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			writeS3Error(m.conn, http.StatusNotImplemented, "NotImplemented",
+				fmt.Sprintf("The specified %s operation is not supported by this server.", op), key)
+			return 0, 0, fmt.Errorf("unsupported object subresource %q: %w", op, syscall.ENOTSUP)
+		}
+	}
+
 	// Intercept POST for multipart operations (issue #764)
 	if req.Method == "POST" {
 		q := req.URL.Query()
@@ -1889,8 +1902,6 @@ func (m *S3Communicator) IsPeer() bool {
 	return m.isPeer
 }
 
-// extractS3BucketAndKey parses the bucket name and key path from an S3 HTTP request.
-// It supports both virtual-host style and path-style S3 URL schemas.
 // ─── Unsupported bucket-config subresources (P3, #912) ─────────────────────
 // S3 bucket-level configuration operations are not implemented. Issue #820 (P3)
 // / #912: return a clean S3-compliant 501 NotImplemented instead of letting these
@@ -1928,6 +1939,33 @@ func unsupportedBucketConfigSubresource(q url.Values) (string, bool) {
 	return "", false
 }
 
+// ─── Unsupported object subresources (P4, #914) ────────────────────────────
+// S3 object-level subresource operations (ACLs, tagging, versioning, retention,
+// legal-hold) are not implemented. Issue #820 (P4) / #914: return a clean
+// S3-compliant 501 NotImplemented instead of silently misrouting these into
+// GetObject/PutObject/DeleteObject. Only object-key addresses (key != "") are
+// intercepted; bucket-root bucket-config handling is #912/#913.
+var unsupportedObjectSubresources = map[string]string{
+	"tagging":    "object tagging",
+	"acl":        "object access-control lists",
+	"versionId":  "object versioning",
+	"retention":  "object retention",
+	"legal-hold": "object legal hold",
+}
+
+// unsupportedObjectSubresource returns the human-readable descriptor of the
+// first unsupported object subresource present in q, if any.
+func unsupportedObjectSubresource(q url.Values) (string, bool) {
+	for param, _ := range q {
+		if op, ok := unsupportedObjectSubresources[param]; ok {
+			return op, true
+		}
+	}
+	return "", false
+}
+
+// extractS3BucketAndKey parses the bucket name and key path from an S3 HTTP request.
+// It supports both virtual-host style and path-style S3 URL schemas.
 func extractS3BucketAndKey(req *http.Request) (bucket string, key string) {
 	// req.Host may include an explicit port (e.g. "mybucket.localhost:9000").
 	// Strip it before host parsing so virtual-host detection still matches.

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -3285,23 +3285,99 @@ func TestS3Communicator_BucketConfigSubresource501(t *testing.T) {
 		}
 	})
 
-	// Object-level subresources (Tier P4) must NOT be intercepted: they keep the
-	// pre-change routing (GetObject) -> 404 NoSuchKey on a missing object.
-	t.Run("object tagging not intercepted", func(t *testing.T) {
+	// Plain GetObject (no subresource) must still be served: 404 NoSuchKey on a
+	// missing object. (Object-level subresource interception is Tier P4, #914;
+	// covered by TestS3Communicator_ObjectSubresource501.)
+	t.Run("object get still served", func(t *testing.T) {
 		mock := &mockStore{
 			getFunc: func(name string) (io.ReadCloser, common.FileMetadata, error) {
 				return nil, common.FileMetadata{}, syscall.ENOENT
 			},
 		}
-		resp, err := runS3RequestCaptureBucket(t, validTokenReq("GET", "/bucket/file.txt?tagging"), mock, "bucket")
+		resp, err := runS3RequestCaptureBucket(t, validTokenReq("GET", "/bucket/file.txt"), mock, "bucket")
 		if err != ErrRequestHandled {
 			t.Fatalf("expected ErrRequestHandled (GetObject path), got: %v", err)
 		}
 		if strings.Contains(resp, "<Code>NotImplemented</Code>") {
-			t.Fatalf("object-level tagging must not be intercepted, got 501:\n%s", resp)
+			t.Fatalf("plain GetObject must not be intercepted, got 501:\n%s", resp)
 		}
 		if !strings.Contains(resp, "HTTP/1.1 404 Not Found") {
-			t.Errorf("expected 404 NoSuchKey for object-level tagging (unchanged), got: %s", resp)
+			t.Errorf("expected 404 NoSuchKey for plain GetObject, got: %s", resp)
 		}
+	})
+}
+
+// TestS3Communicator_ObjectSubresource501 verifies the P4 honest posture
+// (issue #914): unsupported S3 object-level subresources addressed at an object
+// key return a clean 501 NotImplemented instead of silently misrouting into
+// GetObject/PutObject/DeleteObject. Supported object params (uploadId,
+// partNumber) and bucket-root bucket-config rejection remain unchanged.
+func TestS3Communicator_ObjectSubresource501(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	validTokenReq := func(method, target string) string {
+		return method + " " + target + " HTTP/1.1\r\n" +
+			"Host: 127.0.0.1:4440\r\n" +
+			"Authorization: Bearer " + authToken + "\r\n\r\n"
+	}
+	assertNotImplemented := func(resp string, underlyingErr error) {
+		t.Helper()
+		if underlyingErr == nil {
+			t.Fatal("expected non-nil error for unsupported object subresource")
+		}
+		if !strings.Contains(resp, "HTTP/1.1 501 Not Implemented") {
+			t.Errorf("expected 501 Not Implemented, got: %s", resp)
+		}
+		if !strings.Contains(resp, "<Code>NotImplemented</Code>") {
+			t.Errorf("expected NotImplemented code, got: %s", resp)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		target string
+	}{
+		{"tagging get", "GET", "/bucket/file.txt?tagging"},
+		{"tagging put", "PUT", "/bucket/file.txt?tagging"},
+		{"tagging delete", "DELETE", "/bucket/file.txt?tagging"},
+		{"acl get", "GET", "/bucket/file.txt?acl"},
+		{"acl put", "PUT", "/bucket/file.txt?acl"},
+		{"versionId get", "GET", "/bucket/file.txt?versionId=1"},
+		{"versionId delete", "DELETE", "/bucket/file.txt?versionId=1"},
+		{"retention get", "GET", "/bucket/file.txt?retention"},
+		{"retention put", "PUT", "/bucket/file.txt?retention"},
+		{"legal-hold get", "GET", "/bucket/file.txt?legal-hold"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := runS3RequestCaptureBucket(t, validTokenReq(tc.method, tc.target), &mockStore{}, "bucket")
+			assertNotImplemented(resp, err)
+		})
+	}
+
+	// Supported object params (multipart) must still route unchanged: UploadPart
+	// (PUT ?uploadId & partNumber) -> 200, and ListParts (GET ?uploadId).
+	t.Run("multipart still served", func(t *testing.T) {
+		mock := &mockStore{}
+		resp, err := runS3RequestCaptureBucket(t,
+			validTokenReq("PUT", "/bucket/file.txt?uploadId=bogus&partNumber=1"), mock, "bucket")
+		if strings.Contains(resp, "<Code>NotImplemented</Code>") {
+			t.Fatalf("UploadPart must not be intercepted, got 501:\n%s", resp)
+		}
+		if err == nil {
+			// UploadPart may return NoSuchUpload for an unknown id; the key point
+			// is it is NOT a 501 NotImplemented.
+			if !strings.Contains(resp, "HTTP/1.1 404 Not Found") && !strings.Contains(resp, "HTTP/1.1 200 OK") {
+				t.Errorf("expected upload-part routing (404/200), got: %s", resp)
+			}
+		}
+	})
+
+	// Bucket-root bucket-config rejection (#912/#913) must be retained.
+	t.Run("bucket root versioning still 501", func(t *testing.T) {
+		resp, err := runS3RequestCaptureBucket(t, validTokenReq("GET", "/bucket?versioning"), &mockStore{}, "bucket")
+		assertNotImplemented(resp, err)
 	})
 }


### PR DESCRIPTION
Resolves #914

## Issue
#914 — Tier P4 (object ACLs / tagging / object-lock retention) of #820.

## Problem
Object-level subresource query params on GET/PUT/DELETE /bucket/key are silently ignored today, misrouting into the nearest method handler: GET /bucket/key?tagging serves the object as GetObject, PUT /bucket/key?acl uploads as PutObject.

## Fix
Intercept the unsupported object-level subresource query params at the S3 dispatch root when an object key is addressed (key != ""), across all methods, and return a clean S3-compliant 501 code NotImplemented (bounded write, store-independent) — consistent with the bucket-root fix (#912/#913, P3) and SSE (#906/#907, P1).

- New unsupportedObjectSubresources set (tagging, acl, versionId, retention, legal-hold) + unsupportedObjectSubresource(url.Values) detector, alongside the bucket-config helper.
- Sibling intercept branch in HandshakeServer after bucket-extraction for key != "".
- Supported object params (uploadId, partNumber) and bucket-root bucket-config rejection untouched.
- Also fixes an orphaned extractS3BucketAndKey doc comment left by #913.

## OpenSpec change (Rule 73)
openspec/changes/s3-p4-object-subresource-501/ — proposal, spec (ADDED Requirements), tasks.

## Testing
- New TestS3Communicator_ObjectSubresource501: 10 object-subresource cases → 501; guards: multipart (uploadId/partNumber) still routes, bucket-root ?versioning still 501.
- Superseded P3 guard object_tagging_not_intercepted replaced with object_get_still_served (plain GetObject → 404).
- go build ./..., go vet ./transport/, go test ./... (30s), go test ./transport/ -race — all green; go work vendor no-diff; gofmt clean.

## Changelog
- d5b4e66 — feat: return 501 for unsupported object-level subresources (#914)

## Reviewer status
Initial submission.
