### PR TITLE
feat: return 501 for remaining unsupported S3 operations (#920)

### DIFF
--- a/openspec/changes/s3-p5-remaining-subresource-501/proposal.md
+++ b/openspec/changes/s3-p5-remaining-subresource-501/proposal.md
@@ -1,0 +1,31 @@
+# Change: S3 P5 — 501 for remaining unsupported S3 operations
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/920
+
+## Why
+The honest `501 NotImplemented` posture from P3 (#912/#913), P4 (#914/#915) and
+P1 (#906/#907) covers bucket-config and object-level subresources, but a few
+unsupported S3 operations still silently misroute:
+- `POST /bucket/key?select` (SelectObjectContent) is not a recognized POST
+  subresource and falls through the dispatch.
+- `PUT /bucket/key?partNumber=N&uploadId=X` with an `X-Amz-Copy-Source` header
+  (UploadPartCopy) is misread by the UploadPart handler as a part-body upload.
+- Bucket config subresources `?analytics`, `?inventory`, `?metrics`,
+  `?intelligent-tiering` are not yet in the bucket-root reject set.
+
+Momo should answer a clean, S3-compliant `501 NotImplemented` for each.
+
+## What Changes
+- Add `analytics`, `inventory`, `metrics`, `intelligent-tiering` to the
+  bucket-root reject set (`unsupportedBucketConfigSubresources`).
+- Add `select` to the object-level reject set (`unsupportedObjectSubresources`).
+- Intercept UploadPartCopy in the PUT dispatch (before UploadPart): when
+  `?uploadId` + `?partNumber` AND an `X-Amz-Copy-Source` header are present,
+  return `501 NotImplemented`.
+- All responses are bounded-write and store-independent, consistent with the
+  existing rejection paths.
+
+## Non-Goals
+- Any actual implementation of SelectObjectContent, UploadPartCopy, or
+  analytics/inventory/metrics/intelligent-tiering — reject-only honest posture.
+- Changes to the already-covered P3/P4 reject sets.

--- a/openspec/changes/s3-p5-remaining-subresource-501/specs/s3-p5-remaining-subresource-501/spec.md
+++ b/openspec/changes/s3-p5-remaining-subresource-501/specs/s3-p5-remaining-subresource-501/spec.md
@@ -1,0 +1,54 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/920
+
+# s3-p5-remaining-subresource-501 Specification
+
+## Purpose
+Return a clean S3-compliant `501 NotImplemented` for the remaining unsupported
+S3 operations that still silently misroute after the P3/P4 subresource reject
+work: SelectObjectContent (`?select`), UploadPartCopy
+(`PUT ?uploadId&partNumber` plus `X-Amz-Copy-Source`), and the bucket analytics /
+inventory / metrics / intelligent-tiering configuration subresources. Only the
+honest reject is in scope; no feature is implemented.
+
+## ADDED Requirements
+
+### Requirement: bucket analytics/inventory/metrics/intelligent-tiering rejected
+The system SHALL reject `?analytics`, `?inventory`, `?metrics` and
+`?intelligent-tiering` addressed at a bucket root (`key == ""`) with `501` code
+`NotImplemented`, consistent with the existing bucket-config reject set.
+
+#### Scenario: analytics configuration rejected
+- **GIVEN** a `GET /bucket?analytics` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented`
+
+#### Scenario: inventory configuration rejected
+- **GIVEN** a `PUT /bucket?inventory` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented`
+
+### Requirement: SelectObjectContent rejected
+The system SHALL reject `?select` addressed at an object key with `501` code
+`NotImplemented`.
+
+#### Scenario: select object rejected
+- **GIVEN** a `POST /bucket/key?select&select-type=2` request with valid auth
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no bytes are read
+
+### Requirement: UploadPartCopy rejected
+The system SHALL reject a `PUT` carrying both multipart params (`?uploadId`,
+`?partNumber`) and an `X-Amz-Copy-Source` header with `501` code `NotImplemented`,
+instead of misreading the copy source as a part body.
+
+#### Scenario: upload-part-copy rejected
+- **GIVEN** a `PUT /bucket/key?uploadId=X&partNumber=1` request with valid auth
+  and an `X-Amz-Copy-Source: /bucket/src` header
+- **WHEN** processed by the gateway
+- **THEN** the response is `501` with code `NotImplemented` and no part is stored
+
+#### Scenario: plain upload-part still served
+- **GIVEN** a `PUT /bucket/key?uploadId=X&partNumber=1` request with valid auth
+  and no `X-Amz-Copy-Source` header
+- **WHEN** processed by the gateway
+- **THEN** the existing UploadPart behavior is unchanged

--- a/openspec/changes/s3-p5-remaining-subresource-501/tasks.md
+++ b/openspec/changes/s3-p5-remaining-subresource-501/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: S3 P5 — 501 for remaining unsupported S3 operations (#920)
+
+## 1. Phase 1: reject-set extensions
+- [x] Add `analytics`, `inventory`, `metrics`, `intelligent-tiering` to
+      `unsupportedBucketConfigSubresources`
+- [x] Add `select` to `unsupportedObjectSubresources`
+- [x] Confirm no collision with supported subresources / metrics endpoints
+
+## 2. Phase 2: UploadPartCopy interception
+- [x] Intercept `PUT` with `?uploadId`+`?partNumber` AND `X-Amz-Copy-Source`
+      before the UploadPart handler → `501 NotImplemented`
+- [x] Confirm plain UploadPart without `X-Amz-Copy-Source` unchanged
+
+## 3. Phase 3: tests + docs
+- [x] Transport tests: analytics get, inventory put, metrics get,
+      intelligent-tiering get, select post → 501 NotImplemented
+- [x] Guard test: plain UploadPart (no copy-source) still 404/200
+- [x] `go build/vet/test ./...`, `go test -race`, `go work vendor` no-diff
+- [ ] `benchstat` gate — no regression on measured hot paths (CI)

--- a/src/transport/s3_communicator.go
+++ b/src/transport/s3_communicator.go
@@ -1258,10 +1258,25 @@ func (m *S3Communicator) HandshakeServer(expectedAuthToken []byte) (requestedMod
 			return 0, 0, err
 		}
 
+		// UploadPartCopy (issue #820, P5 / #920): a PUT with multipart params
+		// AND an X-Amz-Copy-Source header. Not implemented; reject cleanly
+		// instead of the UploadPart handler misreading the copy source as a
+		// part body. Intercepted before UploadPart/CopyObject.
+		q := req.URL.Query()
+		if copySource := req.Header.Get("X-Amz-Copy-Source"); copySource != "" {
+			_, hasUploadID := q["uploadId"]
+			_, hasPartNum := q["partNumber"]
+			if hasUploadID && hasPartNum && key != "" {
+				m.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				writeS3Error(m.conn, http.StatusNotImplemented, "NotImplemented",
+					"UploadPartCopy is not supported by this server.", key)
+				return 0, 0, fmt.Errorf("unsupported UploadPartCopy: %w", syscall.ENOTSUP)
+			}
+		}
+
 		// UploadPart: PUT /{bucket}/{key}?uploadId=X&partNumber=N (issue #764).
 		// Intercepted before CopyObject/CreateBucket because the query params
 		// are distinct from those operations.
-		q := req.URL.Query()
 		if _, hasUploadID := q["uploadId"]; hasUploadID && key != "" {
 			if _, hasPartNum := q["partNumber"]; hasPartNum {
 				if !m.validBucket(bucket) {
@@ -1910,22 +1925,26 @@ func (m *S3Communicator) IsPeer() bool {
 // CreateBucket). Only bucket-root addresses (key == "") are intercepted;
 // object-level variants (GetObjectTagging, ?versionId, etc.) are Tier P4.
 var unsupportedBucketConfigSubresources = map[string]string{
-	"versioning":        "bucket versioning",
-	"versions":          "bucket version listing",
-	"acl":               "bucket access-control lists",
-	"policy":            "bucket policies",
-	"cors":              "CORS configuration",
-	"website":           "static website hosting",
-	"lifecycle":         "lifecycle configuration",
-	"tagging":           "bucket tagging",
-	"encryption":        "bucket encryption",
-	"publicAccessBlock": "public access block",
-	"accelerate":        "transfer acceleration",
-	"replication":       "replication configuration",
-	"requestPayment":    "request-payer configuration",
-	"logging":           "logging configuration",
-	"object-lock":       "object-lock configuration",
-	"notification":      "notification configuration",
+	"versioning":          "bucket versioning",
+	"versions":            "bucket version listing",
+	"acl":                 "bucket access-control lists",
+	"policy":              "bucket policies",
+	"cors":                "CORS configuration",
+	"website":             "static website hosting",
+	"lifecycle":           "lifecycle configuration",
+	"tagging":             "bucket tagging",
+	"encryption":          "bucket encryption",
+	"publicAccessBlock":   "public access block",
+	"accelerate":          "transfer acceleration",
+	"replication":         "replication configuration",
+	"requestPayment":      "request-payer configuration",
+	"logging":             "logging configuration",
+	"object-lock":         "object-lock configuration",
+	"notification":        "notification configuration",
+	"analytics":           "bucket analytics configuration",
+	"inventory":           "bucket inventory configuration",
+	"metrics":             "bucket metrics configuration",
+	"intelligent-tiering": "S3 Intelligent-Tiering configuration",
 }
 
 // unsupportedBucketConfigSubresource returns the human-readable descriptor of
@@ -1951,6 +1970,7 @@ var unsupportedObjectSubresources = map[string]string{
 	"versionId":  "object versioning",
 	"retention":  "object retention",
 	"legal-hold": "object legal hold",
+	"select":     "SelectObjectContent",
 }
 
 // unsupportedObjectSubresource returns the human-readable descriptor of the

--- a/src/transport/s3_communicator_test.go
+++ b/src/transport/s3_communicator_test.go
@@ -3381,3 +3381,78 @@ func TestS3Communicator_ObjectSubresource501(t *testing.T) {
 		assertNotImplemented(resp, err)
 	})
 }
+
+// TestS3Communicator_RemainingSubresource501 verifies the P5 honest posture
+// (issue #920): the remaining unsupported S3 operations return a clean 501
+// NotImplemented instead of silently misrouting. Covers the bucket
+// analytics/inventory/metrics/intelligent-tiering subresources, SelectObjectContent
+// (?select), and UploadPartCopy (PUT ?uploadId&partNumber + X-Amz-Copy-Source).
+func TestS3Communicator_RemainingSubresource501(t *testing.T) {
+	defer verifyNoLeaks(t)
+
+	authToken := "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6"
+	validTokenReq := func(method, target string) string {
+		return method + " " + target + " HTTP/1.1\r\n" +
+			"Host: 127.0.0.1:4440\r\n" +
+			"Authorization: Bearer " + authToken + "\r\n\r\n"
+	}
+	assertNotImplemented := func(resp string, underlyingErr error) {
+		t.Helper()
+		if underlyingErr == nil {
+			t.Fatal("expected non-nil error for unsupported operation")
+		}
+		if !strings.Contains(resp, "HTTP/1.1 501 Not Implemented") {
+			t.Errorf("expected 501 Not Implemented, got: %s", resp)
+		}
+		if !strings.Contains(resp, "<Code>NotImplemented</Code>") {
+			t.Errorf("expected NotImplemented code, got: %s", resp)
+		}
+	}
+
+	// Bucket-config additions (bucket root) + SelectObjectContent (object).
+	tests := []struct {
+		name   string
+		method string
+		target string
+	}{
+		{"analytics get", "GET", "/bucket?analytics"},
+		{"inventory put", "PUT", "/bucket?inventory"},
+		{"metrics get", "GET", "/bucket?metrics"},
+		{"intelligent-tiering get", "GET", "/bucket?intelligent-tiering"},
+		{"select post", "POST", "/bucket/file.txt?select&select-type=2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := runS3RequestCaptureBucket(t, validTokenReq(tc.method, tc.target), &mockStore{}, "bucket")
+			assertNotImplemented(resp, err)
+		})
+	}
+
+	// UploadPartCopy: PUT with multipart params + X-Amz-Copy-Source header.
+	t.Run("upload-part-copy put", func(t *testing.T) {
+		req := "PUT /bucket/file.txt?uploadId=abcd&partNumber=1 HTTP/1.1\r\n" +
+			"Host: 127.0.0.1:4440\r\n" +
+			"Authorization: Bearer " + authToken + "\r\n" +
+			"X-Amz-Copy-Source: /bucket/src.txt\r\n\r\n"
+		resp, err := runS3RequestCaptureBucket(t, req, &mockStore{}, "bucket")
+		assertNotImplemented(resp, err)
+	})
+
+	// Plain UploadPart (no copy-source) must still route (404 NoSuchUpload for an
+	// unknown upload id — the point is it is NOT a 501).
+	t.Run("plain upload-part still served", func(t *testing.T) {
+		req := "PUT /bucket/file.txt?uploadId=abcd&partNumber=1 HTTP/1.1\r\n" +
+			"Host: 127.0.0.1:4440\r\n" +
+			"Authorization: Bearer " + authToken + "\r\n\r\n"
+		resp, err := runS3RequestCaptureBucket(t, req, &mockStore{}, "bucket")
+		if err == nil {
+			t.Fatalf("expected an error (UploadPart path), got nil")
+		}
+		if strings.Contains(resp, "<Code>NotImplemented</Code>") {
+			t.Fatalf("plain UploadPart must not be intercepted, got 501:\n%s", resp)
+		}
+		if !strings.Contains(resp, "HTTP/1.1 404 Not Found") {
+			t.Errorf("expected 404 NoSuchUpload for plain UploadPart, got: %s", resp)
+		}
+	})
+}


### PR DESCRIPTION
Resolves #920

## Issue
#920 — Tier P5 of #820: extend the honest 501 NotImplemented posture to the remaining unsupported S3 operations that still silently misroute.

## Problem
- POST /bucket/key?select (SelectObjectContent) is not a recognized POST subresource and falls through the dispatch.
- PUT /bucket/key?partNumber=&uploadId= with an X-Amz-Copy-Source header (UploadPartCopy) is misread by the UploadPart handler as a part-body upload.
- Bucket config subresources ?analytics, ?inventory, ?metrics, ?intelligent-tiering were not in the bucket-root reject set.

## Fix
- Added analytics, inventory, metrics, intelligent-tiering to unsupportedBucketConfigSubresources (bucket root, key == "").
- Added select to unsupportedObjectSubresources (object key, key != "").
- Added an UploadPartCopy intercept in the PUT dispatch (before UploadPart/CopyObject): PUT with ?uploadId + ?partNumber AND X-Amz-Copy-Source -> 501 NotImplemented.
- All responses: S3 501 code NotImplemented, bounded write, store-independent (consistent with #912/#913 and #914/#915).

## OpenSpec change (Rule 73)
openspec/changes/s3-p5-remaining-subresource-501/ — proposal, spec (ADDED Requirements), tasks.

## Testing
- New TestS3Communicator_RemainingSubresource501: analytics get, inventory put, metrics get, intelligent-tiering get, select post, upload-part-copy put -> 501; guard plain UploadPart (no copy-source) still routes (404 NoSuchUpload).
- Existing P3/P4 suites re-verified green.
- go build ./..., go vet ./transport/, go test ./... (30s), go test ./transport/ -race — all green; go work vendor no-diff; gofmt clean.

## Notes
Pre-commit-hook regenerated .github/data/benchmark_history.csv and docs/PERFORMANCE.md were removed from this PR (Rule 61) for a clean, code-only diff.

## Changelog
- 655566a — feat: return 501 for remaining unsupported S3 operations (#920)

## Reviewer status
Initial submission.
