### PR TITLE
feat: at-rest integrity — content-hash verify on read + background scrub (#924)

### DIFF
--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -72,6 +72,8 @@ lease_timeout=10
 backend=local
 gc_interval=300
 tombstone_retention=86400
+scrub_interval=3600
+verify_on_read=true
 # S3 backend example:
 # backend=s3
 # s3_endpoint=https://s3.us-east-1.amazonaws.com

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,6 +128,28 @@ Remaining non-subresource gaps that do not arrive via a query param (e.g.
 aws-chunked trailing-checksum form, `SelectObjectContent`'s non-S3 payload
 semantics) are handled by their own paths and not covered here.
 
+### 4f. At-Rest Integrity (content-address re-verification, issue #924)
+Blobs are content-addressed by SHA-256, but the read path used to stream blob
+bytes out without ever re-deriving the hash — a corrupted blob at rest was
+silently served. `src/storage/integrity.go` closes this with two mechanisms
+(config section `[storage]`):
+
+- **Verify-on-read (`verify_on_read`, default `true`)**: `CASStore.Get` wraps the
+  blob stream in a reader that recomputes SHA-256 and, at EOF, asserts it equals
+  the content-hash key. On mismatch the read fails with
+  `common.ErrIntegrityMismatch` + `syscall.EBADMSG` — corrupt bytes are never
+  served. Bounded-memory and computed as the caller drains the stream, outside
+  the bbolt/`s.mu` critical section.
+- **Background scrub (`scrub_interval`, default `3600`s)**: `StartScrub` mirrors
+  the GC loop (`gcOnce`/`gcDone`/`gcWG`). Each pass lists referenced blobs from
+  the `objects` bucket, re-reads and re-hashes each via `BlobStore.GetBlob` (I/O
+  outside `s.mu`), and quarantines a blob whose recomputed hash no longer matches
+  its key — deleting content + metadata so later reads fail explicitly with
+  `ENOENT` rather than serving garbage. The helper `common.HashReader` streams a
+  fixed-buffer SHA-256 (mirrors `common.HashFile`).
+
+Re-replication/healing of quarantined blobs is out of scope here.
+
 ### 5. Automated Governance & AI Reviewer
 To maintain high integrity in a single-contributor environment, Momo employs an automated governance layer:
 - **Gemini AI Reviewer**: A GitHub Action that uses the Gemini API to analyze PR diffs. It specifically enforces the **⚡ Bolt** (performance) and **🛡️ Sentinel** (security) patterns.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -313,6 +313,16 @@ This section controls the Content-Addressable Storage (CAS) engine, including ba
     -   **Type:** Integer
     -   **Default:** `86400` (24 hours)
 
+-   **`scrub_interval`**
+    -   **Description:** The interval in seconds between background integrity scrub passes (issue #924). Each pass re-reads every referenced blob, re-derives its SHA-256, and quarantines any blob whose content no longer matches its content-address key so later reads fail explicitly with `ENOENT` instead of serving corrupt bytes.
+    -   **Type:** Integer
+    -   **Default:** `3600` (1 hour)
+
+-   **`verify_on_read`**
+    -   **Description:** When enabled, `CASStore.Get` re-derives the blob SHA-256 as the read stream ends and fails the read (integrity mismatch) if the bytes no longer match the content-address key, instead of serving corrupt data. Adds a full-hash cost per read; disable only when read throughput trumps integrity (not recommended) (issue #924).
+    -   **Type:** Boolean
+    -   **Default:** `true`
+
 -   **`s3_endpoint`**
     -   **Description:** S3-compatible API endpoint URL (e.g., `https://s3.amazonaws.com`). Only used when `backend = s3`.
     -   **Type:** String
@@ -407,6 +417,8 @@ lease_timeout = 10
 [storage]
 gc_interval = 300
 tombstone_retention = 86400
+scrub_interval = 3600
+verify_on_read = true
 ```
 
 ### NFS Storage Backend

--- a/openspec/changes/storage-at-rest-integrity/proposal.md
+++ b/openspec/changes/storage-at-rest-integrity/proposal.md
@@ -1,0 +1,45 @@
+# Change: Storage at-rest integrity — content-hash verify on read + background scrub
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/924
+- https://github.com/alsotoes/momo/issues/820 (roadmap)
+
+## Why
+
+Momo is content-addressed: every blob's identity is its SHA-256 content hash
+(`common.HashBytes`/`HashFile`), and the storage key for a blob *is* that hash.
+But the read path (`CASStore.Get`) streams blob bytes out to clients **without
+ever re-deriving the hash**. If a blob is corrupted at rest (bit rot, torn
+writes, partial S3 downloads), the corrupt bytes are served to clients silently.
+The existing integrity surface is either additive/opt-in
+(`VerifyChecksum`, issue #903) or in-band ingest-side (`getFile`), neither of
+which detects a blob that no longer matches its own address key.
+
+This change closes that gap with two complementary mechanisms, per recommendation
+item 1 of the #820 production-hardening roadmap:
+
+1. **Verify-on-read** — `CASStore.Get` re-derives the SHA-256 of the whole blob
+   as it streams and, at EOF, asserts it equals the content-hash key. On
+   mismatch it returns an integrity error instead of serving corrupt bytes. It
+   is bounded-memory (streamed through a fixed buffer) and computationally
+   outside the bbolt/`s.mu` read critical section (the caller drains the wrapped
+   reader after `Get` returns).
+2. **Background scrub** — a `StartScrub` goroutine that mirrors the GC loop
+   (`gcLoop`): periodically it iterates the referenced blobs in the `objects`
+   bucket, re-reads and re-hashes each through `BlobStore.GetBlob`, and
+   quarantines any blob whose recomputed hash no longer matches its key (removes
+   blob content + object metadata so the name fails explicitly with `ENOENT`
+   rather than silently serving garbage). Both are defensive (panic-recovered),
+   cancellable on store close (goleak-safe, mirroring `gcDone`/`gcWG`), and
+   `sync.Once`-guarded.
+
+Both are gated by new `[storage]` config keys: `verify_on_read` (default `true`)
+and `scrub_interval` (seconds, default `3600`).
+
+## Non-goals
+
+- No replication/erasure-coding or cross-replica healing. This detects and
+  quarantines local corruption; re-replication is a separate roadmap item.
+- No change to the additive checksum surface (`VerifyChecksum`, issue #903).
+- No change to `GetBlobPath`/direct-file serving paths (follow-up), or to the
+  write side.

--- a/openspec/changes/storage-at-rest-integrity/specs/storage-at-rest-integrity/spec.md
+++ b/openspec/changes/storage-at-rest-integrity/specs/storage-at-rest-integrity/spec.md
@@ -1,0 +1,82 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/924
+
+# storage-at-rest-integrity Specification
+
+## Purpose
+Detect and refuse to serve blobs whose at-rest bytes no longer match their
+SHA-256 content-address key. Two mechanisms: verify-on-read (the read path
+re-derives the hash and fails instead of serving corrupt bytes) and a
+background scrub that iterates referenced blobs, re-hashes each, and
+quarantines corrupt ones so later reads fail explicitly with `ENOENT`.
+Bounded-memory, defensive (panic-recovered), cancellable on store close.
+
+## ADDED Requirements
+
+### Requirement: Verify-on-read failures are explicit
+The system SHALL, when `verify_on_read` is enabled (default `true`), recompute
+the SHA-256 over the entire blob stream returned by `CASStore.Get` and, at EOF,
+assert it equals the blob's content-hash key. When it does not equal, reads
+SHALL fail with an error wrapping `common.ErrIntegrityMismatch` and
+`syscall.EBADMSG`; no corrupt bytes are served.
+
+#### Scenario: valid blob serves normally
+- **GIVEN** a stored blob whose bytes hash to its key
+- **WHEN** a caller reads the stream to EOF
+- **THEN** the read completes with `io.EOF` and no integrity error
+
+#### Scenario: corrupted blob fails at EOF
+- **GIVEN** a stored blob whose bytes have been modified so they no longer hash
+  to its key
+- **WHEN** a caller reads the stream to EOF
+- **THEN** the read returns an error wrapping `common.ErrIntegrityMismatch` and
+  `syscall.EBADMSG`
+
+### Requirement: Verify-on-read is configurable
+The system SHALL accept a `[storage]` config key `verify_on_read` (boolean,
+default `true`) controlling whether `CASStore.Get` wraps blob streams with
+content-hash verification.
+
+#### Scenario: disabled verify-on-read
+- **GIVEN** `verify_on_read = false`
+- **WHEN** a caller reads a corrupted blob to EOF
+- **THEN** the read completes without an integrity error
+
+### Requirement: Background scrub quarantines corrupt blobs
+The system SHALL provide `CASStore.StartScrub` (call-safe at most once,
+mirroring `StartGC`) that periodically iterates referenced blobs in the
+`objects` bucket, re-reads and re-hashes each via `BlobStore.GetBlob`, and for
+any blob whose recomputed hash does not equal its key, quarantines it: removes
+the blob content and its object metadata so subsequent reads for names mapping
+to that hash fail with `syscall.ENOENT`. The pass SHALL be bounded-memory,
+panic-recovered, cancellable on store close, and SHALL NOT hold the store read
+lock across blob I/O.
+
+#### Scenario: scrub round-trips a healthy store
+- **GIVEN** a store whose blobs all hash to their keys
+- **WHEN** a scrub pass runs
+- **THEN** no blobs are quarantined and all reads still succeed
+
+#### Scenario: scrub quarantines a corrupted blob
+- **GIVEN** a stored blob whose bytes have been modified to no longer hash to
+  their key
+- **WHEN** a scrub pass runs
+- **THEN** the blob content and metadata are removed, and a subsequent read of a
+  name mapping to that hash fails with `syscall.ENOENT`
+
+### Requirement: Scrub interval is configurable
+The system SHALL accept a `[storage]` config key `scrub_interval` (integer
+seconds, default `3600`) controlling how often the scrub pass runs.
+
+#### Scenario: default interval
+- **GIVEN** no `scrub_interval` configured
+- **THEN** the default is `3600` seconds
+
+### Requirement: Content-hash streaming helper
+The system SHALL expose `common.HashReader(r io.Reader)` returning the hex
+SHA-256 of `r` while streaming through a fixed-size buffer (bounded memory),
+mirroring `common.HashFile`.
+
+#### Scenario: HashReader matches HashFile
+- **GIVEN** the same content
+- **WHEN** hashed once via `common.HashReader` and once via `common.HashBytes`
+- **THEN** both report the same hex digest

--- a/openspec/changes/storage-at-rest-integrity/tasks.md
+++ b/openspec/changes/storage-at-rest-integrity/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Storage at-rest integrity — content-hash verify on read + background scrub (#924)
+
+## 1. Streaming content-hash helper (`src/common`)
+- [x] Add `HashReader(r io.Reader) (string, error)` to `common/hash.go` streaming
+      SHA-256 through a fixed-size buffer (bounded memory)
+- [x] Unit test: `HashReader` digest equals `HashBytes` for the same content
+
+## 2. Verify-on-read (`src/storage`)
+- [x] Add verifying `io.Reader`/`io.ReadCloser` wrappers in `storage.go` that
+      recompute SHA-256 and assert the key at EOF (mismatch →
+      `ErrIntegrityMismatch` + `syscall.EBADMSG`, no corrupt bytes served)
+- [x] Apply wrapper in `CASStore.Get` when `VerifyOnRead` is enabled
+- [x] Add `VerifyOnRead bool` to `CASStore`; default enable in `factory.go`
+
+## 3. Background scrub (`src/storage`)
+- [x] Add `ScrubConfig` + `DefaultScrubConfig` (interval 3600s)
+- [x] Add `StartScrub` (sync.Once-guarded, mirrors `StartGC`) + `scrubLoop` +
+      `runScrub`, cancellable via `scrubDone`/`scrubWG`
+- [x] Quarantine path: iterate referenced blobs, re-read + re-hash via
+      `BlobStore.GetBlob`, remove corrupt blob content + object metadata
+      (explicit `ENOENT` on later reads); do not hold `s.mu` across blob I/O
+- [x] Close integration: stop scrub in `CASStore.Close` (goleak-safe)
+
+## 4. Config wiring
+- [x] Add `ScrubInterval int`, `VerifyOnRead bool` to `ConfigurationStorage`
+- [x] Load `scrub_interval` (default 3600) and `verify_on_read` (default true)
+      in `loadStorageConfig`; defaults in `defaultStorageConfig`
+- [x] Start scrub with configured interval in `factory.go`
+
+## 5. Tests (`src/storage`)
+- [x] Verify-on-read: valid blob serves to EOF; corrupted blob errors with
+      `ErrIntegrityMismatch`+`EBADMSG`; gated off when `VerifyOnRead=false`
+- [x] Scrub: healthy store round-trip (no quarantine); corrupted blob
+      quarantined → read `ENOENT`
+- [x] Panic-recover + goleak: store close stops scrub goroutine
+- [x] Config: defaults and overrides for `scrub_interval` / `verify_on_read`
+
+## 6. Validation + docs
+- [x] `go fmt ./...`, `go vet ./...`, `go build ./...`, `go test ./...`
+- [x] `go test -race ./...` on storage + common
+- [x] `go work sync` + `go work vendor` parity
+- [x] Docs: config sample + storage docs updated (Rule 27)

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -513,6 +513,8 @@ func defaultStorageConfig() ConfigurationStorage {
 		Backend:            BackendLocal,
 		GCInterval:         300,
 		TombstoneRetention: 86400,
+		ScrubInterval:      3600,
+		VerifyOnRead:       true,
 	}
 }
 
@@ -541,6 +543,16 @@ func loadStorageConfig(section *ini.Section) (ConfigurationStorage, error) {
 	cfg.TombstoneRetention, err = section.Key("tombstone_retention").Int()
 	if err != nil || cfg.TombstoneRetention <= 0 {
 		cfg.TombstoneRetention = 86400
+	}
+
+	cfg.ScrubInterval, err = section.Key("scrub_interval").Int()
+	if err != nil || cfg.ScrubInterval <= 0 {
+		cfg.ScrubInterval = 3600
+	}
+
+	cfg.VerifyOnRead, err = section.Key("verify_on_read").Bool()
+	if err != nil {
+		cfg.VerifyOnRead = true
 	}
 
 	cfg.S3Endpoint = section.Key("s3_endpoint").String()

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -195,6 +195,56 @@ func TestGetConfig_StorageBackends_Valid(t *testing.T) {
 	})
 }
 
+// TestGetConfig_StorageIntegrity covers the #924 scrub_interval and
+// verify_on_read keys, including their defaults.
+func TestGetConfig_StorageIntegrity(t *testing.T) {
+	mk := func(t *testing.T, storage string) string {
+		t.Helper()
+		tmpDir := t.TempDir()
+		tmpfile := filepath.Join(tmpDir, "momo.conf")
+		if err := os.WriteFile(tmpfile, []byte(validConfig+"\n[storage]\n"+storage), 0666); err != nil {
+			t.Fatalf("Failed to write config: %v", err)
+		}
+		return tmpfile
+	}
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg, err := GetConfig(mk(t, "backend = local\n"))
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+		if cfg.Storage.ScrubInterval != 3600 {
+			t.Errorf("default ScrubInterval = %d, want 3600", cfg.Storage.ScrubInterval)
+		}
+		if !cfg.Storage.VerifyOnRead {
+			t.Error("default VerifyOnRead should be true")
+		}
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		cfg, err := GetConfig(mk(t, "backend = local\nscrub_interval = 60\nverify_on_read = false\n"))
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+		if cfg.Storage.ScrubInterval != 60 {
+			t.Errorf("ScrubInterval = %d, want 60", cfg.Storage.ScrubInterval)
+		}
+		if cfg.Storage.VerifyOnRead {
+			t.Error("VerifyOnRead should be false")
+		}
+	})
+
+	t.Run("invalid scrub_interval falls back to default", func(t *testing.T) {
+		cfg, err := GetConfig(mk(t, "backend = local\nscrub_interval = 0\n"))
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+		if cfg.Storage.ScrubInterval != 3600 {
+			t.Errorf("invalid ScrubInterval should fall back to 3600, got %d", cfg.Storage.ScrubInterval)
+		}
+	})
+}
+
 // TestGetConfig_S3GatewayCredentials covers the issue #656 dedicated S3 gateway
 // SigV4 credential pair validation and parsing.
 func TestGetConfig_S3GatewayCredentials(t *testing.T) {

--- a/src/common/hash.go
+++ b/src/common/hash.go
@@ -38,3 +38,28 @@ func HashBytes(data []byte) string {
 	hex.Encode(hexBuf[:], hash[:])
 	return string(hexBuf[:])
 }
+
+// HashReader calculates the SHA-256 hash of a stream and returns it as a
+// hex-encoded string. It streams through a fixed-size buffer (bounded memory),
+// mirroring HashFile. The reader is fully consumed.
+func HashReader(r io.Reader) (string, error) {
+	h := sha256.New()
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			h.Write(buf[:n])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+	var sumBuf [sha256.Size]byte
+	sum := h.Sum(sumBuf[:0])
+	var hexBuf [sha256.Size * 2]byte
+	hex.Encode(hexBuf[:], sum)
+	return string(hexBuf[:]), nil
+}

--- a/src/common/hash_test.go
+++ b/src/common/hash_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"os"
 	"testing"
 )
@@ -33,6 +34,33 @@ func TestHashFile(t *testing.T) {
 		t.Errorf("Expected hash %s, but got %s", expectedHash, actualHash)
 	}
 }
+
+func TestHashReader(t *testing.T) {
+	content := []byte("hello world")
+	got, err := HashReader(bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("HashReader failed: %v", err)
+	}
+	want := "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+	if got != want {
+		t.Errorf("HashReader mismatch: got %s, want %s", got, want)
+	}
+	if got != HashBytes(content) {
+		t.Errorf("HashReader != HashBytes: %s vs %s", got, HashBytes(content))
+	}
+}
+
+func TestHashReader_ErrorPropagated(t *testing.T) {
+	_, err := HashReader(&errReader{err: os.ErrClosed})
+	if err == nil {
+		t.Error("expected error from failing reader")
+	}
+}
+
+// errReader always fails reads with the given error.
+type errReader struct{ err error }
+
+func (e *errReader) Read([]byte) (int, error) { return 0, e.err }
 
 func TestHashFile_NonExistentFile(t *testing.T) {
 	_, err := HashFile("non-existent-file.txt")

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -187,6 +187,11 @@ type ConfigurationStorage struct {
 	GCInterval int
 	// TombstoneRetention is how long tombstones are kept, in seconds.
 	TombstoneRetention int
+	// ScrubInterval is how often the background integrity scrub runs, in seconds.
+	ScrubInterval int
+	// VerifyOnRead re-derives the blob SHA-256 at read EOF and fails reads when
+	// the content no longer matches its address key. Defaults to true (issue #924).
+	VerifyOnRead bool
 	// S3Endpoint is the S3-compatible API endpoint URL.
 	S3Endpoint string
 	// S3Region is the S3 region name.

--- a/src/metrics/go.mod
+++ b/src/metrics/go.mod
@@ -5,6 +5,7 @@ go 1.25.10
 require (
 	github.com/alsotoes/momo/src/common v0.0.0-20260604213252-d8e9e90c2b38
 	github.com/shirou/gopsutil/v3 v3.24.5
+	go.uber.org/goleak v1.3.0
 )
 
 require (

--- a/src/storage/factory.go
+++ b/src/storage/factory.go
@@ -66,5 +66,12 @@ func NewStore(cfg common.ConfigurationStorage, daemon *common.Daemon, encKeyHex 
 		TombstoneRetention: tombstoneRetention,
 	})
 
+	scrubInterval := time.Duration(cfg.ScrubInterval) * time.Second
+	if scrubInterval <= 0 {
+		scrubInterval = time.Hour
+	}
+	s.VerifyOnRead = cfg.VerifyOnRead
+	s.StartScrub(ScrubConfig{Interval: scrubInterval})
+
 	return s, nil
 }

--- a/src/storage/integrity.go
+++ b/src/storage/integrity.go
@@ -1,0 +1,247 @@
+package storage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"syscall"
+	"time"
+
+	"github.com/alsotoes/momo/src/common"
+	"go.etcd.io/bbolt"
+)
+
+// contentHashVerifiedError marks blob content that no longer matches its
+// content-address key. Reads surface it so corrupt bytes are never served.
+func contentHashVerifiedError(key string) error {
+	return fmt.Errorf("%w: blob %s no longer matches its content address: %w", common.ErrIntegrityMismatch, key, syscall.EBADMSG)
+}
+
+// verifyingReader recomputes the SHA-256 of a stream and, at EOF, asserts it
+// equals the expected content-address key. On mismatch it returns an integrity
+// error instead of a clean io.EOF, so corrupt bytes are never reported as a
+// successful read. It is bounded-memory: it streams through the caller's
+// buffer and only holds a SHA-256 state.
+type verifyingReader struct {
+	src      io.Reader
+	h        sha256Alg
+	expected string
+	checked  bool
+	corrupt  error
+}
+
+// sha256Alg avoids dragging the concrete hash.Hash name into the struct.
+type sha256Alg = interface {
+	Write(p []byte) (int, error)
+	Sum(b []byte) []byte
+}
+
+func newVerifyingReader(src io.Reader, expected string) *verifyingReader {
+	return &verifyingReader{src: src, h: sha256.New(), expected: expected}
+}
+
+func (v *verifyingReader) Read(p []byte) (int, error) {
+	if v.corrupt != nil {
+		return 0, v.corrupt
+	}
+	n, err := v.src.Read(p)
+	if n > 0 {
+		v.h.Write(p[:n])
+	}
+	if err == io.EOF && !v.checked {
+		v.checked = true
+		var sum [sha256.Size]byte
+		digest := v.h.Sum(sum[:0])
+		key := hex.EncodeToString(digest)
+		if key != v.expected {
+			v.corrupt = contentHashVerifiedError(v.expected)
+			return n, v.corrupt
+		}
+	}
+	return n, err
+}
+
+// verifyingReadCloser wraps a verifyingReader over an underlying ReadCloser and
+// forwards Close to the underlying stream.
+type verifyingReadCloser struct {
+	*verifyingReader
+	underlying io.Closer
+}
+
+func (v *verifyingReadCloser) Close() error { return v.underlying.Close() }
+
+// ScrubConfig configures the background integrity scrub.
+type ScrubConfig struct {
+	// Interval is how often the scrub passes over referenced blobs.
+	Interval time.Duration
+}
+
+// DefaultScrubConfig returns sensible defaults for the scrubber (1 hour).
+func DefaultScrubConfig() ScrubConfig {
+	return ScrubConfig{Interval: time.Hour}
+}
+
+// StartScrub launches the background integrity scrub goroutine. It is safe to
+// call at most once per CASStore instance — the sync.Once guard makes repeated
+// invocations no-ops (mirroring StartGC) so multiple scrub loops cannot spawn.
+func (s *CASStore) StartScrub(cfg ScrubConfig) {
+	s.scrubOnce.Do(func() {
+		s.scrubWG.Add(1)
+		go s.scrubLoop(cfg)
+	})
+}
+
+func (s *CASStore) scrubLoop(cfg ScrubConfig) {
+	s.scrubStarted.Store(1)
+	defer s.scrubWG.Done()
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("STORAGE SCRUB: scrubLoop panic recovered: %v", r)
+		}
+	}()
+
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.scrubDone:
+			return
+		case <-ticker.C:
+			if err := s.runScrub(); err != nil {
+				log.Printf("STORAGE SCRUB: pass error: %v", err)
+			}
+		}
+	}
+}
+
+// runScrub performs a single integrity pass over all referenced blobs. Blob
+// reads (which may be network I/O for S3 backends) happen outside s.mu to avoid
+// blocking concurrent store operations.
+func (s *CASStore) runScrub() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("STORAGE SCRUB: runScrub panic recovered: %v", r)
+			err = fmt.Errorf("storage scrub panic: %w", syscall.EIO)
+		}
+	}()
+
+	hashes, err := s.referencedBlobs()
+	if err != nil {
+		return err
+	}
+
+	var quarantined []string
+	for _, hash := range hashes {
+		canceled, ok, qerr := s.scrubBlob(hash)
+		if qerr != nil {
+			log.Printf("STORAGE SCRUB: failed to verify blob %s: %v", hash, qerr)
+			continue
+		}
+		if canceled {
+			return nil
+		}
+		if ok {
+			quarantined = append(quarantined, hash)
+		}
+	}
+
+	if len(quarantined) > 0 {
+		log.Printf("AUDIT: STORAGE SCRUB quarantined %d corrupted blob(s): %v", len(quarantined), quarantined)
+	} else {
+		log.Printf("STORAGE SCRUB: pass complete, %d blob(s) verified, 0 corrupted", len(hashes))
+	}
+	return nil
+}
+
+// referencedBlobs returns the content-hash keys of all referenced (non-orphaned)
+// blobs, under a short bbolt read transaction.
+func (s *CASStore) referencedBlobs() ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var hashes []string
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketObjects)
+		if b == nil {
+			return nil
+		}
+		c := b.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(v) != 24 {
+				continue
+			}
+			meta, err := decodeObjectMeta(v)
+			if err != nil {
+				return fmt.Errorf("failed to decode metadata for blob %s: %w", k, err)
+			}
+			if meta.RefCount > 0 {
+				hashes = append(hashes, string(k))
+			}
+		}
+		return nil
+	})
+	return hashes, err
+}
+
+// scrubBlob re-reads and re-hashes a single blob. It reports whether the blob
+// was quarantined and whether the store is being closed (canceled).
+func (s *CASStore) scrubBlob(hash string) (canceled, quarantined bool, err error) {
+	select {
+	case <-s.scrubDone:
+		return true, false, nil
+	default:
+	}
+
+	rc, err := s.blobs.GetBlob(hash)
+	if err != nil {
+		if err == syscall.ENOENT {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	digest, rerr := common.HashReader(rc)
+	closeErr := rc.Close()
+	if rerr != nil {
+		if closeErr != nil {
+			log.Printf("STORAGE SCRUB: close after hash error for %s: %v", hash, closeErr)
+		}
+		return false, false, rerr
+	}
+	if closeErr != nil {
+		return false, false, closeErr
+	}
+	if digest != hash {
+		if err := s.quarantine(hash); err != nil {
+			return false, false, err
+		}
+		return false, true, nil
+	}
+	return false, false, nil
+}
+
+// quarantine removes a corrupted blob's content and its object metadata so
+// later reads for names mapping to that hash fail explicitly with ENOENT. The
+// blob deletion (possibly network I/O for S3 backends) runs outside the write
+// transaction, mirroring the orphan-deletion pattern.
+func (s *CASStore) quarantine(hash string) error {
+	if delErr := s.blobs.DeleteBlob(hash); delErr != nil {
+		log.Printf("AUDIT: STORAGE SCRUB failed to delete corrupted blob %s: %v", hash, delErr)
+		return delErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if metaErr := s.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketObjects).Delete([]byte(hash))
+	}); metaErr != nil {
+		log.Printf("AUDIT: STORAGE SCRUB failed to remove metadata for corrupted blob %s: %v", hash, metaErr)
+		return metaErr
+	}
+	return nil
+}

--- a/src/storage/integrity_test.go
+++ b/src/storage/integrity_test.go
@@ -1,0 +1,203 @@
+package storage
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/alsotoes/momo/src/common"
+	"go.uber.org/goleak"
+)
+
+// putBlob stores a named object and returns its content hash.
+func putBlob(t *testing.T, s *CASStore, name string, content []byte) string {
+	t.Helper()
+	hash := common.HashBytes(content)
+	if err := s.Put(name, hash, int64(len(content)), "", bytes.NewReader(content)); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+	return hash
+}
+
+// corruptBlob overwrites the on-disk blob for a hash so it no longer matches.
+func corruptBlob(t *testing.T, s *CASStore, hash string) {
+	t.Helper()
+	p := s.getBlobPath(hash)
+	f, err := os.OpenFile(p, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open blob for corruption: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteAt([]byte{0xBB}, 0); err != nil {
+		t.Fatalf("corrupt blob: %v", err)
+	}
+}
+
+func TestVerifyOnRead_ValidBlobServesToEOF(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	content := []byte("hello integrity")
+	putBlob(t, s, "f", content)
+
+	rc, _, err := s.Get("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err != nil {
+		t.Fatalf("valid blob should read to EOF without error, got: %v", err)
+	}
+}
+
+func TestVerifyOnRead_CorruptBlobFailsAtEOF(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	content := []byte("hello integrity")
+	hash := putBlob(t, s, "f", content)
+	corruptBlob(t, s, hash)
+
+	rc, _, err := s.Get("f")
+	if err != nil {
+		t.Fatalf("Get should succeed (error only surfaces at EOF): %v", err)
+	}
+	defer rc.Close()
+	_, rerr := io.ReadAll(rc)
+	if rerr == nil {
+		t.Fatal("expected integrity error reading corrupted blob, got nil")
+	}
+	if !errors.Is(rerr, common.ErrIntegrityMismatch) {
+		t.Errorf("expected ErrIntegrityMismatch, got: %v", rerr)
+	}
+	if !errors.Is(rerr, syscall.EBADMSG) {
+		t.Errorf("expected syscall.EBADMSG, got: %v", rerr)
+	}
+}
+
+func TestVerifyOnRead_DisabledServesCorruptBytes(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	content := []byte("hello integrity")
+	hash := putBlob(t, s, "f", content)
+	corruptBlob(t, s, hash)
+	s.VerifyOnRead = false
+
+	rc, _, err := s.Get("f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err != nil {
+		t.Fatalf("verify_on_read=false should not check hash, got: %v", err)
+	}
+}
+
+func TestScrub_HealthyStoreRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	putBlob(t, s, "a", []byte("aaaa"))
+	putBlob(t, s, "b", []byte("bbbb"))
+
+	if err := s.runScrub(); err != nil {
+		t.Fatalf("scrub pass failed: %v", err)
+	}
+
+	for _, name := range []string{"a", "b"} {
+		rc, _, err := s.Get(name)
+		if err != nil {
+			t.Fatalf("read %s after scrub: %v", name, err)
+		}
+		io.Copy(io.Discard, rc)
+		rc.Close()
+	}
+}
+
+func TestScrub_QuarantinesCorruptBlob(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	content := []byte("hello scrub")
+	hash := putBlob(t, s, "f", content)
+	corruptBlob(t, s, hash)
+
+	if err := s.runScrub(); err != nil {
+		t.Fatalf("scrub pass failed: %v", err)
+	}
+
+	if _, _, err := s.Get("f"); !errors.Is(err, syscall.ENOENT) {
+		t.Fatalf("read of quarantined blob should fail ENOENT, got: %v", err)
+	}
+	// Metadata for the blob should also be gone.
+	hashed, err := s.Has(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hashed {
+		t.Error("quarantined blob metadata should have been removed")
+	}
+}
+
+func TestScrub_StartStopGoroutine(t *testing.T) {
+	goleak.VerifyNone(t) // runs after the deferred Close below (LIFO)
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	s.StartScrub(ScrubConfig{Interval: 50 * time.Millisecond})
+	waitScrubStarted(t, s)
+}
+
+func TestScrub_StartScrubIdempotent(t *testing.T) {
+	goleak.VerifyNone(t)
+	dir := t.TempDir()
+	s, err := NewCASStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	s.StartScrub(ScrubConfig{Interval: time.Hour})
+	s.StartScrub(ScrubConfig{Interval: time.Hour})
+	waitScrubStarted(t, s) // single goroutine; sync.Once prevents a second
+}
+
+// waitScrubStarted polls until the scrub goroutine has observed its start flag,
+// avoiding a race between StartScrub and the immediate flag read.
+func waitScrubStarted(t *testing.T, s *CASStore) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for s.scrubStarted.Load() != 1 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if s.scrubStarted.Load() != 1 {
+		t.Fatal("scrub goroutine did not report started")
+	}
+}

--- a/src/storage/storage.go
+++ b/src/storage/storage.go
@@ -93,6 +93,15 @@ type CASStore struct {
 	closeOnce sync.Once
 	gcOnce    sync.Once
 	gcStarted atomic.Int32
+
+	// VerifyOnRead re-derives the blob SHA-256 at read EOF and fails reads when
+	// it no longer matches the content-address key (at-rest integrity, #924).
+	VerifyOnRead bool
+
+	scrubDone    chan struct{}
+	scrubWG      sync.WaitGroup
+	scrubOnce    sync.Once
+	scrubStarted atomic.Int32
 }
 
 // NewCASStore initializes a CAS store with a LocalBlobStore backend.
@@ -145,10 +154,12 @@ func newCASStore(dataDir string, blobs BlobStore) (*CASStore, error) {
 	}
 
 	return &CASStore{
-		db:     db,
-		base:   dataDir,
-		blobs:  blobs,
-		gcDone: make(chan struct{}),
+		db:           db,
+		base:         dataDir,
+		blobs:        blobs,
+		gcDone:       make(chan struct{}),
+		scrubDone:    make(chan struct{}),
+		VerifyOnRead: true,
 	}, nil
 }
 
@@ -157,6 +168,10 @@ func (s *CASStore) Close() error {
 		if s.gcDone != nil {
 			close(s.gcDone)
 			s.gcWG.Wait()
+		}
+		if s.scrubDone != nil {
+			close(s.scrubDone)
+			s.scrubWG.Wait()
 		}
 		s.mu.Lock()
 		if s.blobs != nil {
@@ -293,6 +308,17 @@ func (s *CASStore) Get(name string) (rc io.ReadCloser, meta common.FileMetadata,
 	f, openErr := s.blobs.GetBlob(hash)
 	if openErr != nil {
 		return nil, common.FileMetadata{}, openErr
+	}
+
+	// 🛡️ At-rest integrity (#924): when enabled, re-derive the blob's SHA-256 as
+	// it streams and fail at EOF if it no longer matches the content-address key
+	// instead of serving corrupt bytes. The verification cost runs as the caller
+	// drains the stream — after Get returns, outside s.mu.
+	if s.VerifyOnRead {
+		f = &verifyingReadCloser{
+			verifyingReader: newVerifyingReader(f, hash),
+			underlying:      f,
+		}
 	}
 
 	// 🛡️ Zero-Crash: Ensure file is closed if subsequent metadata lookups fail.


### PR DESCRIPTION
Resolves #924

At-rest integrity for the CAS store: blobs are content-addressed by SHA-256 but the read path never re-derived the hash, so a corrupted blob at rest was served silently. This adds content-address re-verification (verify-on-read) plus a background scrub that detects and quarantines corruption.

## Changes

**`src/common`**
- `hash.go`: new `HashReader(r io.Reader)` — streaming SHA-256 through a fixed 32 KB buffer (bounded-memory), mirrors `HashFile`.
- `struct.go` / `config.go`: `ConfigurationStorage.ScrubInterval int` (default 3600) and `VerifyOnRead bool` (default true); parsed from `[storage]` keys `scrub_interval` and `verify_on_read`.

**`src/storage`**
- `integrity.go` (new):
  - `verifyingReader`/`verifyingReadCloser` — recompute SHA-256; at EOF assert it equals the content-hash key or fail reads with `common.ErrIntegrityMismatch` + `syscall.EBADMSG` (no corrupt bytes served). Verification runs as the caller drains the stream, outside the bbolt/`s.mu` critical section.
  - `StartScrub`/`scrubLoop`/`runScrub`/`quarantine` — mirror the GC loop (`scrubOnce`/`scrubDone`/`scrubWG`, goleak-safe, panic-recovered). Each pass lists referenced blobs, re-reads + re-hashes via `BlobStore.GetBlob` (I/O outside `s.mu`), and quarantines mismatches (delete content + metadata → later reads `ENOENT`).
- `storage.go`: `Get` wraps the blob stream with `verifyingReadCloser` when `VerifyOnRead` (default true); `CASStore.Close` stops the scrub goroutine.
- `factory.go`: `NewStore` applies `cfg.VerifyOnRead` and starts the scrub with `cfg.ScrubInterval`.

**Tests** (all pass): `HashReader` matches `HashBytes`; verify-on-read serves valid blobs / fails corrupted at EOF (`ErrIntegrityMismatch`+`EBADMSG`) / inert when disabled; scrub round-trips healthy store, quarantines corrupt blob (→ `ENOENT`, metadata removed); `StartScrub` start/stop + double-call idempotency with `goleak.VerifyNone`; config defaults/overrides/fallback.

**Docs (Rule 27)**: `docs/ARCHITECTURE.md` §4f, `docs/CONFIGURATION.md` (bullet + example), `conf/momo.conf`.

**OpenSpec (Rule 73)**: `openspec/changes/storage-at-rest-integrity/` — proposal, spec (linked to #924), tasks.

## Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `make test` (vet + `-race -cover` across all 8 modules) ✓ — 0 FAIL
- `gofmt` clean on all changed files (pre-existing `transport/momo_quic_crlf_test.go` untouched — only flagged by newer gofmt, not the pinned 1.25.10)
- `go work sync` + `go work vendor` no vendor diff (1-line goleak require added to `src/metrics/go.mod` by sync)

## Reviewer status
Initial submission. @alsotoes

## Changelog
- bb82a48 — feat: at-rest integrity — content-hash verify on read + background scrub (#924)
