### PR TITLE
docs/openspec: ratify production-readiness roadmap + P0 item specs

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,4 +54,36 @@ This document outlines the high-level roadmap for the Momo project, tracking maj
 - **Client SDKs**: Native SDKs for Python and Rust.
 
 ---
-*Last Updated: 2026-08-02*
+
+## Production-Readiness Roadmap
+
+Ratified in [prod-ready-roadmap](../openspec/changes/prod-ready-roadmap/specs/prod-ready-roadmap/spec.md) (#928). Momo is currently a replicated content-addressed blob store + S3 gateway; the FUSE/POSIX filesystem layer (`docs/momofs/`) is design-only. Phases gate production readiness.
+
+### P0 — Correctness & Durability (blockers)
+
+| ID | Item | Deliverable |
+|----|------|-------------|
+| R1 | Failure-domain-aware CRUSH placement | Rack/zone/DC groups constrain replica placement |
+| R2 | Degraded-read + self-heal rebuild | Re-replicate after corruption/quarantine/underrreplication |
+| R3 | Write durability + ack quorum + consistency | fsync-before-ack, survivor quorum, read-your-writes |
+| R4 | momofs FUSE/POSIX layer | Mountable POSIX filesystem with correct metadata semantics |
+
+### P1 — Operability, Multi-Tenancy, Security
+
+| ID | Item | Deliverable |
+|----|------|-------------|
+| R5 | Metrics phases 2–4 + dashboards/alerts | Storage/CAS + P2P/cluster gauges, latency histograms |
+| R6 | Metadata catalog HA + backup/recovery | Distributed metadata; snapshot/restore |
+| R7 | Error model & ops | ENOSPC surfacing, distinct exit codes, cluster health |
+| R8 | Multi-tenancy + authorization + audit | Identity/ACL/policy, audit logging |
+| R9 | Secrets management + key rotation | Env/KMS secrets, rotation for master/tenant/OPRF/auth keys |
+
+### P2 — S3 Breadth & Scale
+
+| ID | Item | Deliverable |
+|----|------|-------------|
+| R10 | S3 lifecycle/versioning/notification/lock breadth | Extends #820; real-tooling compatibility |
+| R11 | Auto-rebalance on membership change | Dynamic data movement on node join/leave |
+
+---
+*Last Updated: 2026-08-24*

--- a/openspec/changes/prod-ready-roadmap/proposal.md
+++ b/openspec/changes/prod-ready-roadmap/proposal.md
@@ -1,0 +1,57 @@
+# Change: Production-readiness roadmap — prioritized hardening track
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/928 (parent roadmap issue)
+- sub-issues: R1 #929, R2 #930, R3 #931, R4 #932, R5 #933, R6 #934, R7 #935,
+  R8 #936, R9 #937, R10 #938, R11 #939
+
+## Why
+
+Momo today is a replicated, content-addressed **blob store** with an S3-compatible
+gateway and P2P gossip membership. It is not yet a **production-ready distributed
+**filesystem**: the FUSE/POSIX layer (`docs/momofs/`) is design-only, metadata is
+per-node bbolt (no distributed catalog/consensus), and several correctness and
+operability guarantees are missing. A documentation audit (`docs/*.md`, PR #927)
+confirmed the gap surface. This change ratifies the **prioritized production-readiness
+roadmap** and gates future work.
+
+## Scope (out of scope)
+
+This change defines and ratifies the roadmap and its phase gates. It does **not**
+implement any item. Each prioritized item is tracked by its own OpenSpec change
+(under `openspec/changes/`) and GitHub issue, referencing this change.
+
+## Phases & Items
+
+### Phase P0 — correctness & durability (blockers, implement first)
+
+| ID | Item | Deliverable | Status |
+|----|------|-------------|--------|
+| R1 | Failure-domain-aware CRUSH placement | Rack/zone/DC groups constrain replica placement | Planned |
+| R2 | Degraded-read + self-heal rebuild | Re-replicate after corruption/quarantine/underr replication | Planned |
+| R3 | Write durability + ack quorum + defined consistency | fsync-ack semantics, survivor-set quorum, read-your-writes | Planned |
+| R4 | momofs FUSE/POSIX layer | Mountable POSIX filesystem with correct metadata semantics | Planned |
+
+### Phase P1 — operability, multi-tenancy, security
+
+| ID | Item | Deliverable | Status |
+|----|------|-------------|--------|
+| R5 | Metrics phases 2–4 + dashboards/alerts | Storage/CAS + P2P/cluster gauges, latency histograms, alerts | Planned |
+| R6 | Metadata catalog HA/consensus + backup/recovery | Distributed metadata; snapshot/restore story | Planned |
+| R7 | Error model & ops | Dedicated exit codes, ENOSPC surfacing, cluster health/status | Planned |
+| R8 | Multi-tenancy + authorization + audit | Identity/ACL/policy, audit logging | Planned |
+| R9 | Secrets management + key rotation | Env/KMS secrets, rotation for master/tenant/OPRF/auth keys | Planned |
+
+### Phase P2 — S3 breadth & scale
+
+| ID | Item | Deliverable | Status |
+|----|------|-------------|--------|
+| R10 | S3 lifecycle/versioning/notification/lock breadth | Extends #820 long tail; real-tooling compatibility | Planned |
+| R11 | Auto-rebalance on membership change | Dynamic data movement on node join/leave | Planned |
+
+## Definitions of Done per Phase
+
+- **P0**: each sub-change merged with tests (`-race`, goleak), docs updated (Rule 27),
+  CI green; momo passes POSIX smoke + kill-node rebuild assertions.
+- **P1**: each sub-change merged; `make test` green; observability/ops docs updated.
+- **P2**: each sub-change merged; S3 conformance & membership e2e green.

--- a/openspec/changes/prod-ready-roadmap/specs/prod-ready-roadmap/spec.md
+++ b/openspec/changes/prod-ready-roadmap/specs/prod-ready-roadmap/spec.md
@@ -1,0 +1,77 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/928
+
+# prod-ready-roadmap Specification
+
+## Purpose
+Ratify the prioritized production-readiness roadmap for momo and define the phase
+gates. It is a planning/specification change: it does not implement items, it
+assigns each item to an OpenSpec change + GitHub issue and defines Definition of
+Done per phase.
+
+## Terminology
+- **Failure domain** — a group of nodes that share a correlated-failure risk (rack,
+  DC, zone). Placement must spread replicas across distinct domains where possible.
+- **Self-heal rebuild** — background re-replication that restores a blob's target
+  replica count after detected corruption, quarantine, or underreplication.
+- **Durability ack** — a write is acknowledged only after the required number of
+  replicas have durably durable-persisted (fsync) the object.
+- **Survivor-set quorum** — the minimum number of live replicas required to serve
+  a read or accept a write degradation.
+
+## Requirements
+
+### REQ-1 (P0 gate): Failure-domain-aware placement
+R1 MUST constrain CRUSH replica placement such that upstream data is spread across
+distinct failure domains when the cluster topology provides them. `R1` spec: R1.
+
+### REQ-2 (P0 gate): Degraded-read + rebuild
+R2 MUST (a) allow reads to proceed from a degraded/quarantined replica set when a
+survivor-set quorum is available, (b) background-regenerate blobs that are
+corrupt/underrreplicated, restoring the target replica count. R2 spec: R2.
+
+### REQ-3 (P0 gate): Write durability + consistency
+R3 MUST define durability-ack semantics (fsync-before-ack), a survivor-set quorum
+for writes, and a documented consistency model (sequential / read-your-writes for
+single-object ops). R3 spec: R3.
+
+### REQ-4 (P0 gate): POSIX filesystem surface
+R4 MUST provide a mountable FUSE-based POSIX filesystem exposing momo's object
+store with correct metadata semantics (directories, rename atomicity, hardlinks,
+mmap/read-write exports, POSIX locks). R4 spec: R4.
+
+### REQ-5 (P1): Observability & alerts
+R5 MUST add storage/CAS + P2P/cluster gauges and latency histograms, plus
+dashboards/alerts, building on the existing `/metrics` + `MetricsHook`.
+
+### REQ-6 (P1): Metadata HA
+R6 MUST establish a distributed metadata catalog/consensus and a documented
+snapshot/backup/recovery path for metadata.
+
+### REQ-7 (P1): Error model & ops
+R7 MUST surface `ENOSPC`, add distinct fatal exit codes, and provide cluster
+health/status introspection.
+
+### REQ-8 (P1): Multi-tenancy & authorization
+R8 MUST add identity, ACL/policy-based authorization, and audit logging beyond the
+single shared `auth_token`.
+
+### REQ-9 (P1): Secrets management
+R9 MUST support environment/KMS secret sourcing and rotation for master, tenant,
+OPRF-share, and auth-token material.
+
+### REQ-10 (P2): S3 feature breadth
+R10 MUST close high-impact S3 feature gaps (lifecycle, versioning, notification,
+object lock) tracked under #820, for real-tooling compatibility.
+
+### REQ-11 (P2): Membership rebalance
+R11 MUST rebalance existing replicas when cluster membership changes.
+
+## Phasing & Ordering
+1. P0 items (R1→R4) must land, each with `-race`+goleak tests, Rule-27 docs, and
+   CI green, before momo is declared production-ready for a filesystem workload.
+2. P1 items (R5→R9) follow; each independently releasable.
+3. P2 items (R10→R11) follow; each independently releasable.
+
+## Non-Requirements (explicitly out of scope for this change)
+- Implementing any roadmap item.
+- Adding a new storage backend or metadata engine.

--- a/openspec/changes/prod-ready-roadmap/tasks.md
+++ b/openspec/changes/prod-ready-roadmap/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Production-readiness roadmap — prioritized hardening track (#928)
+
+## 1. Ratify roadmap
+- [x] Proposal written (`proposal.md`) with P0/P1/P2 phases, item table, DoD
+- [x] Specification written (`spec.md`) with REQ-1..REQ-11 + phase gates
+- [x] Link each item to its OpenSpec change + GitHub issue
+- [ ] docs/ROADMAP.md updated with the production-readiness tiers (Rule 27)
+- [ ] Mirror to GitHub: create parent roadmap issue + sub-issue chain R1–R11
+      (labels `enhancement` + `automation`, assignee `alsotoes`) — Rule 11/49
+
+## 2. Phase P0 items (separate OpenSpec changes + PRs)
+- [ ] R1 failure-domain-aware CRUSH placement
+- [ ] R2 degraded-read + self-heal rebuild
+- [ ] R3 write durability + ack quorum + consistency model
+- [ ] R4 momofs FUSE/POSIX filesystem layer
+
+## 3. Phase P1 items
+- [ ] R5 metrics phases 2–4 + dashboards/alerts
+- [ ] R6 metadata catalog HA + backup/recovery
+- [ ] R7 error model + ops (ENOSPC, exit codes, cluster health)
+- [ ] R8 multi-tenancy + authorization + audit
+- [ ] R9 secrets management + key rotation
+
+## 4. Phase P2 items
+- [ ] R10 S3 lifecycle/versioning/notification/lock breadth (#820)
+- [ ] R11 auto-rebalance on membership change
+
+## 5. Validation
+- [ ] Each sub-change: `go test -race`, goleak, Rule-27 docs, CI green
+- [ ] Master branch CI green before each new item branch (Rule 71)

--- a/openspec/changes/r1-failure-domains/proposal.md
+++ b/openspec/changes/r1-failure-domains/proposal.md
@@ -1,0 +1,35 @@
+# Change: R1 — Failure-domain-aware CRUSH placement
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/929 (R1)
+- https://github.com/alsotoes/momo/issues/928 (production-readiness roadmap parent)
+
+## Why
+
+`src/common/crush.go` uses a flat, weight-based ring for replica placement. There is
+no concept of a failure domain (rack, data-center, zone). With `replication_factor=3`,
+CRUSH may place all three replicas of an object on nodes that share a single point of
+failure (same rack/power/network), so a single-domain outage destroys every copy.
+Production durability requires copying to be spread across independent failure domains.
+
+## What
+
+1. Model a failure-domain hierarchy. Assign each node a failure-domain label/path
+   (e.g. `rack=A`, or a hierarchy `dc=us-east1/rack=A`), configurable per `[daemon.N]`
+   via a new `failure_domain` key.
+2. Make `ClusterMap.Placement` failure-domain-aware: when placement selects replicas,
+   prefer nodes in distinct domains. Fall back progressively (distinct domain → same
+   domain) only when the cluster cannot satisfy the constraint, and log a degraded
+   warning (consistent with existing degraded-mode logging).
+3. Keep placement deterministic and minimal-movement when topology is stable.
+
+## Out of scope
+
+- Hierarchical CRUSH buckets / Ceph-style full CRUSH (design decision is flat +
+  failure-domain constraint, consistent with `CRUSH-lite`).
+- Live rebalancing (tracked as R11).
+
+## References
+
+- `docs/CRUSH.md` (placement algorithm), `src/common/crush.go`
+- Roadmap REQ-1: `prod-ready-roadmap`

--- a/openspec/changes/r1-failure-domains/specs/r1-failure-domains/spec.md
+++ b/openspec/changes/r1-failure-domains/specs/r1-failure-domains/spec.md
@@ -1,0 +1,57 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/929
+
+# r1-failure-domains Specification
+
+## Purpose
+Make CRUSH replica placement failure-domain-aware so a single-domain outage cannot
+destroy all replicas of an object, while preserving deterministic, minimal-movement,
+degraded-mode behavior.
+
+## Terminology
+- **Failure domain** — an independently failing unit (rack, DC, zone, power domain).
+- **Domain set of a placement** — the set of distinct failure domains occupied by the
+  selected replicas for an object.
+
+## Configuration
+
+### R1-C1: Node failure domain
+- Add `failure_domain string` to per-daemon configuration (`[daemon.N]`).
+- Optional; empty means "unclassified" (single default domain). Require `>= 0` domains
+  recognized per cluster.
+
+## Placement behavior
+
+### R1-C2: Domain-spread ordering
+Given an object hash and `replicationFactor R`, placement MUST pick the top-scoring set
+that maximizes the number of distinct failure domains, then (within the same count of
+distinct domains) maximizes total CRUSH weight per existing `finalScore` ordering.
+
+Algorithm:
+1. Compute per-node `finalScore` (existing WRH).
+2. Among candidate replica sets of size R, choose the one with the largest distinct-domain
+   count; break ties by descending sum of `finalScore`.
+3. Complexity must remain practical (cluster sizes are small; brute-force over
+   combinations is acceptable and documented).
+
+### R1-C3: Deterministic + minimal movement
+- Placement MUST be deterministic for a fixed topology (same object → same set).
+- When topology is unchanged, membership changes MUST NOT remap already-placed replicas
+  unless the new replica count requires it (consistent with today's behavior).
+
+### R1-C4: Degraded fallback + warning
+- If the domain constraint cannot be satisfied (e.g. `R` > distinct-domain count), CRUSH
+  MUST still return `R` replicas but MUST log a warning (extend existing degraded-mode
+  logging).
+- This mirrors the documented degraded-mode behavior for `replication_factor` under-capacity.
+
+## Tests
+
+### R1-T1
+- Table test across same-domain, multi-domain, and partial-domain topologies; assert the
+  selected set maximizes distinct domains and matches reference brute-force optimum.
+### R1-T2
+- Determinism: identical topology + hash yields identical placement across calls.
+### R1-T3
+- Degraded: `R` > distinct domains logs warning and returns `R` replicas.
+### R1-T4
+- Goleak + `-race` green; existing CRUSH benchmarks unchanged.

--- a/openspec/changes/r1-failure-domains/tasks.md
+++ b/openspec/changes/r1-failure-domains/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: R1 — Failure-domain-aware CRUSH placement (#929)
+
+## 1. Topology model (`src/common`)
+- [ ] Add failure-domain representation to the node/cluster model (`ClusterMap`/`Node`)
+- [ ] Parse `failure_domain` per `[daemon.N]` (optional; empty = unclassified)
+
+## 2. Placement (`src/common/crush.go`)
+- [ ] Implement domain-spread candidate selection (maximize distinct domains, tie-break
+      `finalScore`) — REQ R1-C2
+- [ ] Deterministic + minimal-movement behavior — R1-C3
+- [ ] Degraded fallback with warning when domain count < R — R1-C4
+- [ ] Keep `Placement` signature/protocol-compatible
+
+## 3. Config
+- [ ] Add `FailureDomain` to `ConfigurationDaemon` + load in `loadDaemonConfig`
+- [ ] `conf/momo.conf` + `docs/CONFIGURATION.md` (Rule 27)
+
+## 4. Tests (`src/common/crush_test.go`)
+- [ ] R1-T1 same/multi/partial-domain optimum
+- [ ] R1-T2 determinism
+- [ ] R1-T3 degraded fallback warning
+- [ ] R1-T4 goleak + `-race` green; benchmarks unchanged
+
+## 5. Validation
+- [ ] `go fmt`, `go vet`, `go build`, `go test` (common)
+- [ ] `go work sync` + vendor parity
+- [ ] Docs: `docs/CRUSH.md` updated (Rule 27)

--- a/openspec/changes/r2-self-heal-rebuild/proposal.md
+++ b/openspec/changes/r2-self-heal-rebuild/proposal.md
@@ -1,0 +1,32 @@
+# Change: R2 — Degraded-read + self-heal rebuild
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/930 (R2)
+- https://github.com/alsotoes/momo/issues/928 (roadmap parent)
+- https://github.com/alsotoes/momo/issues/924 (integrity scrub baseline)
+
+## Why
+
+`storage-at-rest-integrity` (#924) added verify-on-read and a background scrub that
+**quarantines** corrupt blobs. But quarantine is delete-only: a corrupt copy is removed
+and later reads get `ENOENT`. There is no cross-replica healing — if one replica of an
+object is corrupt/underrreplicated while others hold good bytes, momo does not regenerate
+it from the survivors. A single lost node reduces `replication_factor` to `factor-1`
+permanently (no background repair). Production durability requires degraded reads and a
+self-healing re-replication loop.
+
+## What
+
+1. **Survivor-set degraded read**: when a blob's primary replica is unavailable/corrupt
+   but another replica holds a verified-good copy, reads serve from an eligible survivor
+   (survivor-set quorum), instead of failing.
+2. **Self-heal rebuild**: a background loop (mirroring `StartScrub`/`StartGC`) detects
+   underreplicated or quarantined blobs and re-replicates them from a verified-good
+   survivor to the target replica count (respecting failure domains per R1).
+3. Exploit content-addressing: a correct copy is any node that yields the content hash
+   matching the object key; verify before using (reuse verify-on-read).
+
+## Out of scope
+
+- Consistency protocol changes (R3), membership rebalancing (R11).
+- Rebuild scheduler tuning/administrative controls beyond basic interval config.

--- a/openspec/changes/r2-self-heal-rebuild/specs/r2-self-heal-rebuild/spec.md
+++ b/openspec/changes/r2-self-heal-rebuild/specs/r2-self-heal-rebuild/spec.md
@@ -1,0 +1,66 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/930
+
+# r2-self-heal-rebuild Specification
+
+## Purpose
+Enable reads from a verified-good survivor set when the primary replica is unavailable
+or corrupt, and a background self-heal loop that restores each blob to its target replica
+count, respecting failure domains (R1). Reuses content-address verification.
+
+## Terminology
+- **Survivor** — a node holding a blob whose bytes verify against the object's SHA-256 key.
+- **Survivor-set quorum** — the minimum number of verified survivors required to serve a
+  read or trigger a rebuild; default `min(1, ...)` — configurable via `r2_degraded_*`.
+
+## Read path
+
+### R2-C1: Survivor read
+- When the primary replica read fails (missing, or verify-on-read corruption), the read
+  MUST attempt other placed replicas, verifying each survivor's bytes against the content
+  hash, and serve the first verified survivor.
+- Confirmed-corrupt survivors MUST be quarantined (per #924) so the rebuild loop can act.
+- A read MUST fail `ENOENT`/`EIO` only when no verified survivor exists in the placement.
+
+### R2-C2: Quarantine no longer final-deletes
+- Quarantine must retain the option to mark-and-hold (not hard-delete) so the rebuild loop
+  can replace the copy after re-replication; final delete occurs after a new verified
+  replica lands. (Backward-compatible: hard-delete remains when no survivor exists.)
+
+## Self-heal loop
+
+### R2-C3: Rebuild scheduler
+- Add a background loop (`StartRebuild`/`rebuildLoop`) mirroring `StartScrub`/`StartGC`
+  (sync.Once, cancellable, goleak-safe), with interval from config (default 300s).
+- Iterates content-address entries; for each whose live verified replica count < target,
+  re-replicates from a verified survivor.
+
+### R2-C4: Verify-before-use
+- Rebuild MUST verify every source replica against the content hash before copying
+  (reuse `HashReader` + verifying reader), so corrupt bytes are never propagated.
+
+### R2-C5: Target & failure-domain-aware
+- Rebuild target = current `replication_factor`. When R1 is present, repairs MUST prefer
+  nodes in distinct failure domains from existing survivors.
+
+### R2-C6: Bounded + thundering-herd safe
+- Use a bounded worker pool; limit concurrent rebuilds per blob; cancel on store Close.
+- Panic-recovered (Rule 37); metrics count repairs.
+
+## Config
+
+### R2-G1
+- Add `[storage]` keys: `rebuild_interval` (default 300), `degraded_read` (bool, default
+  true), and bounded worker-pool size (`rebuild_workers`, default 4).
+
+## Tests
+
+### R2-T1
+- Survivor read: primary corrupt + verified survivor → serves survivor; no survivor → `ENOENT`.
+- Quarantine mark-and-hold + post-rebuild replace.
+### R2-T2
+- Self-heal: kill/drop one of 3 replicas → loop restores to 3 (verified) replicas; with R1
+  domains respected.
+### R2-T3
+- Verify-before-use: a corrupted survivor never propagates.
+### R2-T4
+- Goleak + `-race`; Close stops loop.

--- a/openspec/changes/r2-self-heal-rebuild/tasks.md
+++ b/openspec/changes/r2-self-heal-rebuild/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: R2 — Degraded-read + self-heal rebuild (#930)
+
+## 1. Survivor read path (`src/storage`)
+- [ ] On primary read failure, attempt other placed replicas, verify bytes vs content hash
+      (reuse `HashReader`/verifying reader), serve first verified survivor — R2-C1
+- [ ] Quarantine mark-and-hold (non-final) so rebuild can replace after re-replication —
+      R2-C2
+- [ ] Read fails `ENOENT`/`EIO` only when no verified survivor exists
+
+## 2. Self-heal loop (`src/storage`)
+- [ ] `StartRebuild`/`rebuildLoop` mirroring `StartScrub`/`StartGC` (sync.Once, cancellable,
+      goleak-safe) — R2-C3
+- [ ] Iterate content-address entries; re-replicate blobs with verified-replica count <
+      target from a verified survivor — R2-C5 (failure-domain-aware when R1 present)
+- [ ] Verify-before-use on all source replicas — R2-C4
+- [ ] Bounded worker pool, panic-recovered, cancel on Close — R2-C6
+
+## 3. Config
+- [ ] `rebuild_interval` (300), `degraded_read` (true), `rebuild_workers` (4) in
+      `[storage]` — R2-G1
+- [ ] `conf/momo.conf` + `docs/CONFIGURATION.md` (Rule 27)
+
+## 4. Tests (`src/storage/rebuild_test.go`)
+- [ ] R2-T1 survivor read + mark-and-hold + replace
+- [ ] R2-T2 kill-one-of-3 → restored to 3 verified (R1-aware)
+- [ ] R2-T3 no corrupt propagation
+- [ ] R2-T4 goleak + `-race`, Close stops loop
+
+## 5. Validation
+- [ ] `go fmt`, `go vet`, `go build`, `go test` (storage)
+- [ ] `go work sync` + vendor parity
+- [ ] Docs: `docs/ARCHITECTURE.md` §4f + integity/scrub docs updated

--- a/openspec/changes/r3-durability-consistency/proposal.md
+++ b/openspec/changes/r3-durability-consistency/proposal.md
@@ -1,0 +1,35 @@
+# Change: R3 — Write durability + ack quorum + consistency model
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/931 (R3)
+- https://github.com/alsotoes/momo/issues/928 (roadmap parent)
+- https://github.com/alsotoes/momo/issues/822 (durability floor baseline)
+
+## Why
+
+Momo's write path has no defined durability contract. A replica set acknowledges a write
+without a stated fsync-before-ack guarantee, and a write that partially reaches some
+replicas (mid-write failure) leaves inconsistent replica states. There is no documented
+consistency model (reads may observe stale or partial data). The existing
+`minimum_durability_factor` (#822) is a durability *floor* but does not define fsync-ack
+semantics, survivor-set quorum, or linearizable/read-your-writes behavior.
+
+## What
+
+1. **Durability ack**: a write is acknowledged only after the required number of replicas
+   have durably persisted (fsync) the object. `fsync_before_ack` gates this.
+2. **Survivor-set write quorum**: define the minimum replica ack count for a successful
+   write (`write_quorum`), with a defined degraded path when it cannot be met.
+3. **Consistency model**: document and enforce a single-object consistency model —
+   **read-your-writes / sequential** for single-object ops (write then read must observe
+   the write; overlapping writes are serialized per object), compatible with dispersed
+   multi-object operations.
+
+## Interaction with #822
+`minimum_durability_factor` remains the controller's auto-degrade floor. R3 adds the
+explicit fsync-ack + quorum semantics beneath it so the floor is meaningful.
+
+## Out of scope
+
+- Cross-object transactions / distributed consensus (R6, metadata catalog).
+- Versioning/CAS multi-version (roadmap item 3 / separate).

--- a/openspec/changes/r3-durability-consistency/specs/r3-durability-consistency/spec.md
+++ b/openspec/changes/r3-durability-consistency/specs/r3-durability-consistency/spec.md
@@ -1,0 +1,66 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/931
+
+# r3-durability-consistency Specification
+
+## Purpose
+Define and enforce write durability (fsync-before-ack), a survivor-set write quorum, and
+a documented single-object consistency model so that acknowledged writes are durable and
+reads observe acknowledged writes.
+
+## Terminology
+- **Durable** — blob bytes flushed to stable storage (fsync) such that they survive
+  process/OS crash.
+- **Ack** — the moment the object store replies success to the writer.
+- **Write quorum (W)** — number of durable replicas required before ack.
+- **Read quorum (R)** — number of replicas consulted/verified before serving a read.
+
+## Durability ack
+
+### R3-C1: fsync-before-ack
+- A write MUST NOT be acknowledged until at least `W` replica blobs are durably persisted
+  (fsync) on distinct nodes.
+- `fsync_before_ack bool` (default true) gates enforcing the fsync barrier; when false,
+  acks return after target replicas have the blob buffered (best-effort, clearly documented
+  as non-durable).
+
+### R3-C2: Write quorum
+- `[global] write_quorum int` (default `1`). Valid range `1 <= write_quorum <=
+  replication_factor`. If the required count cannot be reached durably, the write MUST
+  fail (no silent ack), matching `minimum_durability_factor` degradation rules.
+
+## Consistency model
+
+### R3-C3: Sequential per-object
+- For a single object, operations are serialized: a client that is acknowledged a write
+  MUST observe it on subsequent reads (read-your-writes).
+- Concurrent writers to the same object MUST be serialized (per-object lock or version
+  fencing); the last acknowledged writer wins the object's current value (LWW preserved,
+  explicitly bounded to last-ack wins).
+
+### R3-C4: Dispersed operations
+- Multi-object or namespace operations have no cross-object atomicity guarantee; each
+  object obeys R3-C3 independently. This limit MUST be documented (no distributed
+  transaction at this milestone).
+
+## Interaction with #822
+- The controller's auto-degrade floor (`minimum_durability_factor`) MUST NOT select a mode
+  whose achievable durable replicas < `write_quorum`; otherwise the write fails.
+
+## Config
+
+### R3-G1
+- Add `fsync_before_ack` (default true) and `write_quorum` (default 1) to `[global]`.
+
+## Tests
+
+### R3-T1
+- fsync-before-ack: without a durable replica the write errors; with W durable replicas it
+  acks. `fsync_before_ack=false` bypasses barrier (unit, mocked store).
+### R3-T2
+- Write quorum: with W=2 and only 1 reachable/durable node, write fails (no silent ack);
+  with 2 → succeeds. Never ack below minimum_durability_factor.
+### R3-T3
+- Read-your-writes: write → read returns new value; concurrent writer serialized (last-ack
+  wins).
+### R3-T4
+- Goleak + `-race` across client/server/storage.

--- a/openspec/changes/r3-durability-consistency/tasks.md
+++ b/openspec/changes/r3-durability-consistency/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: R3 — Write durability + ack quorum + consistency (#931)
+
+## 1. Durability ack (`src/storage`, `src/server`)
+- [ ] Add fsync barrier to blob persist path; ack only after W durable replicas —
+      R3-C1/R3-C2
+- [ ] `fsync_before_ack` gate (default true)
+- [ ] Write fails (no silent ack) when W unreachable durably, honoring
+      `minimum_durability_factor`
+
+## 2. Write quorum (`src/client`, `src/server`)
+- [ ] `write_quorum` default 1, validated `1..=replication_factor` — R3-G1
+- [ ] Client waits for W durable acks before reporting success
+
+## 3. Consistency (`src/storage`, `src/server`)
+- [ ] Per-object serialization (read-your-writes / last-ack-wins) — R3-C3
+- [ ] Document non-atomicity of dispersed multi-object ops — R3-C4
+- [ ] Wire interaction: controller never degrades below `write_quorum`
+
+## 4. Config
+- [ ] `fsync_before_ack`, `write_quorum` in `[global]`
+- [ ] `conf/momo.conf` + `docs/CONFIGURATION.md` + `docs/ARCHITECTURE.md` (Rule 27)
+
+## 5. Tests
+- [ ] R3-T1 fsync-before-ack gate (mock store)
+- [ ] R3-T2 write-quorum reaches/fails (never below floor)
+- [ ] R3-T3 read-your-writes + concurrent-writer last-ack-wins
+- [ ] R3-T4 goleak + `-race`
+
+## 6. Validation
+- [ ] `go fmt`, `go vet`, `go build`, `go test` (affected modules)
+- [ ] `go work sync` + vendor parity
+- [ ] Docs updated (consistency model + durability contract)

--- a/openspec/changes/r4-momofs/proposal.md
+++ b/openspec/changes/r4-momofs/proposal.md
@@ -1,0 +1,32 @@
+# Change: R4 — momofs FUSE/POSIX filesystem layer
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/932 (R4)
+- https://github.com/alsotoes/momo/issues/928 (roadmap parent)
+
+## Why
+
+Momo is a replicated content-addressed object store + S3 gateway, but is **not** a POSIX
+filesystem. The extensive `docs/momofs/` design set (IMPLEMENTATION.md, ARCHITECTURE.md,
+DESIGN_DECISIONS.md, PERFORMANCE_SECURITY.md, RECOVERY.md, SCRUB_HEALING.md, MULTI_TENANCY.md,
+GDPR.md, COMPARISON.md, LIMITATIONS.md) is design-only — there is no `momofs` source, no
+mount command, and no FUSE integration. To be a production **distributed filesystem**, momo
+needs a mountable POSIX surface with correct metadata semantics over the replicated CAS.
+
+## What
+
+Implement the momofs FUSE/POSIX layer ratifying the existing design docs as the spec
+baseline:
+
+1. **Mountable FUSE filesystem** exposing the momo cluster as a POSIX tree
+   (directories, files, renames, hardlinks) over the content-addressed object store.
+2. **Correct metadata semantics**: atomic rename, hardlinks, mode/owner/permissions,
+   correct mmap read/write exports and POSIX locks.
+3. **Native S3/momo access consistency**: objects written over S3/momo-native appear in
+   the mount and vice-versa (single backing store).
+4. **Robustness**: crash recovery, entry caching with invalidation, panic-free operations
+   per project hardening rules.
+
+## Out of scope (per DESIGN_DECISIONS.md/IMPLEMENTATION.md)
+- See the momofs design docs for explicit out-of-scope items (e.g. full POSIX ACLs, quota,
+  snapshots). Ratify those boundaries here.

--- a/openspec/changes/r4-momofs/specs/r4-momofs/spec.md
+++ b/openspec/changes/r4-momofs/specs/r4-momofs/spec.md
@@ -1,0 +1,60 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/932
+
+# r4-momofs Specification
+
+## Purpose
+Ratify the `docs/momofs/` design set as the spec baseline and specify the minimum
+architecture for a production POSIX filesystem surface (FUSE mount) over the replicated
+content-addressed store.
+
+## Baseline & scope boundary
+
+### R4-C0: Ratify momofs design
+- `docs/momofs/{README,ARCHITECTURE,DESIGN_DECISIONS,DESIGN_PRINCIPLES,IMPLEMENTATION,
+  PERFORMANCE_SECURITY,RECOVERY,SCRUB_HEALING,MULTI_TENANCY,GDPR,COMPARISON,LIMITATIONS,
+  ROADMAP}.md` are ratified as the authoritative design. Conflicts between this spec and
+  those docs MUST be resolved in favor of this spec (it is newer); discrepancies noted in
+  R4-L1.
+
+## Surface
+
+### R4-C1: FUSE mount
+- Provide a `momo fs mount <dir>`/`momofs` entrypoint that mounts the cluster as a POSIX
+  tree. Use an existing Go FUSE binding (e.g. `bazil.org/fuse`); pin + vendor per Rule 25.
+- Operations: lookup, getattr/setattr, readdir, open/create/read/write, mkdir/rmdir,
+  unlink, rename, link, symlink? (ratify per build opts), fsync, getxattr/setxattr,
+  posix-locks.
+
+### R4-C2: Correct metadata semantics
+- Atomic rename: rename MUST be atomic per the backing store (single namespace op).
+- Hardlinks: multiple directory entries may reference the same content hash; refcount kept
+  correct (align with CAS GC refcounting).
+- Permissions/ownership: mode/uid/gid stored as object metadata and honored on access;
+  root-squash or configurable enforcement per DESIGN_DECISIONS.md.
+- mmap/read-write export and byte-range semantics correct for consumer apps.
+
+### R4-C3: Single backing store consistency
+- Objects written/overwritten via S3 or momo-native MUST appear in the mount, and mount
+  writes MUST be visible via S3/native, bounded by documented cache incoherence window
+  (entry TTL + on-invalidate refetch).
+- Content key = `H(plaintext)` unless envelope-E2EE changes addressing (document interplay
+  with `encryption_enabled`/`e2ee_key`).
+
+### R4-C4: Robustness
+- Panic-free ops (Rule 37), bounded memory, crash recovery on remount (replay/invalidate
+  stale entries), and coexistence with scrub/heal (R2) and GC.
+
+## Tests
+
+### R4-T1
+- POSIX smoke: create/write/read/rename/unlink/mkdir/hardlink round-trips over the mount.
+### R4-T2
+- Consistency: S3 PUT visible via mount; mount write visible via S3/native within TTL.
+### R4-T3
+- Atomic rename + refcount under hardlinking; GC keeps live entries.
+### R4-T4
+- Crash/remount: stale entries invalidated; goleak + `-race`.
+
+## Non-Requirements
+- Full POSIX ACLs, quotas, and snapshots (out of scope per DESIGN_DECISIONS.md/LIMITATIONS.md);
+  documented as future.

--- a/openspec/changes/r4-momofs/tasks.md
+++ b/openspec/changes/r4-momofs/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: R4 — momofs FUSE/POSIX filesystem layer (#932)
+
+_Design is already authored in `docs/momofs/` (IMPLEMENTATION, ARCHITECTURE, DESIGN_DECISIONS,
+etc.). This change migrates it from design to ratified spec and then to implementation.
+Items below are implementation phases._
+
+## 1. Ratify design + foundation
+- [ ] Ratify `docs/momofs/*` as spec baseline (R4-C0); record spec-vs-design discrepancies
+- [ ] Select + pin Go FUSE binding (e.g. `bazil.org/fuse`); `go work sync` + vendor (Rule 25)
+
+## 2. Core mount + metadata (`momofs` package)
+- [ ] `momo fs mount` entrypoint + FUSE connection lifecycle
+- [ ] Inode/metadata layer over CAS (dirs as content-addressed entries, files as blobs)
+- [ ] lookup/getattr/setattr/readdir/open/create/read/write ops (R4-C1)
+- [ ] Permission/ownership enforcement (mode/uid/gid) — R4-C2
+
+## 3. Metadata semantics + consistency
+- [ ] Atomic rename + hardlink (refcount-aligned with CAS GC) — R4-C2
+- [ ] S3/native ↔ mount visibility (single store, entry TTL + invalidation) — R4-C3
+- [ ] mmap/byte-range correctness; posix-locks — R4-C2
+
+## 4. Robustness
+- [ ] Panic-free op handling (Rule 37), bounded memory
+- [ ] Crash/remount recovery (invalidate stale entries) — R4-C4
+- [ ] Coexist with scrub/heal (R2) + GC
+
+## 5. Tests (`tests` or package e2e)
+- [ ] R4-T1 POSIX smoke round-trips
+- [ ] R4-T2 S3↔mount consistency within TTL
+- [ ] R4-T3 atomic rename + hardlink refcount under GC
+- [ ] R4-T4 crash/remount; goleak + `-race`
+
+## 6. Validation
+- [ ] `make build` + full `make test` green
+- [ ] CI workflow for mount e2e (smoke) added
+- [ ] Docs: `docs/momofs/` marked implemented; ROADMAP R4 done; user guide for mount


### PR DESCRIPTION
Resolves #928

**What changed (docs/planning only — no behavior change):**

Ratifies the prioritized production-readiness roadmap and authors full OpenSpec change sets (proposal + spec + tasks) for the P0 blockers.

- **`openspec/changes/prod-ready-roadmap/`** — ratified roadmap: P0/P1/P2 phases, per-item section-of-work tables, Definition of Done per phase, REQ-1..REQ-11. (spec links #928 at top.)
- **`docs/ROADMAP.md`** — adds the Production-Readiness Roadmap tier tables.

**P0 OpenSpec change sets (full specs, each with top-located GitHub Issue URL):**
- `r1-failure-domains/` (#929) — failure-domain-aware CRUSH placement
- `r2-self-heal-rebuild/` (#930) — degraded-read + background self-heal re-replication
- `r3-durability-consistency/` (#931) — fsync-before-ack + write quorum + read-your-writes
- `r4-momofs/` (#932) — FUSE/POSIX filesystem layer (ratifies design docs, R4-C0)

**Issue chain created (parent + sub):**
#928 parent roadmap; R1 #929, R2 #930, R3 #931, R4 #932 (P0); R5 #933, R6 #934, R7 #935, R8 #936, R9 #937 (P1); R10 #938, R11 #939 (P2).

**Changelog:**
- `53299db` — roadmap ratification + P0 OpenSpec changes (16 files, +707/−1)

**Reviewer status:** awaiting CI + review.
**Testing:** planning/docs-only change; no code touched. CI runs full suite (unchanged).