### PR TITLE
feat: per-node metrics bind (metrics_host/metrics_port) for /metrics on all nodes

### DIFF
--- a/conf/momo.conf
+++ b/conf/momo.conf
@@ -37,6 +37,8 @@ min_threshold=0.1
 max_threshold=0.9
 fallback_interval=30
 prometheus_port=9100
+# Optional default bind host for /metrics (empty = all interfaces).
+# prometheus_bind_host=127.0.0.1
 
 
 [daemon.0]
@@ -44,18 +46,26 @@ host=localhost:8080
 change_replication=localhost:9090
 data=/data/0
 drive=/dev/sda1
+# Optional per-daemon /metrics bind. When set, overrides [metrics] prometheus_port
+# (and prometheus_bind_host). Use distinct ports per node in same-host topologies.
+metrics_host=127.0.0.1
+metrics_port=19100
 
 [daemon.1]
 host=localhost:8081
 change_replication=localhost:9091
 data=/data/1
 drive=/dev/sdb1
+metrics_host=127.0.0.1
+metrics_port=19101
 
 [daemon.2]
 host=localhost:8082
 change_replication=localhost:9092
 data=/data/2
 drive=/dev/sdc1
+metrics_host=127.0.0.1
+metrics_port=19102
 
 [p2p]
 enabled=false

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,6 +207,8 @@ Momo includes a built-in Prometheus metrics exporter (`src/server/metrics_export
 
 **Configuration:** Add `prometheus_port = 9100` to the `[metrics]` section of `momo.conf`. Set to `0` or omit to disable. The metrics server runs on a separate port from the data plane — it does not share the accept loop, connection pool, or semaphore with the main daemon.
 
+**Per-node bind:** each server process starts its own `/metrics` endpoint (`server.Daemon` → `StartMetricsServer`). By default all nodes bind `:prometheus_port` (all interfaces); in same-host/co-located topologies this collides (`EADDRINUSE`). A daemon may opt into a distinct bind via `[daemon.N] metrics_host` / `metrics_port`, which override the global `[metrics] prometheus_bind_host` / `prometheus_port` for that node. This keeps `/metrics` available on every node and lets operators scope the endpoint to an admin/mgmt interface.
+
 **Overhead guarantees:** All counters use `sync/atomic` (~5ns per op). Heavy operations (`runtime.ReadMemStats`, disk stats) run only at scrape time (every 15-60s). No `prometheus/client_golang` dependency. Target: <1% throughput regression.
 
 ## High-Level Architecture

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -161,6 +161,12 @@ This section controls the behavior of the decentralized polymorphic system and t
     -   **Default:** `0` (disabled)
     -   **Example:** `9100`
 
+-   **`prometheus_bind_host`**
+    -   **Description:** The default bind address (host/IP) for the `/metrics` and `/health` endpoints when an individual daemon does not set `[daemon.N] metrics_host`. Empty binds all interfaces (`:port`). Use this to scope the metrics endpoint to an admin/mgmt network or loopback instead of exposing it on the public data-plane interface.
+    -   **Type:** String (host/IP)
+    -   **Default:** (empty — all interfaces)
+    -   **Example:** `127.0.0.1`
+
     **Exported metrics:**
 
     | Metric | Type | Description |
@@ -230,6 +236,17 @@ The configuration must contain a section for each daemon in the cluster, numbere
     -   **Description:** The Shamir evaluation point of `oprf_share` (a daemon's index within the secret split). Must be unique across the cluster and within `[1, len(daemons)]`. Defaults to the daemon's 1-based position in the config when unset.
     -   **Type:** Integer
     -   **Default:** daemon position (1-based)
+
+-   **`metrics_host`**
+    -   **Description:** Optional per-daemon bind address for this node's `/metrics`/`/health` endpoint. Overrides `[metrics] prometheus_bind_host` for this node. Empty falls back to the global default (which itself defaults to all interfaces).
+    -   **Type:** String (host/IP)
+    -   **Default:** (empty — fall back to `[metrics] prometheus_bind_host`)
+    -   **Example:** `127.0.0.1`
+
+-   **`metrics_port`**
+    -   **Description:** Optional per-daemon bind port for this node's `/metrics`/`/health` endpoint. Overrides `[metrics] prometheus_port` for this node. Must be in `[1, 65535]` when set. Use distinct ports per node in same-host/co-located topologies to avoid `EADDRINUSE`; empty falls back to the global `[metrics] prometheus_port`.
+    -   **Type:** Integer (1-65535)
+    -   **Default:** (empty — fall back to `[metrics] prometheus_port`, which defaults to disabled)
 
 ### [p2p]
 

--- a/openspec/changes/metrics-per-node-binding/proposal.md
+++ b/openspec/changes/metrics-per-node-binding/proposal.md
@@ -1,0 +1,34 @@
+# Change: metrics-per-node-binding — optional per-node bind (host + port) for `/metrics`
+
+**Related Issues:**
+- https://github.com/alsotoes/momo/issues/941
+- https://github.com/alsotoes/momo/issues/933 (roadmap R5, related)
+
+## Why
+
+The Prometheus `/metrics` endpoint is started by every server process
+(`server.Daemon` → `StartMetricsServer`) and thus exists on all nodes. However it
+binds `:port` (all interfaces) using a single global `[metrics] prometheus_port`.
+Two production gaps follow:
+
+1. In any **same-host / co-located topology** (multi-node dev on one machine,
+   host-network pods/containers sharing one IP), every node tries to bind the
+   identical `:port` → `EADDRINUSE`, so only the first node's `/metrics` serves.
+2. There is no way to bind `/metrics` to a specific interface or admin network —
+   it is always exposed on all interfaces.
+
+## What Changes
+
+- Per-node opt-in override keys `[daemon.N] metrics_host` and `metrics_port`.
+- Global default bind `[metrics] prometheus_bind_host`.
+- `StartMetricsServer` binds `host:port` via `net.JoinHostPort`; empty host binds
+  all interfaces (`:port`), preserving current behavior.
+- Resolved at runtime: node override → global default → disabled when port `<= 0`.
+- Backward compatible: existing configs (global-only) are unchanged.
+
+## Non-Goals
+
+- No cluster-aggregate `/metrics` endpoint (external Prometheus scrapes each node).
+- No TLS/auth on the metrics endpoint.
+- No change to the polymorphic controller (`metrics.GetMetrics`, node-0 only) —
+  that is a separate concern and remains as-is.

--- a/openspec/changes/metrics-per-node-binding/specs/metrics-per-node-binding/spec.md
+++ b/openspec/changes/metrics-per-node-binding/specs/metrics-per-node-binding/spec.md
@@ -1,0 +1,57 @@
+> GitHub Issue URL: https://github.com/alsotoes/momo/issues/941
+
+# metrics-per-node-binding Specification
+
+## Purpose
+Allow each daemon node to opt-in to a distinct bind (`host`/`port`) for its
+Prometheus `/metrics` `/health` endpoint, so `/metrics` is reliably available on
+every node in same-host/co-located and hardened setups, while remaining fully
+backward compatible with the global `[metrics] prometheus_port`.
+
+## Configuration
+
+### MPC1: Per-daemon override keys
+- `[daemon.N] metrics_host` (string, optional) — bind address for this node's
+  metrics server. Empty means not set (use global default).
+- `[daemon.N] metrics_port` (int, optional) — bind port for this node's metrics
+  server. Must be `1..65535` when present; a value outside that range is a config
+  error (`EINVAL`). Empty means not set (use global default).
+
+### MPC2: Global default bind
+- `[metrics] prometheus_bind_host` (string, optional, default `""`) — bind address
+  used when a node has no `metrics_host` override. Empty binds all interfaces
+  (`:port`), preserving current behavior.
+
+## Resolution & bind behavior
+
+### MPC3: Resolve host and port
+At daemon startup, for each node:
+- `host` = node `metrics_host`, else global `prometheus_bind_host`, else `""`.
+- `port` = node `metrics_port`, else global `prometheus_port`.
+
+### MPC4: Bind
+- `StartMetricsServer(ctx, host, port, collector)`.
+- Address is `net.JoinHostPort(host, strconv.Itoa(port))`; empty host yields
+  `:port` (all interfaces).
+- Disabled when resolved `port <= 0`. Port-in-use logs an error (no panic) and the
+  node continues (endpoint not served on that node).
+
+### MPC5: Backward compatibility
+- A config that only sets `[metrics] prometheus_port` behaves exactly as today
+  (all interfaces, same port on every node — suitable for distinct-host clusters).
+
+## Tests
+
+### MPC-T1
+Config: per-node `metrics_host`/`metrics_port` override global; fallback to global
+when unset; invalid `metrics_port` (0, 65536, non-numeric) rejected.
+### MPC-T2
+Exporter: `StartMetricsServer` with explicit `host:port` serves `/metrics` and
+`/health` (200 + body).
+### MPC-T3
+Same-host: two `StartMetricsServer` calls with distinct ports both bind and serve
+(no EADDRINUSE).
+### MPC-T4
+Collision: binding an already-used port logs an error and returns without panic.
+### MPC-T5
+goleak + `-race` clean.

--- a/openspec/changes/metrics-per-node-binding/tasks.md
+++ b/openspec/changes/metrics-per-node-binding/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: metrics-per-node-binding — per-node bind for `/metrics` (#941)
+
+## 1. Config surface (`src/common`)
+- [ ] `struct.go`: add `Daemon.MetricsBindHost string`, `Daemon.MetricsBindPort int`;
+      add `ConfigurationMetrics.PrometheusBindHost string`
+- [ ] `config.go`: parse+validate `[daemon.N] metrics_host`/`metrics_port`
+      (port 1..65535 else EINVAL); parse `[metrics] prometheus_bind_host`
+
+## 2. Exporter (`src/server`)
+- [ ] `metrics_exporter.go`: `StartMetricsServer(ctx, host string, port int, collector)`;
+      bind `net.JoinHostPort(host, strconv.Itoa(port))`; empty host → `:port`;
+      keep `port<=0` disabled
+- [ ] `server.go`: resolve per-node (override → global default → bind); call new signature
+
+## 3. Tests
+- [ ] `config_test.go`: overrides + fallback + invalid-port rejection (MPC-T1)
+- [ ] `metrics_exporter_test.go`: bind host:port + /metrics + /health (MPC-T2);
+      same-host distinct ports (MPC-T3); collision no-panic (MPC-T4)
+- [ ] goleak + `-race` (MPC-T5)
+
+## 4. Docs (Rule 27)
+- [ ] `docs/CONFIGURATION.md`: `[metrics] prometheus_bind_host`,
+      `[daemon.N] metrics_host`/`metrics_port`
+- [ ] `conf/momo.conf` example
+- [ ] `docs/ARCHITECTURE.md` metrics section note
+
+## 5. Validation
+- [ ] `go fmt`, `go vet`, `go build`, `go test` (common + server)
+- [ ] `go work sync` + vendor parity
+- [ ] CI: `make test` green

--- a/src/common/config.go
+++ b/src/common/config.go
@@ -438,6 +438,8 @@ func loadMetricsConfig(section *ini.Section) (ConfigurationMetrics, error) {
 		metricsCfg.PrometheusPort = 0
 	}
 
+	metricsCfg.PrometheusBindHost = section.Key("prometheus_bind_host").String()
+
 	return metricsCfg, nil
 }
 
@@ -637,6 +639,19 @@ func loadDaemons(cfg *ini.File) ([]*Daemon, error) {
 			if v, e := key.Int(); e == nil {
 				d.OPRFShareIndex = v
 			}
+		}
+
+		d.MetricsBindHost = section.Key("metrics_host").String()
+
+		if key, err := section.GetKey("metrics_port"); err == nil {
+			v, e := key.Int()
+			if e != nil {
+				return nil, fmt.Errorf("invalid 'metrics_port' in section [%s]: %v: %w", sectionName, e, syscall.EINVAL)
+			}
+			if v < 1 || v > 65535 {
+				return nil, fmt.Errorf("invalid 'metrics_port' %d in section [%s]: must be in [1, 65535]: %w", v, sectionName, syscall.EINVAL)
+			}
+			d.MetricsBindPort = v
 		}
 
 		daemons = append(daemons, d)

--- a/src/common/config_test.go
+++ b/src/common/config_test.go
@@ -832,3 +832,75 @@ func TestGetConfig_GossipFanout(t *testing.T) {
 		t.Fatal("expected negative fanout to be rejected")
 	}
 }
+
+func writeConf(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "momo.conf")
+	if err := os.WriteFile(p, []byte(body), 0666); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	return p
+}
+
+// TestGetConfig_MetricsPerNodeBind verifies per-daemon metrics_host/metrics_port
+// overrides fall back to the global [metrics] bind, and ports are validated.
+func TestGetConfig_MetricsPerNodeBind(t *testing.T) {
+	base := `
+[global]
+debug = true
+auth_token = a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6 # notsecret
+replication_order = 1
+polymorphic_system = true
+
+[metrics]
+interval = 10
+min_threshold = 0.1
+max_threshold = 0.9
+fallback_interval = 30
+`
+
+	// Global default bind only: node falls back to it.
+	globalOnly := base + "prometheus_port = 9100\nprometheus_bind_host = 10.0.0.5\n\n" +
+		"[daemon.0]\nhost = h0\ndrive = d0\nchange_replication = c0\ndata = d0\n"
+	cfg, err := GetConfig(writeConf(t, globalOnly))
+	if err != nil {
+		t.Fatalf("global-only config failed: %v", err)
+	}
+	if cfg.Metrics.PrometheusPort != 9100 {
+		t.Fatalf("expected global prometheus_port 9100, got %d", cfg.Metrics.PrometheusPort)
+	}
+	if cfg.Metrics.PrometheusBindHost != "10.0.0.5" {
+		t.Fatalf("expected global prometheus_bind_host 10.0.0.5, got %q", cfg.Metrics.PrometheusBindHost)
+	}
+	if cfg.Daemons[0].MetricsBindPort != 0 {
+		t.Fatalf("expected default MetricsBindPort 0, got %d", cfg.Daemons[0].MetricsBindPort)
+	}
+	if cfg.Daemons[0].MetricsBindHost != "" {
+		t.Fatalf("expected default MetricsBindHost empty, got %q", cfg.Daemons[0].MetricsBindHost)
+	}
+
+	// Per-daemon overrides win over the global default.
+	override := base + "prometheus_port = 9100\n\n" +
+		"[daemon.0]\nhost = h0\ndrive = d0\nchange_replication = c0\ndata = d0\n" +
+		"metrics_host = 127.0.0.1\nmetrics_port = 9123\n"
+	cfg2, err := GetConfig(writeConf(t, override))
+	if err != nil {
+		t.Fatalf("override config failed: %v", err)
+	}
+	if cfg2.Daemons[0].MetricsBindHost != "127.0.0.1" {
+		t.Fatalf("expected per-daemon MetricsBindHost 127.0.0.1, got %q", cfg2.Daemons[0].MetricsBindHost)
+	}
+	if cfg2.Daemons[0].MetricsBindPort != 9123 {
+		t.Fatalf("expected per-daemon MetricsBindPort 9123, got %d", cfg2.Daemons[0].MetricsBindPort)
+	}
+
+	// Invalid ports rejected.
+	for _, bad := range []string{"0", "65536", "abc"} {
+		badCfg := base + "prometheus_port = 9100\n\n" +
+			"[daemon.0]\nhost = h0\ndrive = d0\nchange_replication = c0\ndata = d0\n" +
+			"metrics_port = " + bad + "\n"
+		if _, err := GetConfig(writeConf(t, badCfg)); err == nil {
+			t.Fatalf("expected metrics_port=%q to be rejected", bad)
+		}
+	}
+}

--- a/src/common/struct.go
+++ b/src/common/struct.go
@@ -51,6 +51,12 @@ type Daemon struct {
 	Data string
 	// Drive is the drive used by the daemon.
 	Drive string
+	// MetricsBindHost is an optional per-daemon bind address (host) for the
+	// /metrics endpoint. Empty falls back to the global [metrics] bind host.
+	MetricsBindHost string
+	// MetricsBindPort is an optional per-daemon bind port for the /metrics
+	// endpoint. 0 (unset) falls back to the global [metrics] prometheus_port.
+	MetricsBindPort int
 	// OPRFShare is the hex-encoded 256-bit Shamir share of the threshold OPRF
 	// secret assigned to this daemon. Required when oprf_enabled is true.
 	// Each daemon holds a distinct share; no daemon holds the full secret.
@@ -147,6 +153,9 @@ type ConfigurationMetrics struct {
 	FallbackInterval int
 	// PrometheusPort is the port for the Prometheus /metrics endpoint (0 = disabled).
 	PrometheusPort int
+	// PrometheusBindHost is the default bind address for the /metrics endpoint.
+	// Empty binds all interfaces.
+	PrometheusBindHost string
 }
 
 // ConfigurationP2P holds the P2P transport and gossip configuration.

--- a/src/server/metrics_exporter.go
+++ b/src/server/metrics_exporter.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strconv"
 	"sync/atomic"
 	"time"
 )
@@ -125,10 +126,10 @@ func (m *MetricsCollector) handler(w http.ResponseWriter, r *http.Request) {
 	m.writeMetrics(w)
 }
 
-// StartMetricsServer starts an HTTP server exposing Prometheus metrics on the given port.
-// It runs in a background goroutine and returns immediately.
-// The server is shut down when the provided context is canceled.
-func StartMetricsServer(ctx context.Context, port int, collector *MetricsCollector) {
+// StartMetricsServer starts an HTTP server exposing Prometheus metrics on the given
+// host and port (empty host binds all interfaces). It runs in a background goroutine
+// and returns immediately. The server is shut down when the provided context is canceled.
+func StartMetricsServer(ctx context.Context, host string, port int, collector *MetricsCollector) {
 	if port <= 0 {
 		return
 	}
@@ -140,7 +141,7 @@ func StartMetricsServer(ctx context.Context, port int, collector *MetricsCollect
 		w.Write([]byte("OK"))
 	})
 
-	addr := fmt.Sprintf(":%d", port)
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		log.Printf("Failed to start metrics server on port %d: %v", port, err)

--- a/src/server/metrics_exporter_test.go
+++ b/src/server/metrics_exporter_test.go
@@ -1,9 +1,137 @@
 package server
 
 import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"go.uber.org/goleak"
 )
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("failed to release reserved port: %v", err)
+	}
+	return port
+}
+
+func httpGetPort(t *testing.T, port int, path string) (int, string) {
+	t.Helper()
+	req, err := http.Get("http://127.0.0.1:" + strconv.Itoa(port) + path)
+	if err != nil {
+		t.Fatalf("GET %s on port %d failed: %v", path, port, err)
+	}
+	defer req.Body.Close()
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body failed: %v", err)
+	}
+	return req.StatusCode, string(body)
+}
+
+// TestStartMetricsServer_HostPort verifies an explicit host:port bind serves
+// /metrics and /health.
+func TestStartMetricsServer_HostPort(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	port := freePort(t)
+	mc := NewMetricsCollector()
+
+	done := make(chan struct{})
+	go func() { StartMetricsServer(ctx, "127.0.0.1", port, mc); close(done) }()
+
+	// /health 200 + "OK".
+	code, body := httpGetPort(t, port, "/health")
+	if code != http.StatusOK {
+		t.Fatalf("expected /health 200, got %d", code)
+	}
+	if !strings.Contains(body, "OK") {
+		t.Fatalf("expected /health body to contain OK, got %q", body)
+	}
+
+	// /metrics 200 + a metric line.
+	code, body = httpGetPort(t, port, "/metrics")
+	if code != http.StatusOK {
+		t.Fatalf("expected /metrics 200, got %d", code)
+	}
+	if !strings.Contains(body, "momo_connections_total ") {
+		t.Fatalf("expected /metrics to contain momo_connections_total, got head %q", body[:min(120, len(body))])
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("StartMetricsServer did not return after cancel")
+	}
+	time.Sleep(50 * time.Millisecond)
+	goleak.VerifyNone(t)
+}
+
+// TestStartMetricsServer_DistinctSameHostPorts verifies two nodes on the same
+// host with distinct ports both serve /metrics (no EADDRINUSE).
+func TestStartMetricsServer_DistinctSameHostPorts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p1 := freePort(t)
+	p2 := freePort(t)
+	for p2 == p1 {
+		p2 = freePort(t)
+	}
+
+	var wg sync.WaitGroup
+	for _, p := range []int{p1, p2} {
+		wg.Add(1)
+		go func(pp int) { defer wg.Done(); StartMetricsServer(ctx, "127.0.0.1", pp, NewMetricsCollector()) }(p)
+	}
+
+	// Both must respond.
+	httpGetPort(t, p1, "/metrics")
+	httpGetPort(t, p2, "/metrics")
+
+	cancel()
+	wg.Wait()
+	time.Sleep(50 * time.Millisecond)
+	goleak.VerifyNone(t)
+}
+
+// TestStartMetricsServer_PortCollisionNoPanic verifies binding an in-use port
+// logs an error and returns without panicking.
+func TestStartMetricsServer_PortCollisionNoPanic(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { StartMetricsServer(ctx, "127.0.0.1", port, NewMetricsCollector()); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("StartMetricsServer should return quickly on collision")
+	}
+	goleak.VerifyNone(t)
+}
 
 func TestMetricsCollector_Counters(t *testing.T) {
 	mc := NewMetricsCollector()

--- a/src/server/metrics_exporter_test.go
+++ b/src/server/metrics_exporter_test.go
@@ -27,18 +27,27 @@ func freePort(t *testing.T) int {
 	return port
 }
 
+// httpGetPort retries GET until the async server is listening (or a deadline is
+// hit), so tests are deterministic regardless of scheduler timing.
 func httpGetPort(t *testing.T, port int, path string) (int, string) {
 	t.Helper()
-	req, err := http.Get("http://127.0.0.1:" + strconv.Itoa(port) + path)
-	if err != nil {
-		t.Fatalf("GET %s on port %d failed: %v", path, port, err)
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + path
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		req, err := http.Get(url)
+		if err == nil {
+			body, rerr := io.ReadAll(req.Body)
+			req.Body.Close()
+			if rerr != nil {
+				t.Fatalf("read body failed: %v", rerr)
+			}
+			return req.StatusCode, string(body)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("GET %s on port %d failed after retries: %v", path, port, err)
+		}
+		time.Sleep(25 * time.Millisecond)
 	}
-	defer req.Body.Close()
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("read body failed: %v", err)
-	}
-	return req.StatusCode, string(body)
 }
 
 // TestStartMetricsServer_HostPort verifies an explicit host:port bind serves

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -143,9 +143,18 @@ func Daemon(ctx context.Context, cfg common.Configuration, serverId int) (err er
 	log.Printf("Server primary Daemon started... at %s using %s", daemons[serverId].Host, cfg.Global.Protocol)
 	log.Printf("...Waiting for connections...")
 
-	// Start Prometheus metrics endpoint if configured
+	// Start Prometheus metrics endpoint if configured. Per-daemon override
+	// (metrics_host / metrics_port) falls back to the global [metrics] bind.
 	metricsCollector := NewMetricsCollector()
-	StartMetricsServer(ctx, cfg.Metrics.PrometheusPort, metricsCollector)
+	metricsHost := daemons[serverId].MetricsBindHost
+	if metricsHost == "" {
+		metricsHost = cfg.Metrics.PrometheusBindHost
+	}
+	metricsPort := daemons[serverId].MetricsBindPort
+	if metricsPort == 0 {
+		metricsPort = cfg.Metrics.PrometheusPort
+	}
+	StartMetricsServer(ctx, metricsHost, metricsPort, metricsCollector)
 
 	// 🛡️ Sentinel: Adaptive failed-auth backoff & temporary lockout (issue #821).
 	// Disabled (Allow always true) when auth_backoff_delay is 0.


### PR DESCRIPTION
Resolves #941

**What changed:** The Prometheus `/metrics` endpoint already runs on every server process, but bound `:prometheus_port` (all interfaces) using a single global `[metrics] prometheus_port`. In same-host/co-located topologies every node tried to bind the identical port → `EADDRINUSE` (only the first node's `/metrics` served), and there was no way to scope `/metrics` to an admin interface.

This adds **per-node bind overrides**:
- `[daemon.N] metrics_host` / `metrics_port` — per-node `/metrics` binding.
- `[metrics] prometheus_bind_host` — global default bind address.
- Backward compatible: when unset, nodes fall back to the global `[metrics] prometheus_port` (existing behavior).

**Implementation:**
- `struct.go` — `Daemon.MetricsBindHost`/`MetricsBindPort`, `ConfigurationMetrics.PrometheusBindHost`.
- `config.go` — parse + validate `metrics_host`/`metrics_port` (port 1–65535, else `EINVAL`) and `prometheus_bind_host`.
- `metrics_exporter.go` — `StartMetricsServer(ctx, host, port, collector)` binds `net.JoinHostPort`; empty host → `:port`; resolved `port<=0` → disabled.
- `server.go` — resolve per-node override → global default → bind.

**Tests:** config overrides/fallback/invalid-port; exporter `host:port` serves `/health`+`/metrics`; two same-host servers on distinct ports both serve; port-collision returns without panic. `-race` + goleak clean (common 190, server 87).

**Docs (Rule 27):** CONFIGURATION.md (`[metrics]`, `[daemon.N]`), conf/momo.conf example, ARCHITECTURE.md metrics note.

**OpenSpec:** `openspec/changes/metrics-per-node-binding/` (proposal/spec/tasks), spec links #941.

**Changelog:**
- `79c0d9f` — feat: per-node metrics bind (`metrics_host`/`metrics_port`)
- `8c1d808` — fix: make exporter test deterministic (retry GET until async listener is up)

**Reviewer status:** awaiting CI + review.
**Testing:** `go test -race` on src/common (190) + src/server (87); `go build ./...`; `go vet`; `gofmt`, workspace vendor parity.
